### PR TITLE
Improve release process

### DIFF
--- a/.github/changelog-processor.py
+++ b/.github/changelog-processor.py
@@ -12,13 +12,15 @@ parser.add_argument(
     default="CHANGELOG.md",
     nargs='?'
 )
-parser.add_argument(
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument(
     "--print-latest-version",
     dest="print_latest_version",
     help="Print the latest version (first in the file) found in the CHANGELOG.md",
     action="store_true"
 )
-parser.add_argument(
+group.add_argument(
     "--should-release",
     dest="should_release",
     help="Should a release be made? Prints `1` or `0`.",

--- a/.github/changelog-processor.py
+++ b/.github/changelog-processor.py
@@ -33,7 +33,7 @@ with open(args.changelog, "r") as changelog:
         if not line.startswith("## ["):
             continue
 
-        version = line.strip().removeprefix("## [").removesuffix("]")
+        version = line.strip().removeprefix("## [").split("]")[0]
         break
 
     if args.print_latest_version:
@@ -43,6 +43,9 @@ with open(args.changelog, "r") as changelog:
         if version.lower() == "unreleased":
             print("0", end = "")
             sys.exit(1)
+        elif version.count(".") != 2:
+            print("0", end = "")
+            sys.exit(-1)
 
         stream = os.popen("git tag -l v" + version)
         output = stream.read()

--- a/.github/changelog-processor.py
+++ b/.github/changelog-processor.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import argparse
+
+parser = argparse.ArgumentParser(description="Process the CHANGELOG.md")
+parser.add_argument(
+    "changelog",
+    metavar="CHANGELOG",
+    help="Path to the CHANGELOG.md file"
+)
+parser.add_argument(
+    "--print-latest-version",
+    dest="print_latest_version",
+    help="Print the latest version (first in the file) found in the CHANGELOG.md",
+    action="store_true"
+)
+parser.add_argument(
+    "--should-release",
+    dest="should_release",
+    help="Should a release be made? Prints `1` or `0`.",
+    action="store_true"
+)
+
+args = parser.parse_args()
+
+with open(args.changelog, "r") as changelog:
+    lines = changelog.readlines()
+
+    # Find the latest version
+    for line in lines:
+        if not line.startswith("## ["):
+            continue
+
+        version = line.strip().removeprefix("## [").removesuffix("]")
+        break
+
+    if args.print_latest_version:
+        print(version, end = "")
+        sys.exit(1)
+    elif args.should_release:
+        if version.lower() == "unreleased":
+            print("0", end = "")
+            sys.exit(1)
+
+        stream = os.popen("git tag -l v" + version)
+        output = stream.read()
+
+        # Empty output means that the tag doesn't exist and that we should release.
+        if output.strip() == "":
+            print("1", end = "")
+        else:
+            print("0", end = "")
+
+        sys.exit(1)
+    else:
+        parser.print_help()

--- a/.github/changelog-processor.py
+++ b/.github/changelog-processor.py
@@ -8,7 +8,9 @@ parser = argparse.ArgumentParser(description="Process the CHANGELOG.md")
 parser.add_argument(
     "changelog",
     metavar="CHANGELOG",
-    help="Path to the CHANGELOG.md file"
+    help="Path to the CHANGELOG.md file",
+    default="CHANGELOG.md",
+    nargs='?'
 )
 parser.add_argument(
     "--print-latest-version",

--- a/.github/changelog-processor.py
+++ b/.github/changelog-processor.py
@@ -40,11 +40,11 @@ with open(args.changelog, "r") as changelog:
 
     if args.print_latest_version:
         print(version, end = "")
-        sys.exit(1)
+        sys.exit(0)
     elif args.should_release:
         if version.lower() == "unreleased":
             print("0", end = "")
-            sys.exit(1)
+            sys.exit(-1)
         elif version.count(".") != 2:
             print("0", end = "")
             sys.exit(-1)
@@ -58,6 +58,6 @@ with open(args.changelog, "r") as changelog:
         else:
             print("0", end = "")
 
-        sys.exit(1)
+        sys.exit(0)
     else:
         parser.print_help()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           cat $GITHUB_OUTPUT
   runtime-matrix:
     needs: [ collect-release-information ]
-    if: ${{ needs.collect-release-information.outputs.should-release == 1 }}
+    if: needs.collect-release-information.outputs.should-release == '1'
     runs-on: ubuntu-latest
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           cat $GITHUB_OUTPUT
   runtime-matrix:
     needs: [ collect-release-information ]
-    if: ${{ needs.collect-release-information.should-release == 1 }}
+    if: ${{ needs.collect-release-information.outputs.should-release == 1 }}
     runs-on: ubuntu-latest
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}
@@ -136,7 +136,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ format('v{0}', needs.collect-release-information.version) }}
+          tag_name: ${{ format('v{0}', needs.collect-release-information.outputs.version) }}
           release_name: Runtimes ${{ github.sha }}
           body_path: DRAFT
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           cat $GITHUB_OUTPUT
   runtime-matrix:
     needs: [ collect-release-information ]
-    if: ${{ needs.collect-release-information.should-release == '1' }}
+    if: ${{ needs.collect-release-information.should-release == 1 }}
     runs-on: ubuntu-latest
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,7 @@ name: Create Draft Release
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    paths: [ "CHANGELOG.md" ]
   workflow_dispatch:
 
 jobs:
@@ -81,7 +80,7 @@ jobs:
           path: |
             ${{ steps.srtool_build.outputs.wasm_compressed }}
 
-  publish-draft-release:
+  publish-release:
     runs-on: ubuntu-latest
     needs: [ build-runtimes, collect-release-information ]
     outputs:
@@ -107,7 +106,6 @@ jobs:
           SRTOOL() { <$(<<<$CONTEXT head -n1) jq -r .$1; }
           WASM() { <${JSON} jq -r ".runtimes.compressed.subwasm.$1"; }
           tee -a DRAFT <<-EOF
-          ## Changelog
           EOF
           tee -a DRAFT <CHANGELOG.md
           tee -a DRAFT <<-EOF
@@ -130,19 +128,19 @@ jobs:
           EOF
           done
 
-      - name: Create draft release
+      - name: Create release
         id: create-release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ format('v{0}', needs.collect-release-information.outputs.version) }}
