### PR TITLE
[ci/cd] add gha runner space cleanup job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,17 @@ jobs:
       - name: Install updates and protobuf-compiler
         run: sudo apt update && sudo apt install --assume-yes cmake protobuf-compiler
 
+      - name: Free space on the runner
+        run: |
+          df -h
+          sudo apt -y autoremove --purge
+          sudo apt -y autoclean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Cleanup space on the GHA runner to avoid problems like [this](https://github.com/polkadot-fellows/runtimes/actions/runs/6336414040/job/17209435142?pr=48)