### PR TITLE
Remove `ChildSystemParachainAsSuperuser` from Kusama runtime + align "System" vs "common good" terminology

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -637,7 +637,7 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 		// all para-ids that are currently active.
 		let auctioned_slots = Paras::parachains()
 			.into_iter()
-			// all active para-ids that do not belong to a system or common good chain is the number
+			// all active para-ids that do not belong to a system chain is the number
 			// of parachains that we should take into account for inflation.
 			.filter(|i| *i >= LOWEST_PUBLIC_ID)
 			.count() as u64;

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -38,11 +38,10 @@ use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
 	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, ChildParachainAsNative,
-	ChildParachainConvertsVia, ChildSystemParachainAsSuperuser,
-	CurrencyAdapter as XcmCurrencyAdapter, IsChildSystemParachain, IsConcrete, MintLocation,
-	OriginToPluralityVoice, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
-	WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
+	ChildParachainConvertsVia, CurrencyAdapter as XcmCurrencyAdapter, IsChildSystemParachain,
+	IsConcrete, MintLocation, OriginToPluralityVoice, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
+	UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 };
 use xcm_executor::traits::WithOriginFilter;
 
@@ -97,8 +96,6 @@ type LocalOriginConverter = (
 	ChildParachainAsNative<parachains_origin::Origin, RuntimeOrigin>,
 	// The AccountId32 location type can be expressed natively as a `Signed` origin.
 	SignedAccountId32AsNative<ThisNetwork, RuntimeOrigin>,
-	// A system child parachain, expressed as a Superuser, converts to the `Root` origin.
-	ChildSystemParachainAsSuperuser<ParaId, RuntimeOrigin>,
 );
 
 parameter_types! {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -547,7 +547,7 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 		// all para-ids that are not active.
 		let auctioned_slots = Paras::parachains()
 			.into_iter()
-			// all active para-ids that do not belong to a system or common good chain is the number
+			// all active para-ids that do not belong to a system chain is the number
 			// of parachains that we should take into account for inflation.
 			.filter(|i| *i >= LOWEST_PUBLIC_ID)
 			.count() as u64;

--- a/system-parachains/collectives/collectives-polkadot/src/lib.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ### Governance
 //!
-//! As a common good parachain, Collectives defers its governance (namely, its `Root` origin), to
+//! As a system parachain, Collectives defers its governance (namely, its `Root` origin), to
 //! its Relay Chain parent, Polkadot.
 //!
 //! ### Collator Selection


### PR DESCRIPTION
## Summary

This PR proposes the alignment of the terminology used for "common-good" and "system" parachains in the Polkadot ecosystem, as discussed in [PR#1406](https://github.com/paritytech/polkadot-sdk/pull/1406). Additionally, it suggests the removal of the `ChildSystemParachainAsSuperuser` feature from the Kusama runtime, as mentioned in a comment on the same PR [comment link](https://github.com/paritytech/polkadot-sdk/pull/1406#issuecomment-1708218715).

## Explanation

A significant [change of PR#1406](https://github.com/paritytech/polkadot-sdk/pull/1406/files#diff-0b7b4f5b962a18ce980354592b55ab2a27b5a2e9f6f8089ec803ca73853e8583L202-R224) is the redefinition of what constitutes a "system" parachain. Previously, a "system" parachain was identified with `para_id <= 1000`. However, the [PR#1406](https://github.com/paritytech/polkadot-sdk/pull/1406) changed a definition, considering a "system" parachain to have `para_id <= 1999`. 

One consequence of this change is the reconsideration of the [`ChildSystemParachainAsSuperuser`](https://github.com/paritytech/polkadot-sdk/blob/a50e6ba7af50a4be9ae78ebb90e86a61f3dd85e1/polkadot/xcm/xcm-builder/src/origin_conversion.rs#L72-L88) feature. This feature relies on the [`is_system`](https://github.com/paritytech/polkadot-sdk/blob/a50e6ba7af50a4be9ae78ebb90e86a61f3dd85e1/polkadot/parachain/src/primitives.rs#L216-L226) function, which, in turn, depends on the para_id of a parachain to determine "system" status. However, further examination has revealed that there is no known scenario in which a system parachain would need to call the Kusama runtime with `RuntimeOrigin::root()` privileges. Consequently, maintaining the `ChildSystemParachainAsSuperuser` feature in the Kusama runtime is deemed unnecessary.

## References

- [GitHub Pull Request #1406](https://github.com/paritytech/polkadot-sdk/pull/1406)
- Redo of https://github.com/polkadot-fellows/runtimes/pull/32 on main.