### PR TITLE
Introduce Tinkernet multisig XCM configs to Kusama/Asset Hub Kusama

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-offchain",
  "sp-runtime",
  "sp-session",

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -21,19 +21,23 @@ use super::{
 	RuntimeCall, RuntimeEvent, RuntimeOrigin, StakingAdmin, TransactionByteFee, WeightToFee,
 	XcmPallet,
 };
+use core::marker::PhantomData;
 use frame_support::{
 	match_types, parameter_types,
-	traits::{Contains, Everything, Nothing},
+	traits::{Contains, Everything, Nothing, OriginTrait},
 	weights::Weight,
 };
 use frame_system::EnsureRoot;
 use kusama_runtime_constants::currency::CENTS;
+use parity_scale_codec::{Decode, Encode};
 use runtime_common::{
 	crowdloan, paras_registrar,
 	xcm_sender::{ChildParachainRouter, ExponentialPrice},
 	ToAuthor,
 };
-use sp_core::ConstU32;
+use sp_core::{ConstU32, H256};
+use sp_io::hashing::blake2_256;
+use sp_runtime::traits::TrailingZeroInput;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -44,7 +48,7 @@ use xcm_builder::{
 	SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
 	WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 };
-use xcm_executor::traits::WithOriginFilter;
+use xcm_executor::traits::{ConvertLocation, ConvertOrigin, WithOriginFilter};
 
 parameter_types! {
 	/// The location of the KSM token, from the context of this chain. Since this token is native to this
@@ -70,6 +74,8 @@ pub type SovereignAccountOf = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	// We can directly alias an `AccountId32` into a local account.
 	AccountId32Aliases<ThisNetwork, AccountId>,
+	// Mapping Tinkernet multisig to the correctly derived AccountId.
+	TinkernetMultisigAsAccountId<AccountId>,
 );
 
 /// Our asset transactor. This is what allows us to interest with the runtime facilities from the
