### PR TITLE
use github app for auto-merge-bot

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,6 +5,8 @@ on:
   issue_comment:
     types: [created]
 
+env: master
+
 jobs:
   set-auto-merge:
     runs-on: ubuntu-latest
@@ -14,9 +16,15 @@ jobs:
       - name: Get the GitHub handle of the fellows
         uses: paritytech/get-fellows-action@v1.0.0
         id: fellows
+      - name: Generate token
+        id: merge_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REVIEW_APP_ID }}
+          private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: Set auto merge
         uses: paritytech/auto-merge-bot@v1.0.0
         with:
-          GITHUB_TOKEN: '${{ github.token }}'
+          GITHUB_TOKEN: ${{ steps.merge_token.outputs.token }}
           MERGE_METHOD: "SQUASH"
           ALLOWLIST: ${{ steps.fellows.outputs.github-handles }}


### PR DESCRIPTION
This changes the credentials for auto-merge-bot

With this it stops using a GitHub action but instead it uses a GitHub app, by using a GitHub app, PRs merged by it will trigger GitHub actions.

This is to circumvent a security measure set up by GitHub to stop recursive action executions.

This supersedes #88 
