### PR TITLE
Use the github app for auto-merging

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,9 +14,15 @@ jobs:
       - name: Get the GitHub handle of the fellows
         uses: paritytech/get-fellows-action@v1.0.0
         id: fellows
+      - name: Generate token
+        id: merge_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REVIEW_APP_ID }}
+          private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: Set auto merge
         uses: paritytech/auto-merge-bot@v1.0.0
         with:
-          GITHUB_TOKEN: '${{ github.token }}'
+          GITHUB_TOKEN: ${{ steps.merge_token.outputs.token }}
           MERGE_METHOD: "SQUASH"
           ALLOWLIST: ${{ steps.fellows.outputs.github-handles }}


### PR DESCRIPTION
Without that, the commits merged in the result of the built-in `github-actions` bot enabling the auto-merge, the CI jobs do not run on the commit on `main`.