### PR TITLE
Enable async backing on Kusama

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,8 +19,8 @@ jobs:
         id: merge_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.REVIEW_APP_ID }}
-          private_key: ${{ secrets.REVIEW_APP_KEY }}
+          app_id: ${{ secrets.MERGE_APP_ID }}
+          private_key: ${{ secrets.MERGE_APP_KEY }}
       - name: Set auto merge
         uses: paritytech/auto-merge-bot@v1.0.0
         with:

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1910,7 +1910,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
-		#[api_version(7)]
+	#[api_version(7)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1910,6 +1910,7 @@ sp_api::impl_runtime_apis! {
 		}
 	}
 
+		#[api_version(7)]
 	impl primitives::runtime_api::ParachainHost<Block, Hash, BlockNumber> for Runtime {
 		fn validators() -> Vec<ValidatorId> {
 			parachains_runtime_api_impl::validators::<Runtime>()
@@ -2039,6 +2040,18 @@ sp_api::impl_runtime_apis! {
 				dispute_proof,
 				key_ownership_proof,
 			)
+		}
+
+			fn minimum_backing_votes() -> u32 {
+			parachains_runtime_api_impl::minimum_backing_votes::<Runtime>()
+		}
+
+		fn para_backing_state(para_id: ParaId) -> Option<primitives::async_backing::BackingState> {
+			parachains_runtime_api_impl::backing_state::<Runtime>(para_id)
+		}
+
+		fn async_backing_params() -> primitives::AsyncBackingParams {
+			parachains_runtime_api_impl::async_backing_params::<Runtime>()
 		}
 	}
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -2042,7 +2042,7 @@ sp_api::impl_runtime_apis! {
 			)
 		}
 
-			fn minimum_backing_votes() -> u32 {
+		fn minimum_backing_votes() -> u32 {
 			parachains_runtime_api_impl::minimum_backing_votes::<Runtime>()
 		}
 


### PR DESCRIPTION
This enables async backing in the Kusama runtime. Note that for candidates to actually be backed asynchronously, a subsequent governance proposal changing two new parameters is needed.