### PR TITLE
dummy chopsticks

### DIFF
--- a/.github/workflows/chopsticks.yml
+++ b/.github/workflows/chopsticks.yml
@@ -1,0 +1,43 @@
+name: "Run Chopsticks"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # v0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Install updates and protobuf-compiler
+        run: sudo apt update && sudo apt install --assume-yes cmake protobuf-compiler
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: wasm32-unknown-unknown
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Test all features
+        run: cargo test --workspace --release --locked --features=runtime-benchmarks,runtime-metrics,try-runtime
+        env:
+          RUSTFLAGS: "-C debug-assertions -D warnings"


### PR DESCRIPTION
We need a dummy github actions workflow file on main before we can run and/or make changes to it on a branch

See [comment](https://github.com/polkadot-fellows/runtimes/pull/19#issuecomment-1700480462)