@@ -99,6 +105,8 @@ type LocalOriginConverter = (
 	SignedAccountId32AsNative<ThisNetwork, RuntimeOrigin>,
 	// A system child parachain, expressed as a Superuser, converts to the `Root` origin.
 	ChildSystemParachainAsSuperuser<ParaId, RuntimeOrigin>,
+	// Derives signed AccountId origins for Tinkernet multisigs.
+	TinkernetMultisigAsNativeOrigin<RuntimeOrigin>,
 );
 
 parameter_types! {
@@ -174,140 +182,140 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 		#[cfg(feature = "runtime-benchmarks")]
 		{
 			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
-				return true
+				return true;
 			}
 		}
 
 		match call {
 			RuntimeCall::System(
 				frame_system::Call::kill_prefix { .. } | frame_system::Call::set_heap_pages { .. },
-			) |
-			RuntimeCall::Babe(..) |
-			RuntimeCall::Timestamp(..) |
-			RuntimeCall::Indices(..) |
-			RuntimeCall::Balances(..) |
-			RuntimeCall::Crowdloan(
-				crowdloan::Call::create { .. } |
-				crowdloan::Call::contribute { .. } |
-				crowdloan::Call::withdraw { .. } |
-				crowdloan::Call::refund { .. } |
-				crowdloan::Call::dissolve { .. } |
-				crowdloan::Call::edit { .. } |
-				crowdloan::Call::poke { .. } |
-				crowdloan::Call::contribute_all { .. },
-			) |
-			RuntimeCall::Staking(
-				pallet_staking::Call::bond { .. } |
-				pallet_staking::Call::bond_extra { .. } |
-				pallet_staking::Call::unbond { .. } |
-				pallet_staking::Call::withdraw_unbonded { .. } |
-				pallet_staking::Call::validate { .. } |
-				pallet_staking::Call::nominate { .. } |
-				pallet_staking::Call::chill { .. } |
-				pallet_staking::Call::set_payee { .. } |
-				pallet_staking::Call::set_controller { .. } |
-				pallet_staking::Call::set_validator_count { .. } |
-				pallet_staking::Call::increase_validator_count { .. } |
-				pallet_staking::Call::scale_validator_count { .. } |
-				pallet_staking::Call::force_no_eras { .. } |
-				pallet_staking::Call::force_new_era { .. } |
-				pallet_staking::Call::set_invulnerables { .. } |
-				pallet_staking::Call::force_unstake { .. } |
-				pallet_staking::Call::force_new_era_always { .. } |
-				pallet_staking::Call::payout_stakers { .. } |
-				pallet_staking::Call::rebond { .. } |
-				pallet_staking::Call::reap_stash { .. } |
-				pallet_staking::Call::set_staking_configs { .. } |
-				pallet_staking::Call::chill_other { .. } |
-				pallet_staking::Call::force_apply_min_commission { .. },
-			) |
-			RuntimeCall::Session(pallet_session::Call::purge_keys { .. }) |
-			RuntimeCall::Grandpa(..) |
-			RuntimeCall::ImOnline(..) |
-			RuntimeCall::Treasury(..) |
-			RuntimeCall::ConvictionVoting(..) |
-			RuntimeCall::Referenda(
-				pallet_referenda::Call::place_decision_deposit { .. } |
-				pallet_referenda::Call::refund_decision_deposit { .. } |
-				pallet_referenda::Call::cancel { .. } |
-				pallet_referenda::Call::kill { .. } |
-				pallet_referenda::Call::nudge_referendum { .. } |
-				pallet_referenda::Call::one_fewer_deciding { .. },
-			) |
-			RuntimeCall::FellowshipCollective(..) |
-			RuntimeCall::FellowshipReferenda(
-				pallet_referenda::Call::place_decision_deposit { .. } |
-				pallet_referenda::Call::refund_decision_deposit { .. } |
-				pallet_referenda::Call::cancel { .. } |
-				pallet_referenda::Call::kill { .. } |
-				pallet_referenda::Call::nudge_referendum { .. } |
-				pallet_referenda::Call::one_fewer_deciding { .. },
-			) |
-			RuntimeCall::Claims(
-				super::claims::Call::claim { .. } |
-				super::claims::Call::mint_claim { .. } |
-				super::claims::Call::move_claim { .. },
-			) |
-			RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. }) |
-			RuntimeCall::Identity(
-				pallet_identity::Call::add_registrar { .. } |
-				pallet_identity::Call::set_identity { .. } |
-				pallet_identity::Call::clear_identity { .. } |
-				pallet_identity::Call::request_judgement { .. } |
-				pallet_identity::Call::cancel_request { .. } |
-				pallet_identity::Call::set_fee { .. } |
-				pallet_identity::Call::set_account_id { .. } |
-				pallet_identity::Call::set_fields { .. } |
-				pallet_identity::Call::provide_judgement { .. } |
-				pallet_identity::Call::kill_identity { .. } |
-				pallet_identity::Call::add_sub { .. } |
-				pallet_identity::Call::rename_sub { .. } |
-				pallet_identity::Call::remove_sub { .. } |
-				pallet_identity::Call::quit_sub { .. },
-			) |
-			RuntimeCall::Society(..) |
-			RuntimeCall::Recovery(..) |
-			RuntimeCall::Vesting(..) |
-			RuntimeCall::Bounties(
-				pallet_bounties::Call::propose_bounty { .. } |
-				pallet_bounties::Call::approve_bounty { .. } |
-				pallet_bounties::Call::propose_curator { .. } |
-				pallet_bounties::Call::unassign_curator { .. } |
-				pallet_bounties::Call::accept_curator { .. } |
-				pallet_bounties::Call::award_bounty { .. } |
-				pallet_bounties::Call::claim_bounty { .. } |
-				pallet_bounties::Call::close_bounty { .. },
-			) |
-			RuntimeCall::ChildBounties(..) |
-			RuntimeCall::ElectionProviderMultiPhase(..) |
-			RuntimeCall::VoterList(..) |
-			RuntimeCall::NominationPools(
-				pallet_nomination_pools::Call::join { .. } |
-				pallet_nomination_pools::Call::bond_extra { .. } |
-				pallet_nomination_pools::Call::claim_payout { .. } |
-				pallet_nomination_pools::Call::unbond { .. } |
-				pallet_nomination_pools::Call::pool_withdraw_unbonded { .. } |
-				pallet_nomination_pools::Call::withdraw_unbonded { .. } |
-				pallet_nomination_pools::Call::create { .. } |
-				pallet_nomination_pools::Call::create_with_pool_id { .. } |
-				pallet_nomination_pools::Call::set_state { .. } |
-				pallet_nomination_pools::Call::set_configs { .. } |
-				pallet_nomination_pools::Call::update_roles { .. } |
-				pallet_nomination_pools::Call::chill { .. },
-			) |
-			RuntimeCall::Hrmp(..) |
-			RuntimeCall::Registrar(
-				paras_registrar::Call::deregister { .. } |
-				paras_registrar::Call::swap { .. } |
-				paras_registrar::Call::remove_lock { .. } |
-				paras_registrar::Call::reserve { .. } |
-				paras_registrar::Call::add_lock { .. },
-			) |
-			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
+			)
+			| RuntimeCall::Babe(..)
+			| RuntimeCall::Timestamp(..)
+			| RuntimeCall::Indices(..)
+			| RuntimeCall::Balances(..)
+			| RuntimeCall::Crowdloan(
+				crowdloan::Call::create { .. }
+				| crowdloan::Call::contribute { .. }
+				| crowdloan::Call::withdraw { .. }
+				| crowdloan::Call::refund { .. }
+				| crowdloan::Call::dissolve { .. }
+				| crowdloan::Call::edit { .. }
+				| crowdloan::Call::poke { .. }
+				| crowdloan::Call::contribute_all { .. },
+			)
+			| RuntimeCall::Staking(
+				pallet_staking::Call::bond { .. }
+				| pallet_staking::Call::bond_extra { .. }
+				| pallet_staking::Call::unbond { .. }
+				| pallet_staking::Call::withdraw_unbonded { .. }
+				| pallet_staking::Call::validate { .. }
+				| pallet_staking::Call::nominate { .. }
+				| pallet_staking::Call::chill { .. }
+				| pallet_staking::Call::set_payee { .. }
+				| pallet_staking::Call::set_controller { .. }
+				| pallet_staking::Call::set_validator_count { .. }
+				| pallet_staking::Call::increase_validator_count { .. }
+				| pallet_staking::Call::scale_validator_count { .. }
+				| pallet_staking::Call::force_no_eras { .. }
+				| pallet_staking::Call::force_new_era { .. }
+				| pallet_staking::Call::set_invulnerables { .. }
+				| pallet_staking::Call::force_unstake { .. }
+				| pallet_staking::Call::force_new_era_always { .. }
+				| pallet_staking::Call::payout_stakers { .. }
+				| pallet_staking::Call::rebond { .. }
+				| pallet_staking::Call::reap_stash { .. }
+				| pallet_staking::Call::set_staking_configs { .. }
+				| pallet_staking::Call::chill_other { .. }
+				| pallet_staking::Call::force_apply_min_commission { .. },
+			)
+			| RuntimeCall::Session(pallet_session::Call::purge_keys { .. })
+			| RuntimeCall::Grandpa(..)
+			| RuntimeCall::ImOnline(..)
+			| RuntimeCall::Treasury(..)
+			| RuntimeCall::ConvictionVoting(..)
+			| RuntimeCall::Referenda(
+				pallet_referenda::Call::place_decision_deposit { .. }
+				| pallet_referenda::Call::refund_decision_deposit { .. }
+				| pallet_referenda::Call::cancel { .. }
+				| pallet_referenda::Call::kill { .. }
+				| pallet_referenda::Call::nudge_referendum { .. }
+				| pallet_referenda::Call::one_fewer_deciding { .. },
+			)
+			| RuntimeCall::FellowshipCollective(..)
+			| RuntimeCall::FellowshipReferenda(
+				pallet_referenda::Call::place_decision_deposit { .. }
+				| pallet_referenda::Call::refund_decision_deposit { .. }
+				| pallet_referenda::Call::cancel { .. }
+				| pallet_referenda::Call::kill { .. }
+				| pallet_referenda::Call::nudge_referendum { .. }
+				| pallet_referenda::Call::one_fewer_deciding { .. },
+			)
+			| RuntimeCall::Claims(
+				super::claims::Call::claim { .. }
+				| super::claims::Call::mint_claim { .. }
+				| super::claims::Call::move_claim { .. },
+			)
+			| RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. })
+			| RuntimeCall::Identity(
+				pallet_identity::Call::add_registrar { .. }
+				| pallet_identity::Call::set_identity { .. }
+				| pallet_identity::Call::clear_identity { .. }
+				| pallet_identity::Call::request_judgement { .. }
+				| pallet_identity::Call::cancel_request { .. }
+				| pallet_identity::Call::set_fee { .. }
+				| pallet_identity::Call::set_account_id { .. }
+				| pallet_identity::Call::set_fields { .. }
+				| pallet_identity::Call::provide_judgement { .. }
+				| pallet_identity::Call::kill_identity { .. }
+				| pallet_identity::Call::add_sub { .. }
+				| pallet_identity::Call::rename_sub { .. }
+				| pallet_identity::Call::remove_sub { .. }
+				| pallet_identity::Call::quit_sub { .. },
+			)
+			| RuntimeCall::Society(..)
+			| RuntimeCall::Recovery(..)
+			| RuntimeCall::Vesting(..)
+			| RuntimeCall::Bounties(
+				pallet_bounties::Call::propose_bounty { .. }
+				| pallet_bounties::Call::approve_bounty { .. }
+				| pallet_bounties::Call::propose_curator { .. }
+				| pallet_bounties::Call::unassign_curator { .. }
+				| pallet_bounties::Call::accept_curator { .. }
+				| pallet_bounties::Call::award_bounty { .. }
+				| pallet_bounties::Call::claim_bounty { .. }
+				| pallet_bounties::Call::close_bounty { .. },
+			)
+			| RuntimeCall::ChildBounties(..)
+			| RuntimeCall::ElectionProviderMultiPhase(..)
+			| RuntimeCall::VoterList(..)
+			| RuntimeCall::NominationPools(
+				pallet_nomination_pools::Call::join { .. }
+				| pallet_nomination_pools::Call::bond_extra { .. }
+				| pallet_nomination_pools::Call::claim_payout { .. }
+				| pallet_nomination_pools::Call::unbond { .. }
+				| pallet_nomination_pools::Call::pool_withdraw_unbonded { .. }
+				| pallet_nomination_pools::Call::withdraw_unbonded { .. }
+				| pallet_nomination_pools::Call::create { .. }
+				| pallet_nomination_pools::Call::create_with_pool_id { .. }
+				| pallet_nomination_pools::Call::set_state { .. }
+				| pallet_nomination_pools::Call::set_configs { .. }
+				| pallet_nomination_pools::Call::update_roles { .. }
+				| pallet_nomination_pools::Call::chill { .. },
+			)
+			| RuntimeCall::Hrmp(..)
+			| RuntimeCall::Registrar(
+				paras_registrar::Call::deregister { .. }
+				| paras_registrar::Call::swap { .. }
+				| paras_registrar::Call::remove_lock { .. }
+				| paras_registrar::Call::reserve { .. }
+				| paras_registrar::Call::add_lock { .. },
+			)
+			| RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
-			}) |
-			RuntimeCall::Whitelist(pallet_whitelist::Call::whitelist_call { .. }) |
-			RuntimeCall::Proxy(..) => true,
+			})
+			| RuntimeCall::Whitelist(pallet_whitelist::Call::whitelist_call { .. })
+			| RuntimeCall::Proxy(..) => true,
 			_ => false,
 		}
 	}
