### PR TITLE
Added GitHub action to auto-merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,8 +11,12 @@ jobs:
     # Important! This forces the job to run only on comments on Pull Requests that starts with '/merge'
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
     steps:
+      - name: Get the GitHub handle of the fellows
+        uses: paritytech/get-fellows-action@v1.0.0
+        id: fellows
       - name: Set auto merge
         uses: paritytech/auto-merge-bot@v1.0.0
         with:
           GITHUB_TOKEN: '${{ github.token }}'
           MERGE_METHOD: "SQUASH"
+          ALLOWLIST: ${{ steps.fellows.outputs.github-handles }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,18 @@
+name: Auto Merge Bot
+
+on:
+  # GitHub considers PRs as issues
+  issue_comment:
+    types: [created]
+
+jobs:
+  set-auto-merge:
+    runs-on: ubuntu-latest
+    # Important! This forces the job to run only on comments on Pull Requests that starts with '/merge'
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
+    steps:
+      - name: Set auto merge
+        uses: paritytech/auto-merge-bot@v1.0.0
+        with:
+          GITHUB_TOKEN: '${{ github.token }}'
+          MERGE_METHOD: "SQUASH"

--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ Each leaf folder contains one runtime crate:
     └── gluttons
         └── glutton-kusama
 ```
+
+# Working on Pull Requests
+
+To merge a pull request, we use [Auto Merge Bot](https://github.com/paritytech/auto-merge-bot).
+
+To use it, write a comment in a PR that says:
+
+> `/merge`
+
+This will enable [`auto-merge`](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) in the Pull Request (or merge it if it is ready to merge).
+
+The automation can be triggered by the author of the PR or any fellow whose GitHub handle is part of their identity.


### PR DESCRIPTION
Added two GitHub actions to enable auto-merge in the repository.

This resolves #41

## [Auto-Merge-Bot](https://github.com/paritytech/auto-merge-bot)

This bot allows _public_ members of the organization and the author of the PR to enable/disable auto-merge in a PR. It also has a field for a list of users who are also allowed to trigger the bot. For that we have the second action.

## [Get Fellows Action](https://github.com/paritytech/get-fellows-action)

This action gets the fellows from the chain data and it extracts their GitHub handles. This handles are then input into the `auto-merge-bot` action as a list of users who are allowed to trigger the bot.

---

I have also updated the Pull Request template to mention the existence of this bot to new contributors.