### PR TITLE
up-to-date: fixed wrong branch name

### DIFF
--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -3,7 +3,7 @@ name: Keep PR up to date
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   updatePullRequests:


### PR DESCRIPTION
I put master when it was main.
