### PR TITLE
auto-merge: replaced review bot for merge bot

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,8 +19,8 @@ jobs:
         id: merge_token
         uses: tibdex/github-app-token@v1
         with:
-          app_id: ${{ secrets.REVIEW_APP_ID }}
-          private_key: ${{ secrets.REVIEW_APP_KEY }}
+          app_id: ${{ secrets.MERGE_APP_ID }}
+          private_key: ${{ secrets.MERGE_APP_KEY }}
       - name: Set auto merge
         uses: paritytech/auto-merge-bot@v1.0.0
         with:


### PR DESCRIPTION
When adapted the code from #88 I forgot to update the location of the credentials, so it was using review-bot which can only enable auto-merge but can not merge a ready to merge PR. Follow up to #97 
