### PR TITLE
Fellowship entities get free xcm execution 

### DIFF
--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
@@ -414,8 +414,12 @@ match_types! {
 /// Locations that will not be charged fees in the executor,
 /// either execution or delivery.
 /// We only waive fees for system functions, which these locations represent.
-pub type WaivedLocations =
-	(RelayOrOtherSystemParachains<SystemParachains, Runtime>, Equals<RelayTreasuryLocation>);
+pub type WaivedLocations = (
+	RelayOrOtherSystemParachains<SystemParachains, Runtime>,
+	Equals<RelayTreasuryLocation>,
+	FellowsPlurality,
+	FellowshipSalaryPallet,
+);
 
 /// Cases where a remote origin is accepted as trusted Teleporter for a given asset:
 ///

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/xcm_config.rs
@@ -210,8 +210,11 @@ match_types! {
 /// Locations that will not be charged fees in the executor,
 /// either execution or delivery.
 /// We only waive fees for system functions, which these locations represent.
-pub type WaivedLocations =
-	(RelayOrOtherSystemParachains<SystemParachains, Runtime>, Equals<RelayTreasuryLocation>);
+pub type WaivedLocations = (
+	RelayOrOtherSystemParachains<SystemParachains, Runtime>,
+	Equals<RelayTreasuryLocation>,
+	FellowsPlurality,
+);
 
 /// Cases where a remote origin is accepted as trusted Teleporter for a given asset:
 /// - DOT with the parent Relay Chain and sibling parachains.


### PR DESCRIPTION
Fellowship entities get free xcm execution.

Same as the Fellowship entities allowed to pass `UnpaidExecution` command to bypass the fees charged by `Trader` impl, we include the Fellowship locations to `WaivedLocations` to not be charged by `FeeManager` impl.