### PR TITLE
Enable `runtime-benchmarks` feature for chain spec generator

### DIFF
--- a/chain-spec-generator/Cargo.toml
+++ b/chain-spec-generator/Cargo.toml
@@ -27,3 +27,9 @@ sc-consensus-grandpa = "0.14.0"
 pallet-im-online = "22.0.0"
 sp-runtime = "26.0.0"
 sp-consensus-beefy = "8.0.0"
+
+[features]
+runtime-benchmarks = [
+	"kusama-runtime/runtime-benchmarks",
+	"polkadot-runtime/runtime-benchmarks",
+]


### PR DESCRIPTION
Based on: https://github.com/polkadot-fellows/runtimes/pull/78

Without this fix we cannot run benchmarks for kusama/polkadot.

Tested here: https://github.com/polkadot-fellows/runtimes/pull/58#issuecomment-1814123768

