### PR TITLE
Allow treasury to send XCM calls

### DIFF
--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -17,9 +17,9 @@
 //! XCM configurations for the Kusama runtime.
 
 use super::{
-	governance::Spender, parachains_origin, AccountId, AllPalletsWithSystem, Balances, Dmp, Fellows, ParaId, Runtime,
-	RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin, TransactionByteFee, WeightToFee,
-	XcmPallet,
+	governance::Spender, parachains_origin, AccountId, AllPalletsWithSystem, Balances, Dmp,
+	Fellows, ParaId, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin,
+	TransactionByteFee, WeightToFee, XcmPallet,
 };
 use frame_support::{
 	match_types, parameter_types,

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -367,6 +367,8 @@ parameter_types! {
 pub type LocalOriginToLocation = (
 	// And a usual Signed origin to be used in XCM as a corresponding AccountId32
 	SignedToAccountId32<RuntimeOrigin, AccountId, ThisNetwork>,
+	// Treasury Origin to be used to reserve transfer
+	TreasurerToPlurality,
 );
 
 /// Type to convert the `StakingAdmin` origin to a Plurality `MultiLocation` value.
@@ -386,8 +388,6 @@ pub type LocalPalletOriginToLocation = (
 	StakingAdminToPlurality,
 	// Fellows origin to be used in XCM as a corresponding Plurality `MultiLocation` value.
 	FellowsToPlurality,
-	// Treasurer origin to be used in XCM as a corresponding Plurality `MultiLocation` value.
-	TreasurerToPlurality,
 );
 
 impl pallet_xcm::Config for Runtime {

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -17,9 +17,9 @@
 //! XCM configurations for the Kusama runtime.
 
 use super::{
-	governance::Spender, parachains_origin, AccountId, AllPalletsWithSystem, Balances, Dmp,
-	Fellows, ParaId, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin,
-	TransactionByteFee, WeightToFee, XcmPallet,
+	parachains_origin, AccountId, AllPalletsWithSystem, Balances, Dmp, Fellows, ParaId, Runtime,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin, TransactionByteFee, WeightToFee,
+	XcmPallet,
 };
 use frame_support::{
 	match_types, parameter_types,
@@ -353,8 +353,8 @@ parameter_types! {
 	pub const StakingAdminBodyId: BodyId = BodyId::Defense;
 	// Fellows pluralistic body.
 	pub const FellowsBodyId: BodyId = BodyId::Technical;
-	// Spender pluralistic body.
-	pub const SpenderBodyId: BodyId = BodyId::Treasury;
+	// Treasurer pluralistic body.
+	pub const TreasurerBodyId: BodyId = BodyId::Treasury;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -376,8 +376,8 @@ pub type StakingAdminToPlurality =
 /// Type to convert the Fellows origin to a Plurality `MultiLocation` value.
 pub type FellowsToPlurality = OriginToPluralityVoice<RuntimeOrigin, Fellows, FellowsBodyId>;
 
-/// Type to convert the Fellows origin to a Plurality `MultiLocation` value.
-pub type SpenderToPlurality = OriginToPluralityVoice<RuntimeOrigin, Spender, SpenderBodyId>;
+/// Type to convert the Treasury origin to a Plurality `MultiLocation` value.
+pub type TreasurerToPlurality = OriginToPluralityVoice<RuntimeOrigin, Treasurer, TreasurerBodyId>;
 
 /// Type to convert a pallet `Origin` type value into a `MultiLocation` value which represents an interior location
 /// of this chain for a destination chain.
@@ -386,8 +386,8 @@ pub type LocalPalletOriginToLocation = (
 	StakingAdminToPlurality,
 	// Fellows origin to be used in XCM as a corresponding Plurality `MultiLocation` value.
 	FellowsToPlurality,
-	// Spender origin to be used in XCM as a corresponding Plurality `MultiLocation` value.
-	SpenderToPlurality,
+	// Treasurer origin to be used in XCM as a corresponding Plurality `MultiLocation` value.
+	TreasurerToPlurality,
 );
 
 impl pallet_xcm::Config for Runtime {

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -18,8 +18,8 @@
 
 use super::{
 	parachains_origin, AccountId, AllPalletsWithSystem, Balances, Dmp, Fellows, ParaId, Runtime,
-	RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin, TransactionByteFee, WeightToFee,
-	XcmPallet,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin, TransactionByteFee, Treasurer,
+	WeightToFee, XcmPallet,
 };
 use frame_support::{
 	match_types, parameter_types,

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -17,7 +17,7 @@
 //! XCM configurations for the Kusama runtime.
 
 use super::{
-	parachains_origin, AccountId, AllPalletsWithSystem, Balances, Dmp, Fellows, ParaId, Runtime,
+	governance::Spender, parachains_origin, AccountId, AllPalletsWithSystem, Balances, Dmp, Fellows, ParaId, Runtime,
 	RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin, TransactionByteFee, WeightToFee,
 	XcmPallet,
 };
@@ -353,6 +353,8 @@ parameter_types! {
 	pub const StakingAdminBodyId: BodyId = BodyId::Defense;
 	// Fellows pluralistic body.
 	pub const FellowsBodyId: BodyId = BodyId::Technical;
+	// Spender pluralistic body.
+	pub const SpenderBodyId: BodyId = BodyId::Treasury;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -374,6 +376,9 @@ pub type StakingAdminToPlurality =
 /// Type to convert the Fellows origin to a Plurality `MultiLocation` value.
 pub type FellowsToPlurality = OriginToPluralityVoice<RuntimeOrigin, Fellows, FellowsBodyId>;
 
+/// Type to convert the Fellows origin to a Plurality `MultiLocation` value.
+pub type SpenderToPlurality = OriginToPluralityVoice<RuntimeOrigin, Spender, SpenderBodyId>;
+
 /// Type to convert a pallet `Origin` type value into a `MultiLocation` value which represents an interior location
 /// of this chain for a destination chain.
 pub type LocalPalletOriginToLocation = (
@@ -381,6 +386,8 @@ pub type LocalPalletOriginToLocation = (
 	StakingAdminToPlurality,
 	// Fellows origin to be used in XCM as a corresponding Plurality `MultiLocation` value.
 	FellowsToPlurality,
+	// Spender origin to be used in XCM as a corresponding Plurality `MultiLocation` value.
+	SpenderToPlurality,
 );
 
 impl pallet_xcm::Config for Runtime {


### PR DESCRIPTION
Closes https://github.com/polkadot-fellows/runtimes/issues/18

This [PR](https://github.com/paritytech/substrate/pull/14434) would make it possible for treasury spends via xcm but its currently blocked awaiting an audit so this is an interim solution that should achieve a similar result


How I envisage this working with treasury spends:

```
Treasurer track to ensure we avoid spend limits

batch { 
spend(ParachainSovereignAccount), 
// Notify destination of funds sent
send(dest: para, xcm: [ReserveAssetDeposited, ..]) 
}
```