@@ -422,6 +430,83 @@ impl pallet_xcm::Config for Runtime {
 	#[cfg(feature = "runtime-benchmarks")]
 	type ReachableDest = ReachableDest;
 	type AdminOrigin = EnsureRoot<AccountId>;
+}
+
+/// Tinkernet ParaId used when matching Multisig MultiLocations.
+const TINKERNET_PARA_ID: u32 = 2125;
+
+/// Tinkernet Multisig pallet instance used when matching Multisig MultiLocations.
+const TINKERNET_MULTISIG_PALLET: u8 = 71;
+
+/// Constant derivation function for Tinkernet Multisigs.
+/// Uses the Tinkernet genesis hash as a salt.
+pub fn derive_tinkernet_multisig<AccountId: Decode>(id: u128) -> Result<AccountId, ()> {
+	AccountId::decode(&mut TrailingZeroInput::new(
+		&(
+			// The constant salt used to derive Tinkernet Multisigs, this is Tinkernet's genesis hash.
+			H256([
+				212, 46, 150, 6, 169, 149, 223, 228, 51, 220, 121, 85, 220, 42, 112, 244, 149, 243,
+				80, 243, 115, 218, 162, 0, 9, 138, 232, 68, 55, 129, 106, 210,
+			]),
+			// The actual multisig integer id.
+			u32::try_from(id).map_err(|_| ())?,
+		)
+			.using_encoded(blake2_256),
+	))
+	.map_err(|_| ())
+}
+
+/// Convert a Tinkernet Multisig `MultiLocation` value into a local `AccountId`.
+pub struct TinkernetMultisigAsAccountId<AccountId>(PhantomData<AccountId>);
+impl<AccountId: Decode + Clone> ConvertLocation<AccountId>
+	for TinkernetMultisigAsAccountId<AccountId>
+{
+	fn convert_location(location: &MultiLocation) -> Option<AccountId> {
+		match location {
+			MultiLocation {
+				parents: 0,
+				interior:
+					X3(
+						Parachain(TINKERNET_PARA_ID),
+						PalletInstance(TINKERNET_MULTISIG_PALLET),
+						// Index from which the multisig account is derived.
+						GeneralIndex(id),
+					),
+			} => derive_tinkernet_multisig(*id).ok(),
+			_ => None,
+		}
+	}
+}
+
+/// Convert a Tinkernet Multisig `MultiLocation` value into a `Signed` origin.
+pub struct TinkernetMultisigAsNativeOrigin<RuntimeOrigin>(PhantomData<RuntimeOrigin>);
+impl<RuntimeOrigin: OriginTrait> ConvertOrigin<RuntimeOrigin>
+	for TinkernetMultisigAsNativeOrigin<RuntimeOrigin>
+where
+	RuntimeOrigin::AccountId: Decode,
+{
+	fn convert_origin(
+		origin: impl Into<MultiLocation>,
+		kind: OriginKind,
+	) -> Result<RuntimeOrigin, MultiLocation> {
+		let origin = origin.into();
+		match (kind, origin) {
+			(
+				OriginKind::Native,
+				MultiLocation {
+					parents: 0,
+					interior:
+						X3(
+							Junction::Parachain(TINKERNET_PARA_ID),
+							Junction::PalletInstance(TINKERNET_MULTISIG_PALLET),
+							// Index from which the multisig account is derived.
+							Junction::GeneralIndex(id),
+						),
+				},
+			) => Ok(RuntimeOrigin::signed(derive_tinkernet_multisig(id).map_err(|_| origin)?)),
+			(_, origin) => Err(origin),
+		}
+	}
 }
 
 #[test]

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -182,140 +182,140 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 		#[cfg(feature = "runtime-benchmarks")]
 		{
 			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
-				return true;
+				return true
 			}
 		}
 
 		match call {
 			RuntimeCall::System(
 				frame_system::Call::kill_prefix { .. } | frame_system::Call::set_heap_pages { .. },
-			)
-			| RuntimeCall::Babe(..)
-			| RuntimeCall::Timestamp(..)
-			| RuntimeCall::Indices(..)
-			| RuntimeCall::Balances(..)
-			| RuntimeCall::Crowdloan(
-				crowdloan::Call::create { .. }
-				| crowdloan::Call::contribute { .. }
-				| crowdloan::Call::withdraw { .. }
-				| crowdloan::Call::refund { .. }
-				| crowdloan::Call::dissolve { .. }
-				| crowdloan::Call::edit { .. }
-				| crowdloan::Call::poke { .. }
-				| crowdloan::Call::contribute_all { .. },
-			)
-			| RuntimeCall::Staking(
-				pallet_staking::Call::bond { .. }
-				| pallet_staking::Call::bond_extra { .. }
-				| pallet_staking::Call::unbond { .. }
-				| pallet_staking::Call::withdraw_unbonded { .. }
-				| pallet_staking::Call::validate { .. }
-				| pallet_staking::Call::nominate { .. }
-				| pallet_staking::Call::chill { .. }
-				| pallet_staking::Call::set_payee { .. }
-				| pallet_staking::Call::set_controller { .. }
-				| pallet_staking::Call::set_validator_count { .. }
-				| pallet_staking::Call::increase_validator_count { .. }
-				| pallet_staking::Call::scale_validator_count { .. }
-				| pallet_staking::Call::force_no_eras { .. }
-				| pallet_staking::Call::force_new_era { .. }
-				| pallet_staking::Call::set_invulnerables { .. }
-				| pallet_staking::Call::force_unstake { .. }
-				| pallet_staking::Call::force_new_era_always { .. }
-				| pallet_staking::Call::payout_stakers { .. }
-				| pallet_staking::Call::rebond { .. }
-				| pallet_staking::Call::reap_stash { .. }
-				| pallet_staking::Call::set_staking_configs { .. }
-				| pallet_staking::Call::chill_other { .. }
-				| pallet_staking::Call::force_apply_min_commission { .. },
-			)
-			| RuntimeCall::Session(pallet_session::Call::purge_keys { .. })
-			| RuntimeCall::Grandpa(..)
-			| RuntimeCall::ImOnline(..)
-			| RuntimeCall::Treasury(..)
-			| RuntimeCall::ConvictionVoting(..)
-			| RuntimeCall::Referenda(
-				pallet_referenda::Call::place_decision_deposit { .. }
-				| pallet_referenda::Call::refund_decision_deposit { .. }
-				| pallet_referenda::Call::cancel { .. }
-				| pallet_referenda::Call::kill { .. }
-				| pallet_referenda::Call::nudge_referendum { .. }
-				| pallet_referenda::Call::one_fewer_deciding { .. },
-			)
-			| RuntimeCall::FellowshipCollective(..)
-			| RuntimeCall::FellowshipReferenda(
-				pallet_referenda::Call::place_decision_deposit { .. }
-				| pallet_referenda::Call::refund_decision_deposit { .. }
-				| pallet_referenda::Call::cancel { .. }
-				| pallet_referenda::Call::kill { .. }
-				| pallet_referenda::Call::nudge_referendum { .. }
-				| pallet_referenda::Call::one_fewer_deciding { .. },
-			)
-			| RuntimeCall::Claims(
-				super::claims::Call::claim { .. }
-				| super::claims::Call::mint_claim { .. }
-				| super::claims::Call::move_claim { .. },
-			)
-			| RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. })
-			| RuntimeCall::Identity(
-				pallet_identity::Call::add_registrar { .. }
-				| pallet_identity::Call::set_identity { .. }
-				| pallet_identity::Call::clear_identity { .. }
-				| pallet_identity::Call::request_judgement { .. }
-				| pallet_identity::Call::cancel_request { .. }
-				| pallet_identity::Call::set_fee { .. }
-				| pallet_identity::Call::set_account_id { .. }
-				| pallet_identity::Call::set_fields { .. }
-				| pallet_identity::Call::provide_judgement { .. }
-				| pallet_identity::Call::kill_identity { .. }
-				| pallet_identity::Call::add_sub { .. }
-				| pallet_identity::Call::rename_sub { .. }
-				| pallet_identity::Call::remove_sub { .. }
-				| pallet_identity::Call::quit_sub { .. },
-			)
-			| RuntimeCall::Society(..)
-			| RuntimeCall::Recovery(..)
-			| RuntimeCall::Vesting(..)
-			| RuntimeCall::Bounties(
-				pallet_bounties::Call::propose_bounty { .. }
-				| pallet_bounties::Call::approve_bounty { .. }
-				| pallet_bounties::Call::propose_curator { .. }
-				| pallet_bounties::Call::unassign_curator { .. }
-				| pallet_bounties::Call::accept_curator { .. }
-				| pallet_bounties::Call::award_bounty { .. }
-				| pallet_bounties::Call::claim_bounty { .. }
-				| pallet_bounties::Call::close_bounty { .. },
-			)
-			| RuntimeCall::ChildBounties(..)
-			| RuntimeCall::ElectionProviderMultiPhase(..)
-			| RuntimeCall::VoterList(..)
-			| RuntimeCall::NominationPools(
-				pallet_nomination_pools::Call::join { .. }
-				| pallet_nomination_pools::Call::bond_extra { .. }
-				| pallet_nomination_pools::Call::claim_payout { .. }
-				| pallet_nomination_pools::Call::unbond { .. }
-				| pallet_nomination_pools::Call::pool_withdraw_unbonded { .. }
-				| pallet_nomination_pools::Call::withdraw_unbonded { .. }
-				| pallet_nomination_pools::Call::create { .. }
-				| pallet_nomination_pools::Call::create_with_pool_id { .. }
-				| pallet_nomination_pools::Call::set_state { .. }
-				| pallet_nomination_pools::Call::set_configs { .. }
-				| pallet_nomination_pools::Call::update_roles { .. }
-				| pallet_nomination_pools::Call::chill { .. },
-			)
-			| RuntimeCall::Hrmp(..)
-			| RuntimeCall::Registrar(
-				paras_registrar::Call::deregister { .. }
-				| paras_registrar::Call::swap { .. }
-				| paras_registrar::Call::remove_lock { .. }
-				| paras_registrar::Call::reserve { .. }
-				| paras_registrar::Call::add_lock { .. },
-			)
-			| RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
+			) |
+			RuntimeCall::Babe(..) |
+			RuntimeCall::Timestamp(..) |
+			RuntimeCall::Indices(..) |
+			RuntimeCall::Balances(..) |
+			RuntimeCall::Crowdloan(
+				crowdloan::Call::create { .. } |
+				crowdloan::Call::contribute { .. } |
+				crowdloan::Call::withdraw { .. } |
+				crowdloan::Call::refund { .. } |
+				crowdloan::Call::dissolve { .. } |
+				crowdloan::Call::edit { .. } |
+				crowdloan::Call::poke { .. } |
+				crowdloan::Call::contribute_all { .. },
+			) |
+			RuntimeCall::Staking(
+				pallet_staking::Call::bond { .. } |
+				pallet_staking::Call::bond_extra { .. } |
+				pallet_staking::Call::unbond { .. } |
+				pallet_staking::Call::withdraw_unbonded { .. } |
+				pallet_staking::Call::validate { .. } |
+				pallet_staking::Call::nominate { .. } |
+				pallet_staking::Call::chill { .. } |
+				pallet_staking::Call::set_payee { .. } |
+				pallet_staking::Call::set_controller { .. } |
+				pallet_staking::Call::set_validator_count { .. } |
+				pallet_staking::Call::increase_validator_count { .. } |
+				pallet_staking::Call::scale_validator_count { .. } |
+				pallet_staking::Call::force_no_eras { .. } |
+				pallet_staking::Call::force_new_era { .. } |
+				pallet_staking::Call::set_invulnerables { .. } |
+				pallet_staking::Call::force_unstake { .. } |
+				pallet_staking::Call::force_new_era_always { .. } |
+				pallet_staking::Call::payout_stakers { .. } |
+				pallet_staking::Call::rebond { .. } |
+				pallet_staking::Call::reap_stash { .. } |
+				pallet_staking::Call::set_staking_configs { .. } |
+				pallet_staking::Call::chill_other { .. } |
+				pallet_staking::Call::force_apply_min_commission { .. },
+			) |
+			RuntimeCall::Session(pallet_session::Call::purge_keys { .. }) |
+			RuntimeCall::Grandpa(..) |
+			RuntimeCall::ImOnline(..) |
+			RuntimeCall::Treasury(..) |
+			RuntimeCall::ConvictionVoting(..) |
+			RuntimeCall::Referenda(
+				pallet_referenda::Call::place_decision_deposit { .. } |
+				pallet_referenda::Call::refund_decision_deposit { .. } |
+				pallet_referenda::Call::cancel { .. } |
+				pallet_referenda::Call::kill { .. } |
+				pallet_referenda::Call::nudge_referendum { .. } |
+				pallet_referenda::Call::one_fewer_deciding { .. },
+			) |
+			RuntimeCall::FellowshipCollective(..) |
+			RuntimeCall::FellowshipReferenda(
+				pallet_referenda::Call::place_decision_deposit { .. } |
+				pallet_referenda::Call::refund_decision_deposit { .. } |
+				pallet_referenda::Call::cancel { .. } |
+				pallet_referenda::Call::kill { .. } |
+				pallet_referenda::Call::nudge_referendum { .. } |
+				pallet_referenda::Call::one_fewer_deciding { .. },
+			) |
+			RuntimeCall::Claims(
+				super::claims::Call::claim { .. } |
+				super::claims::Call::mint_claim { .. } |
+				super::claims::Call::move_claim { .. },
+			) |
+			RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. }) |
+			RuntimeCall::Identity(
+				pallet_identity::Call::add_registrar { .. } |
+				pallet_identity::Call::set_identity { .. } |
+				pallet_identity::Call::clear_identity { .. } |
+				pallet_identity::Call::request_judgement { .. } |
+				pallet_identity::Call::cancel_request { .. } |
+				pallet_identity::Call::set_fee { .. } |
+				pallet_identity::Call::set_account_id { .. } |
+				pallet_identity::Call::set_fields { .. } |
+				pallet_identity::Call::provide_judgement { .. } |
+				pallet_identity::Call::kill_identity { .. } |
+				pallet_identity::Call::add_sub { .. } |
+				pallet_identity::Call::rename_sub { .. } |
+				pallet_identity::Call::remove_sub { .. } |
+				pallet_identity::Call::quit_sub { .. },
+			) |
+			RuntimeCall::Society(..) |
+			RuntimeCall::Recovery(..) |
+			RuntimeCall::Vesting(..) |
+			RuntimeCall::Bounties(
+				pallet_bounties::Call::propose_bounty { .. } |
+				pallet_bounties::Call::approve_bounty { .. } |
+				pallet_bounties::Call::propose_curator { .. } |
+				pallet_bounties::Call::unassign_curator { .. } |
+				pallet_bounties::Call::accept_curator { .. } |
+				pallet_bounties::Call::award_bounty { .. } |
+				pallet_bounties::Call::claim_bounty { .. } |
+				pallet_bounties::Call::close_bounty { .. },
+			) |
+			RuntimeCall::ChildBounties(..) |
+			RuntimeCall::ElectionProviderMultiPhase(..) |
+			RuntimeCall::VoterList(..) |
+			RuntimeCall::NominationPools(
+				pallet_nomination_pools::Call::join { .. } |
+				pallet_nomination_pools::Call::bond_extra { .. } |
+				pallet_nomination_pools::Call::claim_payout { .. } |
+				pallet_nomination_pools::Call::unbond { .. } |
+				pallet_nomination_pools::Call::pool_withdraw_unbonded { .. } |
+				pallet_nomination_pools::Call::withdraw_unbonded { .. } |
+				pallet_nomination_pools::Call::create { .. } |
+				pallet_nomination_pools::Call::create_with_pool_id { .. } |
+				pallet_nomination_pools::Call::set_state { .. } |
+				pallet_nomination_pools::Call::set_configs { .. } |
+				pallet_nomination_pools::Call::update_roles { .. } |
+				pallet_nomination_pools::Call::chill { .. },
+			) |
+			RuntimeCall::Hrmp(..) |
+			RuntimeCall::Registrar(
+				paras_registrar::Call::deregister { .. } |
+				paras_registrar::Call::swap { .. } |
+				paras_registrar::Call::remove_lock { .. } |
+				paras_registrar::Call::reserve { .. } |
+				paras_registrar::Call::add_lock { .. },
+			) |
+			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
 				..
