### PR TITLE
added up-to-date-action

### DIFF
--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -1,0 +1,22 @@
+name: Keep PR up to date
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  updatePullRequests:
+    runs-on: ubuntu-latest
+    environment: master
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.MERGE_APP_ID }}
+          private_key: ${{ secrets.MERGE_APP_KEY }}
+      - name: Update all the PRs
+        uses: paritytech/up-to-date-action@v0.1.0
+        with:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Added action to keep pull requests up to date. Every time master receives a push, it will look for all the PRs and sync them with the master branch.

This only works when the PR has `auto-merge` enabled (it can be enabled for all PRs too if required).

Merging this PR will count as solving paritytech/auto-merge-bot#21 and paritytech/up-to-date-action#1

We use a github app to solve the issue that tests would not run if the credentials comes from a github action.

I'm resuing the credentials for the [`fellowship-merge-bot`](https://github.com/apps/fellowship-merge-bot) used in [`auto-merge`](https://github.com/polkadot-fellows/runtimes/blob/main/.github/workflows/auto-merge.yml).

It needs to have the following permissions:
- Repository permissions:
  - Pull Requests
    - [x] Write
  - Contents
    - [x] Write
