### PR TITLE
add review-bot to require fellows as reviewers

### DIFF
--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -4,7 +4,7 @@ rules:
       include:
         - ^\.github/.*
     type: basic
-    minFellowsRank: 6
+    minFellowsRank: 4
     min_approvals: 2
   - name: Relay and system files
     condition:

--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -23,13 +23,6 @@ rules:
     type: basic
     minFellowsRank: 2
     min_approvals: 2
-  - name: Target Files
-    condition:
-      include:
-        - ^target\/.*
-    type: basic
-    minFellowsRank: 4
-    min_approvals: 2
   - name: General Files
     condition:
       include:

--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -1,0 +1,44 @@
+rules:
+  - name: CI Files
+    condition:
+      include:
+        - ^\.github/.*
+    type: basic
+    minFellowsRank: 6
+    min_approvals: 2
+  - name: Relay files
+    condition:
+      include:
+        - ^relay\/kusama\/.*
+        - ^relay\/polkadot\/.*
+      exclude: 
+        - ^relay\/.+\.adoc$
+    type: basic
+    minFellowsRank: 4
+    min_approvals: 2
+  - name: System Parachain Files
+    condition:
+      include:
+        - ^system-parachains\/.*
+    type: basic
+    minFellowsRank: 2
+    min_approvals: 2
+  - name: Target Files
+    condition:
+      include:
+        - ^target\/.*
+    type: basic
+    minFellowsRank: 4
+    min_approvals: 2
+  - name: General Files
+    condition:
+      include:
+        - '.*'
+      exclude: 
+        - ^relay\/kusama\/.*
+        - ^relay\/polkadot\/.*
+        - ^\.github/.*
+        - ^system-parachains\/.*
+        - ^target\/.*
+    type: basic
+    minFellowsRank: 1

--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -12,6 +12,7 @@ rules:
         - ^relay\/kusama\/.*
         - ^relay\/polkadot\/.*
         - ^system-parachains\/.*
+        - ^CHANGELOG$
       exclude: 
         - ^relay\/.+\.adoc$
     type: fellows

--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -3,9 +3,9 @@ rules:
     condition:
       include:
         - ^\.github/.*
-    type: basic
-    minFellowsRank: 4
-    min_approvals: 2
+    type: fellows
+    minRank: 4
+    minApprovals: 2
   - name: Relay and system files
     condition:
       include:
@@ -14,9 +14,9 @@ rules:
         - ^system-parachains\/.*
       exclude: 
         - ^relay\/.+\.adoc$
-    type: basic
-    minFellowsRank: 3
-    min_approvals: 4
+    type: fellows
+    minRank: 3
+    minApprovals: 4
   - name: General Files
     condition:
       include:
@@ -27,5 +27,5 @@ rules:
         - ^\.github/.*
         - ^system-parachains\/.*
         - ^target\/.*
-    type: basic
-    minFellowsRank: 2
+    type: fellows
+    minRank: 2

--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -14,8 +14,8 @@ rules:
       exclude: 
         - ^relay\/.+\.adoc$
     type: basic
-    minFellowsRank: 4
-    min_approvals: 2
+    minFellowsRank: 3
+    min_approvals: 4
   - name: System Parachain Files
     condition:
       include:
@@ -34,4 +34,4 @@ rules:
         - ^system-parachains\/.*
         - ^target\/.*
     type: basic
-    minFellowsRank: 1
+    minFellowsRank: 2

--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -6,23 +6,17 @@ rules:
     type: basic
     minFellowsRank: 6
     min_approvals: 2
-  - name: Relay files
+  - name: Relay and system files
     condition:
       include:
         - ^relay\/kusama\/.*
         - ^relay\/polkadot\/.*
+        - ^system-parachains\/.*
       exclude: 
         - ^relay\/.+\.adoc$
     type: basic
     minFellowsRank: 3
     min_approvals: 4
-  - name: System Parachain Files
-    condition:
-      include:
-        - ^system-parachains\/.*
-    type: basic
-    minFellowsRank: 2
-    min_approvals: 2
   - name: General Files
     condition:
       include:

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -25,7 +25,7 @@ jobs:
           app_id: ${{ secrets.REVIEW_APP_ID }}
           private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v1.1.0
+        uses: paritytech/review-bot@v2.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           team-token: ${{ steps.team_token.outputs.token }}

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -1,0 +1,32 @@
+name: Review PR
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - review_requested
+      - review_request_removed
+      - ready_for_review
+  pull_request_review:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  review-approvals:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: team_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REVIEW_APP_ID }}
+          private_key: ${{ secrets.REVIEW_APP_KEY }}
+      - name: "Evaluates PR reviews and assigns reviewers"
+        uses: paritytech/review-bot@v1.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          team-token: ${{ steps.team_token.outputs.token }}
+          checks-token: ${{ steps.team_token.outputs.token }}


### PR DESCRIPTION
Created a Github Action that uses the [Review-Bot app](https://github.com/paritytech/review-bot) to require fellows to review pull requests before allowing the PR to be merged.

The user's information is fetched always from the chain after every event.

It looks in the fellows data for a field named GitHub and it extracts the handle from there. This resolves #7 (you can find more information about the request there)

This uses [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) for the event, not `pull_request`. This is a security measure so that an attacker can't steal secrets by changing the workflow file

---

I added an example configuration for this repository so that we can tweak each individual requirements for the files. Feel free to suggest edits to fulfill your requirements.

- CI Files
  - All `.github/` files.
  - Requires 2 approvals of rank 6 or above
- Relay files
  - All files inside the `relay/kusama` or `relay/polkadot` folder with the exception of the files that end in `.adoc`.
  - Requires 2 approvals of rank 4 or above
- System Parachain Files
  - All the files inside `system/parachains` folder.
  - Requires 2 approvals of rank 2 or above
- General Files
  - All the files, with the exclusion of the files inside the other rules.
  - Requires 1 approval of rank 1 or above.

All these rules are of type `basic`. There [are more types of rules available](https://github.com/paritytech/review-bot/tree/v1.1.0#types) but it is intended for teams with different users, and because higher ranks also fulfill requirements for lower ranks, I thought it would be redundant to use those particular type of rules.

Side notes:
- We can move `.github/review-bot.yml` to a different file, there is [an option to move the location](https://github.com/paritytech/review-bot/tree/v1.1.0#inputs).

