### PR TITLE
fixed auto-merge-bot

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,11 +5,10 @@ on:
   issue_comment:
     types: [created]
 
-env: master
-
 jobs:
   set-auto-merge:
     runs-on: ubuntu-latest
+    environment: master
     # Important! This forces the job to run only on comments on Pull Requests that starts with '/merge'
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
     steps:


### PR DESCRIPTION
I confused `env` which is used for environment variables for `environment` which is the key word to fetch environment secrets when doing #94.

This will fix that mistake.