-          release_name: Runtimes ${{ github.sha }}
+          release_name: Runtimes ${{ needs.collect-release-information.outputs.version }}
           body_path: DRAFT
-          draft: true
+          draft: false
 
   publish-runtimes:
-    needs: [ runtime-matrix, publish-draft-release ]
+    needs: [ runtime-matrix, publish-release ]
     continue-on-error: true
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,26 @@ name: Create Draft Release
 on:
   push:
     branches: [ "main" ]
-    paths: [ "CHANGELOG.md" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
+  collect-release-information:
+    runs-on: ubuntu-latest
+    outputs:
+      should-release: ${{ steps.run.outputs.should-release }}
+      version: ${{ steps.run.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: runtime
+        run: |
+          echo "should-release=$(.github/changelog-processor.py CHANGELOG.md --should-release)" >> $GITHUB_OUTPUT
+          echo "version=$(.github/changelog-processor.py CHANGELOG.md --print-latest-version)" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
   runtime-matrix:
+    needs: [ collect-release-information ]
+    if: ${{ collect-release-information.should-release == "1" }}
     runs-on: ubuntu-latest
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}
@@ -68,7 +83,7 @@ jobs:
 
   publish-draft-release:
     runs-on: ubuntu-latest
-    needs: [ build-runtimes ]
+    needs: [ build-runtimes, collect-release-information ]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
@@ -121,7 +136,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
+          tag_name: ${{ format('v{0}', collect-release-information.version) }}
           release_name: Runtimes ${{ github.sha }}
           body_path: DRAFT
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           cat $GITHUB_OUTPUT
   runtime-matrix:
     needs: [ collect-release-information ]
-    if: ${{ needs.collect-release-information.should-release == "1" }}
+    if: ${{ needs.collect-release-information.should-release == '1' }}
     runs-on: ubuntu-latest
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       version: ${{ steps.run.outputs.version }}
     steps:
       - uses: actions/checkout@v2
-      - id: runtime
+      - id: run
         run: |
           echo "should-release=$(.github/changelog-processor.py CHANGELOG.md --should-release)" >> $GITHUB_OUTPUT
           echo "version=$(.github/changelog-processor.py CHANGELOG.md --print-latest-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           cat $GITHUB_OUTPUT
   runtime-matrix:
     needs: [ collect-release-information ]
-    if: ${{ collect-release-information.should-release == "1" }}
+    if: ${{ needs.collect-release-information.should-release == "1" }}
     runs-on: ubuntu-latest
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}
@@ -136,7 +136,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ format('v{0}', collect-release-information.version) }}
+          tag_name: ${{ format('v{0}', needs.collect-release-information.version) }}
           release_name: Runtimes ${{ github.sha }}
           body_path: DRAFT
           draft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 Changelog for the runtimes governed by the Polkadot Fellowship.
 
-## [1.0.0]
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ To use it, write a comment in a PR that says:
 This will enable [`auto-merge`](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) in the Pull Request (or merge it if it is ready to merge).
 
 The automation can be triggered by the author of the PR or any fellow whose GitHub handle is part of their identity.
+
+# Release process
+
+Releases are automatically pushed on commits merged to master that fulfill the following requirements:
+
+- The [`CHANGELOG.md`](CHANGELOG.md) file was modified.
+- The latest version (the version at the top of the file) in [`CHANGELOG.md`](CHANGELOG.md) has no tag in the repository.
+
+The release process is building all runtimes and then puts them into a release in this github repository.
+
+The format of [`CHANGELOG.md`](CHANGELOG.md) is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).


### PR DESCRIPTION
This pull request introduces the `changelog-processor.py`. A small script for getting some information out of the `CHANGELOG.md` file for improving the release process. The script supports to get the latest version in the `CHANGELOG.md` file, aka the version top of the file. (This could also be `Unreleased`) The other command is for printing if there should be done a release or not. This is decided based on the latest version and if there exists a tag for it.

Closes: https://github.com/polkadot-fellows/runtimes/issues/40