### PR TITLE
Restore governance lock periods to 7 days in Polkadot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.0.1] 22.10.2023
+
+### Changed
+
+- Restore governance lock periods to 7 days in Polkadot ([polkadot-fellows/runtimes#86](https://github.com/polkadot-fellows/runtimes/pull/86))
+
 ## [1.0.0] 22.10.2023
 
 ### Changed

--- a/relay/polkadot/src/governance/mod.rs
+++ b/relay/polkadot/src/governance/mod.rs
@@ -32,7 +32,7 @@ mod tracks;
 pub use tracks::TracksInfo;
 
 parameter_types! {
-	pub const VoteLockingPeriod: BlockNumber = prod_or_fast!(28 * DAYS, 1);
+	pub const VoteLockingPeriod: BlockNumber = 7 * DAYS;
 }
 
 impl pallet_conviction_voting::Config for Runtime {

--- a/relay/polkadot/src/governance/mod.rs
+++ b/relay/polkadot/src/governance/mod.rs
@@ -32,7 +32,7 @@ mod tracks;
 pub use tracks::TracksInfo;
 
 parameter_types! {
-	pub const VoteLockingPeriod: BlockNumber = 7 * DAYS;
+	pub const VoteLockingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1);
 }
 
 impl pallet_conviction_voting::Config for Runtime {


### PR DESCRIPTION
This is a revert of https://github.com/paritytech/polkadot/commit/d73503cc2351ffec047a4912ecdb3e1eab5f46aa which has not been released.

Deploying without this change would lead to referendum participants and delegates having their tokens locked for 4 times longer than expected.

Participants in any referendums ending after the runtime upgrade is applied would be affected.
Even more of an issue is delegates, where all current delegates would be affected by 4 times longer lock up issues. The affected user-base is enormous, and there is little to no possibility of reaching all these users to get them to adapt in time.

Although a 7 Day lock multiplier wasn't the originally intended target for Polkadot, breaking user expectations with this change is an even larger issue.