### PR TITLE
upgraded review bot to v2.1.0

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -1,23 +1,24 @@
-name: Review PR
+name: Review Bot
+
 on:
-  pull_request_target:
+  workflow_run:
+    workflows:
+      - Review-Trigger
     types:
-      - opened
-      - reopened
-      - synchronize
-      - review_requested
-      - review_request_removed
-      - ready_for_review
-  pull_request_review:
+      - completed
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   review-approvals:
     runs-on: ubuntu-latest
     steps:
+      - name: Extract content of artifact
+        id: number
+        uses: Bullrich/extract-text-from-artifact@v1.0.0
+        with:
+          artifact-name: pr_number
       - name: Generate token
         id: team_token
         uses: tibdex/github-app-token@v1
@@ -25,8 +26,9 @@ jobs:
           app_id: ${{ secrets.REVIEW_APP_ID }}
           private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v2.0.0
+        uses: paritytech/review-bot@v2.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           team-token: ${{ steps.team_token.outputs.token }}
           checks-token: ${{ steps.team_token.outputs.token }}
+          pr-number: ${{ steps.number.outputs.content }}

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -1,0 +1,31 @@
+name: Review-Trigger
+
+on: 
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - review_requested
+      - review_request_removed
+      - ready_for_review
+  pull_request_review:
+
+jobs:
+  trigger-review-bot:
+    runs-on: ubuntu-latest
+    name: trigger review bot
+    steps:
+      - name: Get PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Saving PR number: $PR_NUMBER"
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        name: Save PR number
+        with:
+          name: pr_number
+          path: pr/
+          retention-days: 5


### PR DESCRIPTION
Upgraded to version 2.1.0 which has paritytech/review-bot#94, a change in the logic of the action to overcome some problems with permissions coming from PRs from forks

For this, we needed to divide the actions into two files:
- A first action that triggers on PRs and reviews and uploads the PR number.
- A second action which is triggered under the completion of the first one and runs as the action normally runs (but won't have any problems regarding permissions because it is triggered from the master branch)
