### PR TITLE
Switch Collectives Slash Handler to Use Limited Teleport Assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,4 +39,7 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 - XCM: Fix issue with RequestUnlock ([paritytech/polkadot#7278](https://github.com/paritytech/polkadot/pull/7278))
 - Clear Existing HRMP Channel Request When Force Opening ([paritytech/polkadot#7389](https://github.com/paritytech/polkadot/pull/7389))
 - Prune upgrade cooldowns ([paritytech/polkadot#7470](https://github.com/paritytech/polkadot/pull/7470))
-- Assets `destroy_accounts` releases the deposit ([paritytech/substrate#14443](https://github.com/paritytech/substrate/pull/14443))
+- Assets `destroy_accounts` releases the deposit
+  ([paritytech/substrate#14443](https://github.com/paritytech/substrate/pull/14443))
+- Update Polkadot Collectives to use `limited_teleport_assets` for automatic slash handling, as
+  `teleport_assets` is deprecated and caused a failing integration test. ([polkadot-fellows/runtimes#46](https://github.com/polkadot-fellows/runtimes/pull/46))

--- a/system-parachains/collectives/collectives-polkadot/src/impls.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/impls.rs
@@ -24,7 +24,7 @@ use pallet_alliance::{ProposalIndex, ProposalProvider};
 use parachains_common::impls::NegativeImbalance;
 use sp_runtime::DispatchError;
 use sp_std::{cmp::Ordering, marker::PhantomData, prelude::*};
-use xcm::latest::{Fungibility, Junction, Parent};
+use xcm::latest::{Fungibility, Junction, Parent, WeightLimit};
 
 type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 
@@ -63,7 +63,7 @@ where
 
 		<pallet_balances::Pallet<T>>::resolve_creating(&pallet_acc, amount);
 
-		let result = <pallet_xcm::Pallet<T>>::teleport_assets(
+		let result = <pallet_xcm::Pallet<T>>::limited_teleport_assets(
 			<<T as frame_system::Config>::RuntimeOrigin>::signed(pallet_acc.into()),
 			Box::new(Parent.into()),
 			Box::new(
@@ -73,6 +73,7 @@ where
 			),
 			Box::new((Parent, imbalance).into()),
 			0,
+			WeightLimit::Unlimited,
 		);
 
 		if let Err(err) = result {


### PR DESCRIPTION
`teleport_assets` is marked [as deprecated](https://github.com/paritytech/polkadot-sdk/blob/fa4c672/polkadot/xcm/pallet-xcm/src/lib.rs#L789) and the message fails to execute on the Relay Chain due to incorrect weight. This migrates to `limited_teleport_assets` with an `Unlimited` weight limit.

I added the note to the CHANGELOG for the 1.0.0 release, as I don't think this release should be published without this change. I can create a 1.0.1 section instead if people want that.