-			})
-			| RuntimeCall::Whitelist(pallet_whitelist::Call::whitelist_call { .. })
-			| RuntimeCall::Proxy(..) => true,
+			}) |
+			RuntimeCall::Whitelist(pallet_whitelist::Call::whitelist_call { .. }) |
+			RuntimeCall::Proxy(..) => true,
 			_ => false,
 		}
 	}

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -443,7 +443,8 @@ const TINKERNET_MULTISIG_PALLET: u8 = 71;
 pub fn derive_tinkernet_multisig<AccountId: Decode>(id: u128) -> Result<AccountId, ()> {
 	AccountId::decode(&mut TrailingZeroInput::new(
 		&(
-			// The constant salt used to derive Tinkernet Multisigs, this is Tinkernet's genesis hash.
+			// The constant salt used to derive Tinkernet Multisigs, this is Tinkernet's genesis
+			// hash.
 			H256([
 				212, 46, 150, 6, 169, 149, 223, 228, 51, 220, 121, 85, 220, 42, 112, 244, 149, 243,
 				80, 243, 115, 218, 162, 0, 9, 138, 232, 68, 55, 129, 106, 210,

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -43,6 +43,7 @@ sp-block-builder = { default-features = false, version = "21.0.0" }
 sp-consensus-aura = { default-features = false, version = "0.27.0" }
 sp-core = { default-features = false, version = "23.0.0" }
 sp-inherents = { default-features = false, version = "21.0.0" }
+sp-io = { default-features = false , version = "25.0.0" }
 sp-offchain = { default-features = false, version = "21.0.0" }
 sp-runtime = { default-features = false, version = "26.0.0" }
 sp-session = { default-features = false, version = "22.0.0" }
@@ -208,6 +209,7 @@ std = [
 	"sp-consensus-aura/std",
 	"sp-core/std",
 	"sp-inherents/std",
+	"sp-io/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs
@@ -647,7 +647,8 @@ const TINKERNET_MULTISIG_PALLET: u8 = 71;
 pub fn derive_tinkernet_multisig<AccountId: Decode>(id: u128) -> Result<AccountId, ()> {
 	AccountId::decode(&mut TrailingZeroInput::new(
 		&(
-			// The constant salt used to derive Tinkernet Multisigs, this is Tinkernet's genesis hash.
+			// The constant salt used to derive Tinkernet Multisigs, this is Tinkernet's genesis
+			// hash.
 			H256([
 				212, 46, 150, 6, 169, 149, 223, 228, 51, 220, 121, 85, 220, 42, 112, 244, 149, 243,
 				80, 243, 115, 218, 162, 0, 9, 138, 232, 68, 55, 129, 106, 210,

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs
@@ -37,8 +37,7 @@ use parachains_common::{impls::ToStakingPot, xcm_config::AssetFeeAsExistentialDe
 use polkadot_parachain_primitives::primitives::Sibling;
 use sp_core::H256;
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::ConvertInto;
-use sp_runtime::traits::TrailingZeroInput;
+use sp_runtime::traits::{ConvertInto, TrailingZeroInput};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -257,194 +256,194 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 		#[cfg(feature = "runtime-benchmarks")]
 		{
 			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
-				return true;
+				return true
 			}
 		}
 
 		matches!(
 			call,
-			RuntimeCall::PolkadotXcm(pallet_xcm::Call::force_xcm_version { .. })
-				| RuntimeCall::System(
-					frame_system::Call::set_heap_pages { .. }
-						| frame_system::Call::set_code { .. }
-						| frame_system::Call::set_code_without_checks { .. }
-						| frame_system::Call::kill_prefix { .. },
-				) | RuntimeCall::ParachainSystem(..)
-				| RuntimeCall::Timestamp(..)
-				| RuntimeCall::Balances(..)
-				| RuntimeCall::CollatorSelection(
-					pallet_collator_selection::Call::set_desired_candidates { .. }
-						| pallet_collator_selection::Call::set_candidacy_bond { .. }
-						| pallet_collator_selection::Call::register_as_candidate { .. }
-						| pallet_collator_selection::Call::leave_intent { .. }
-						| pallet_collator_selection::Call::set_invulnerables { .. }
-						| pallet_collator_selection::Call::add_invulnerable { .. }
-						| pallet_collator_selection::Call::remove_invulnerable { .. },
-				) | RuntimeCall::Session(pallet_session::Call::purge_keys { .. })
-				| RuntimeCall::XcmpQueue(..)
-				| RuntimeCall::DmpQueue(..)
-				| RuntimeCall::Assets(
-					pallet_assets::Call::create { .. }
-						| pallet_assets::Call::force_create { .. }
-						| pallet_assets::Call::start_destroy { .. }
-						| pallet_assets::Call::destroy_accounts { .. }
-						| pallet_assets::Call::destroy_approvals { .. }
-						| pallet_assets::Call::finish_destroy { .. }
-						| pallet_assets::Call::block { .. }
-						| pallet_assets::Call::mint { .. }
-						| pallet_assets::Call::burn { .. }
-						| pallet_assets::Call::transfer { .. }
-						| pallet_assets::Call::transfer_keep_alive { .. }
-						| pallet_assets::Call::force_transfer { .. }
-						| pallet_assets::Call::freeze { .. }
-						| pallet_assets::Call::thaw { .. }
-						| pallet_assets::Call::freeze_asset { .. }
-						| pallet_assets::Call::thaw_asset { .. }
-						| pallet_assets::Call::transfer_ownership { .. }
-						| pallet_assets::Call::set_team { .. }
-						| pallet_assets::Call::set_metadata { .. }
-						| pallet_assets::Call::clear_metadata { .. }
-						| pallet_assets::Call::force_set_metadata { .. }
-						| pallet_assets::Call::force_clear_metadata { .. }
-						| pallet_assets::Call::force_asset_status { .. }
-						| pallet_assets::Call::approve_transfer { .. }
-						| pallet_assets::Call::cancel_approval { .. }
-						| pallet_assets::Call::force_cancel_approval { .. }
-						| pallet_assets::Call::transfer_approved { .. }
-						| pallet_assets::Call::touch { .. }
-						| pallet_assets::Call::touch_other { .. }
-						| pallet_assets::Call::refund { .. }
-						| pallet_assets::Call::refund_other { .. },
+			RuntimeCall::PolkadotXcm(pallet_xcm::Call::force_xcm_version { .. }) |
+				RuntimeCall::System(
+					frame_system::Call::set_heap_pages { .. } |
+						frame_system::Call::set_code { .. } |
+						frame_system::Call::set_code_without_checks { .. } |
+						frame_system::Call::kill_prefix { .. },
+				) | RuntimeCall::ParachainSystem(..) |
+				RuntimeCall::Timestamp(..) |
+				RuntimeCall::Balances(..) |
+				RuntimeCall::CollatorSelection(
+					pallet_collator_selection::Call::set_desired_candidates { .. } |
+						pallet_collator_selection::Call::set_candidacy_bond { .. } |
+						pallet_collator_selection::Call::register_as_candidate { .. } |
+						pallet_collator_selection::Call::leave_intent { .. } |
+						pallet_collator_selection::Call::set_invulnerables { .. } |
+						pallet_collator_selection::Call::add_invulnerable { .. } |
+						pallet_collator_selection::Call::remove_invulnerable { .. },
+				) | RuntimeCall::Session(pallet_session::Call::purge_keys { .. }) |
+				RuntimeCall::XcmpQueue(..) |
+				RuntimeCall::DmpQueue(..) |
+				RuntimeCall::Assets(
+					pallet_assets::Call::create { .. } |
+						pallet_assets::Call::force_create { .. } |
+						pallet_assets::Call::start_destroy { .. } |
+						pallet_assets::Call::destroy_accounts { .. } |
+						pallet_assets::Call::destroy_approvals { .. } |
+						pallet_assets::Call::finish_destroy { .. } |
+						pallet_assets::Call::block { .. } |
+						pallet_assets::Call::mint { .. } |
+						pallet_assets::Call::burn { .. } |
+						pallet_assets::Call::transfer { .. } |
+						pallet_assets::Call::transfer_keep_alive { .. } |
+						pallet_assets::Call::force_transfer { .. } |
+						pallet_assets::Call::freeze { .. } |
+						pallet_assets::Call::thaw { .. } |
+						pallet_assets::Call::freeze_asset { .. } |
+						pallet_assets::Call::thaw_asset { .. } |
+						pallet_assets::Call::transfer_ownership { .. } |
+						pallet_assets::Call::set_team { .. } |
+						pallet_assets::Call::set_metadata { .. } |
+						pallet_assets::Call::clear_metadata { .. } |
+						pallet_assets::Call::force_set_metadata { .. } |
+						pallet_assets::Call::force_clear_metadata { .. } |
+						pallet_assets::Call::force_asset_status { .. } |
+						pallet_assets::Call::approve_transfer { .. } |
+						pallet_assets::Call::cancel_approval { .. } |
+						pallet_assets::Call::force_cancel_approval { .. } |
+						pallet_assets::Call::transfer_approved { .. } |
+						pallet_assets::Call::touch { .. } |
+						pallet_assets::Call::touch_other { .. } |
+						pallet_assets::Call::refund { .. } |
+						pallet_assets::Call::refund_other { .. },
 				) | RuntimeCall::ForeignAssets(
-				pallet_assets::Call::create { .. }
-					| pallet_assets::Call::force_create { .. }
-					| pallet_assets::Call::start_destroy { .. }
-					| pallet_assets::Call::destroy_accounts { .. }
-					| pallet_assets::Call::destroy_approvals { .. }
-					| pallet_assets::Call::finish_destroy { .. }
-					| pallet_assets::Call::block { .. }
-					| pallet_assets::Call::mint { .. }
-					| pallet_assets::Call::burn { .. }
-					| pallet_assets::Call::transfer { .. }
-					| pallet_assets::Call::transfer_keep_alive { .. }
-					| pallet_assets::Call::force_transfer { .. }
-					| pallet_assets::Call::freeze { .. }
-					| pallet_assets::Call::thaw { .. }
-					| pallet_assets::Call::freeze_asset { .. }
-					| pallet_assets::Call::thaw_asset { .. }
-					| pallet_assets::Call::transfer_ownership { .. }
-					| pallet_assets::Call::set_team { .. }
-					| pallet_assets::Call::set_metadata { .. }
-					| pallet_assets::Call::clear_metadata { .. }
-					| pallet_assets::Call::force_set_metadata { .. }
-					| pallet_assets::Call::force_clear_metadata { .. }
-					| pallet_assets::Call::force_asset_status { .. }
-					| pallet_assets::Call::approve_transfer { .. }
-					| pallet_assets::Call::cancel_approval { .. }
-					| pallet_assets::Call::force_cancel_approval { .. }
-					| pallet_assets::Call::transfer_approved { .. }
-					| pallet_assets::Call::touch { .. }
-					| pallet_assets::Call::touch_other { .. }
-					| pallet_assets::Call::refund { .. }
-					| pallet_assets::Call::refund_other { .. },
+				pallet_assets::Call::create { .. } |
+					pallet_assets::Call::force_create { .. } |
+					pallet_assets::Call::start_destroy { .. } |
+					pallet_assets::Call::destroy_accounts { .. } |
+					pallet_assets::Call::destroy_approvals { .. } |
+					pallet_assets::Call::finish_destroy { .. } |
+					pallet_assets::Call::block { .. } |
+					pallet_assets::Call::mint { .. } |
+					pallet_assets::Call::burn { .. } |
+					pallet_assets::Call::transfer { .. } |
+					pallet_assets::Call::transfer_keep_alive { .. } |
+					pallet_assets::Call::force_transfer { .. } |
+					pallet_assets::Call::freeze { .. } |
+					pallet_assets::Call::thaw { .. } |
+					pallet_assets::Call::freeze_asset { .. } |
+					pallet_assets::Call::thaw_asset { .. } |
+					pallet_assets::Call::transfer_ownership { .. } |
+					pallet_assets::Call::set_team { .. } |
+					pallet_assets::Call::set_metadata { .. } |
+					pallet_assets::Call::clear_metadata { .. } |
+					pallet_assets::Call::force_set_metadata { .. } |
+					pallet_assets::Call::force_clear_metadata { .. } |
+					pallet_assets::Call::force_asset_status { .. } |
+					pallet_assets::Call::approve_transfer { .. } |
+					pallet_assets::Call::cancel_approval { .. } |
+					pallet_assets::Call::force_cancel_approval { .. } |
+					pallet_assets::Call::transfer_approved { .. } |
+					pallet_assets::Call::touch { .. } |
+					pallet_assets::Call::touch_other { .. } |
+					pallet_assets::Call::refund { .. } |
+					pallet_assets::Call::refund_other { .. },
 			) | RuntimeCall::PoolAssets(
-				pallet_assets::Call::force_create { .. }
-					| pallet_assets::Call::block { .. }
-					| pallet_assets::Call::burn { .. }
-					| pallet_assets::Call::transfer { .. }
-					| pallet_assets::Call::transfer_keep_alive { .. }
-					| pallet_assets::Call::force_transfer { .. }
-					| pallet_assets::Call::freeze { .. }
-					| pallet_assets::Call::thaw { .. }
-					| pallet_assets::Call::freeze_asset { .. }
-					| pallet_assets::Call::thaw_asset { .. }
-					| pallet_assets::Call::transfer_ownership { .. }
-					| pallet_assets::Call::set_team { .. }
-					| pallet_assets::Call::set_metadata { .. }
-					| pallet_assets::Call::clear_metadata { .. }
-					| pallet_assets::Call::force_set_metadata { .. }
-					| pallet_assets::Call::force_clear_metadata { .. }
-					| pallet_assets::Call::force_asset_status { .. }
-					| pallet_assets::Call::approve_transfer { .. }
-					| pallet_assets::Call::cancel_approval { .. }
-					| pallet_assets::Call::force_cancel_approval { .. }
-					| pallet_assets::Call::transfer_approved { .. }
-					| pallet_assets::Call::touch { .. }
-					| pallet_assets::Call::touch_other { .. }
-					| pallet_assets::Call::refund { .. }
-					| pallet_assets::Call::refund_other { .. },
+				pallet_assets::Call::force_create { .. } |
+					pallet_assets::Call::block { .. } |
+					pallet_assets::Call::burn { .. } |
+					pallet_assets::Call::transfer { .. } |
+					pallet_assets::Call::transfer_keep_alive { .. } |
+					pallet_assets::Call::force_transfer { .. } |
+					pallet_assets::Call::freeze { .. } |
+					pallet_assets::Call::thaw { .. } |
+					pallet_assets::Call::freeze_asset { .. } |
+					pallet_assets::Call::thaw_asset { .. } |
+					pallet_assets::Call::transfer_ownership { .. } |
+					pallet_assets::Call::set_team { .. } |
+					pallet_assets::Call::set_metadata { .. } |
+					pallet_assets::Call::clear_metadata { .. } |
+					pallet_assets::Call::force_set_metadata { .. } |
+					pallet_assets::Call::force_clear_metadata { .. } |
+					pallet_assets::Call::force_asset_status { .. } |
+					pallet_assets::Call::approve_transfer { .. } |
+					pallet_assets::Call::cancel_approval { .. } |
+					pallet_assets::Call::force_cancel_approval { .. } |
+					pallet_assets::Call::transfer_approved { .. } |
+					pallet_assets::Call::touch { .. } |
+					pallet_assets::Call::touch_other { .. } |
+					pallet_assets::Call::refund { .. } |
+					pallet_assets::Call::refund_other { .. },
 			) | RuntimeCall::AssetConversion(
-				pallet_asset_conversion::Call::create_pool { .. }
-					| pallet_asset_conversion::Call::add_liquidity { .. }
-					| pallet_asset_conversion::Call::remove_liquidity { .. }
-					| pallet_asset_conversion::Call::swap_tokens_for_exact_tokens { .. }
-					| pallet_asset_conversion::Call::swap_exact_tokens_for_tokens { .. },
+				pallet_asset_conversion::Call::create_pool { .. } |
+					pallet_asset_conversion::Call::add_liquidity { .. } |
+					pallet_asset_conversion::Call::remove_liquidity { .. } |
+					pallet_asset_conversion::Call::swap_tokens_for_exact_tokens { .. } |
+					pallet_asset_conversion::Call::swap_exact_tokens_for_tokens { .. },
 			) | RuntimeCall::NftFractionalization(
-				pallet_nft_fractionalization::Call::fractionalize { .. }
-					| pallet_nft_fractionalization::Call::unify { .. },
+				pallet_nft_fractionalization::Call::fractionalize { .. } |
+					pallet_nft_fractionalization::Call::unify { .. },
 			) | RuntimeCall::Nfts(
-				pallet_nfts::Call::create { .. }
-					| pallet_nfts::Call::force_create { .. }
-					| pallet_nfts::Call::destroy { .. }
-					| pallet_nfts::Call::mint { .. }
-					| pallet_nfts::Call::force_mint { .. }
-					| pallet_nfts::Call::burn { .. }
-					| pallet_nfts::Call::transfer { .. }
-					| pallet_nfts::Call::lock_item_transfer { .. }
-					| pallet_nfts::Call::unlock_item_transfer { .. }
-					| pallet_nfts::Call::lock_collection { .. }
-					| pallet_nfts::Call::transfer_ownership { .. }
-					| pallet_nfts::Call::set_team { .. }
-					| pallet_nfts::Call::force_collection_owner { .. }
-					| pallet_nfts::Call::force_collection_config { .. }
-					| pallet_nfts::Call::approve_transfer { .. }
-					| pallet_nfts::Call::cancel_approval { .. }
-					| pallet_nfts::Call::clear_all_transfer_approvals { .. }
-					| pallet_nfts::Call::lock_item_properties { .. }
-					| pallet_nfts::Call::set_attribute { .. }
-					| pallet_nfts::Call::force_set_attribute { .. }
-					| pallet_nfts::Call::clear_attribute { .. }
-					| pallet_nfts::Call::approve_item_attributes { .. }
-					| pallet_nfts::Call::cancel_item_attributes_approval { .. }
-					| pallet_nfts::Call::set_metadata { .. }
-					| pallet_nfts::Call::clear_metadata { .. }
-					| pallet_nfts::Call::set_collection_metadata { .. }
-					| pallet_nfts::Call::clear_collection_metadata { .. }
-					| pallet_nfts::Call::set_accept_ownership { .. }
-					| pallet_nfts::Call::set_collection_max_supply { .. }
-					| pallet_nfts::Call::update_mint_settings { .. }
-					| pallet_nfts::Call::set_price { .. }
-					| pallet_nfts::Call::buy_item { .. }
-					| pallet_nfts::Call::pay_tips { .. }
-					| pallet_nfts::Call::create_swap { .. }
-					| pallet_nfts::Call::cancel_swap { .. }
-					| pallet_nfts::Call::claim_swap { .. },
+				pallet_nfts::Call::create { .. } |
+					pallet_nfts::Call::force_create { .. } |
+					pallet_nfts::Call::destroy { .. } |
+					pallet_nfts::Call::mint { .. } |
+					pallet_nfts::Call::force_mint { .. } |
+					pallet_nfts::Call::burn { .. } |
+					pallet_nfts::Call::transfer { .. } |
+					pallet_nfts::Call::lock_item_transfer { .. } |
+					pallet_nfts::Call::unlock_item_transfer { .. } |
+					pallet_nfts::Call::lock_collection { .. } |
+					pallet_nfts::Call::transfer_ownership { .. } |
+					pallet_nfts::Call::set_team { .. } |
+					pallet_nfts::Call::force_collection_owner { .. } |
+					pallet_nfts::Call::force_collection_config { .. } |
+					pallet_nfts::Call::approve_transfer { .. } |
+					pallet_nfts::Call::cancel_approval { .. } |
+					pallet_nfts::Call::clear_all_transfer_approvals { .. } |
+					pallet_nfts::Call::lock_item_properties { .. } |
+					pallet_nfts::Call::set_attribute { .. } |
+					pallet_nfts::Call::force_set_attribute { .. } |
+					pallet_nfts::Call::clear_attribute { .. } |
+					pallet_nfts::Call::approve_item_attributes { .. } |
+					pallet_nfts::Call::cancel_item_attributes_approval { .. } |
+					pallet_nfts::Call::set_metadata { .. } |
+					pallet_nfts::Call::clear_metadata { .. } |
+					pallet_nfts::Call::set_collection_metadata { .. } |
+					pallet_nfts::Call::clear_collection_metadata { .. } |
+					pallet_nfts::Call::set_accept_ownership { .. } |
+					pallet_nfts::Call::set_collection_max_supply { .. } |
+					pallet_nfts::Call::update_mint_settings { .. } |
+					pallet_nfts::Call::set_price { .. } |
+					pallet_nfts::Call::buy_item { .. } |
+					pallet_nfts::Call::pay_tips { .. } |
+					pallet_nfts::Call::create_swap { .. } |
+					pallet_nfts::Call::cancel_swap { .. } |
+					pallet_nfts::Call::claim_swap { .. },
 			) | RuntimeCall::Uniques(
-				pallet_uniques::Call::create { .. }
-					| pallet_uniques::Call::force_create { .. }
-					| pallet_uniques::Call::destroy { .. }
-					| pallet_uniques::Call::mint { .. }
-					| pallet_uniques::Call::burn { .. }
-					| pallet_uniques::Call::transfer { .. }
-					| pallet_uniques::Call::freeze { .. }
-					| pallet_uniques::Call::thaw { .. }
-					| pallet_uniques::Call::freeze_collection { .. }
-					| pallet_uniques::Call::thaw_collection { .. }
-					| pallet_uniques::Call::transfer_ownership { .. }
-					| pallet_uniques::Call::set_team { .. }
-					| pallet_uniques::Call::approve_transfer { .. }
-					| pallet_uniques::Call::cancel_approval { .. }
-					| pallet_uniques::Call::force_item_status { .. }
-					| pallet_uniques::Call::set_attribute { .. }
-					| pallet_uniques::Call::clear_attribute { .. }
-					| pallet_uniques::Call::set_metadata { .. }
-					| pallet_uniques::Call::clear_metadata { .. }
-					| pallet_uniques::Call::set_collection_metadata { .. }
-					| pallet_uniques::Call::clear_collection_metadata { .. }
-					| pallet_uniques::Call::set_accept_ownership { .. }
-					| pallet_uniques::Call::set_collection_max_supply { .. }
-					| pallet_uniques::Call::set_price { .. }
-					| pallet_uniques::Call::buy_item { .. }
+				pallet_uniques::Call::create { .. } |
+					pallet_uniques::Call::force_create { .. } |
+					pallet_uniques::Call::destroy { .. } |
+					pallet_uniques::Call::mint { .. } |
+					pallet_uniques::Call::burn { .. } |
+					pallet_uniques::Call::transfer { .. } |
+					pallet_uniques::Call::freeze { .. } |
+					pallet_uniques::Call::thaw { .. } |
+					pallet_uniques::Call::freeze_collection { .. } |
+					pallet_uniques::Call::thaw_collection { .. } |
+					pallet_uniques::Call::transfer_ownership { .. } |
+					pallet_uniques::Call::set_team { .. } |
+					pallet_uniques::Call::approve_transfer { .. } |
+					pallet_uniques::Call::cancel_approval { .. } |
+					pallet_uniques::Call::force_item_status { .. } |
+					pallet_uniques::Call::set_attribute { .. } |
+					pallet_uniques::Call::clear_attribute { .. } |
+					pallet_uniques::Call::set_metadata { .. } |
+					pallet_uniques::Call::clear_metadata { .. } |
+					pallet_uniques::Call::set_collection_metadata { .. } |
+					pallet_uniques::Call::clear_collection_metadata { .. } |
+					pallet_uniques::Call::set_accept_ownership { .. } |
+					pallet_uniques::Call::set_collection_max_supply { .. } |
+					pallet_uniques::Call::set_price { .. } |
+					pallet_uniques::Call::buy_item { .. }
 			)
 		)
 	}


### PR DESCRIPTION
This PR is a follow up of https://github.com/paritytech/polkadot/pull/7165, which was approved and merged, but then reverted due the usage of the `xcm-builder` crate to define the XCM configs, which are not generic and universal enough to fit within the scope of that crate. As a solution, this PR defines the configs directly in the two runtimes, which should solve the `xcm-builder` issue.

For a proper overview of the PR and it's goals, here is the description of the original PR:

> This PR introduces the XCM configs required for Saturn multisigs from Tinkernet to transact on Kusama/Rococo, this is done simply by providing implementations to convert the MultiLocation to both an AccountId and a Signed RuntimeOrigin.
> 
> For more information regarding why this approach of using a very specific derivation function and defining this function in the receiver chain's runtime is necessary for Saturn, and also general information about Saturn, you can check the discussion that was opened in the forum prior: https://forum.polkadot.network/t/saturn-xcm-multisig-integration-on-kusama-a-technical-discussion/2694
> 
> For a more high level overview of Saturn, check this article: https://invarch.medium.com/saturn-the-future-of-multi-party-ownership-ac7190f86a7b

Please feel free to discuss this in here or in the fellowship chat and thanks in advance for your time!