### PR TITLE
[ci] Remove shared key for cache and add cache for migrations

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+        with:
+          cache-on-failure: true
 
       - name: Build ${{ matrix.runtime.name }}
         run: |

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
         with:
-          cache-on-failure: true
+          shared-key: "fellowship-cache-migrations"
 
       - name: Build ${{ matrix.runtime.name }}
         run: |

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 # drop permissions for default token
-permissions: read-all
+permissions: {}
 
 jobs:
   runtime-matrix:
@@ -54,7 +54,7 @@ jobs:
           chmod +x ./try-runtime
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
         with:
           version: "3.6.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 # drop permissions for default token
-permissions: {}
+permissions: read-all
 
 jobs:
   runtime-matrix:
@@ -54,8 +54,7 @@ jobs:
           chmod +x ./try-runtime
 
       - name: Install Protoc
-        # uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
-        uses: arduino/setup-protoc@v2.1.0
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           version: "3.6.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Add wasm32-unknown-unknown target
         run: rustup target add wasm32-unknown-unknown
 
+      - name: Fetch cache
+        uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+        with:
+          shared-key: "fellowship-cache"
+
       - name: Build ${{ matrix.runtime.name }}
         run: |
           cargo build --profile production -p ${{ matrix.runtime.package }} --features try-runtime -q --locked

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# drop permissions for default token
+permissions: {}
+
 jobs:
   runtime-matrix:
     runs-on: ubuntu-latest
@@ -51,9 +54,10 @@ jobs:
           chmod +x ./try-runtime
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
         with:
           version: "3.6.1"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add wasm32-unknown-unknown target
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -60,8 +60,6 @@ jobs:
 
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
-        with:
-          shared-key: "fellowship-cache"
 
       - name: Build ${{ matrix.runtime.name }}
         run: |

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -54,7 +54,7 @@ jobs:
           chmod +x ./try-runtime
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
+        uses: arduino/setup-protoc@v1
         with:
           version: "3.6.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -54,7 +54,8 @@ jobs:
           chmod +x ./try-runtime
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
+        # uses: arduino/setup-protoc@a8b67ba40b37d35169e222f3bb352603327985b6 # v2.1.0
+        uses: arduino/setup-protoc@v2.1.0
         with:
           version: "3.6.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
-        with:
-          shared-key: "fellowship-cache"
 
       - name: Clippy
         run: cargo +nightly clippy --all-targets --locked -q

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+        with:
+          cache-on-failure: true
 
       - name: Clippy
         run: cargo +nightly clippy --all-targets --locked -q

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,10 +2,15 @@ name: "Clippy"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
+
+# cancel previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   clippy:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
         with:
-          cache-on-failure: true
+          shared-key: "fellowship-cache-clippy"
 
       - name: Clippy
         run: cargo +nightly clippy --all-targets --locked -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,6 @@ jobs:
 
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
-        with:
-          shared-key: "fellowship-cache"
 
       - name: Test
         run: cargo test --workspace --release --locked -q --features=runtime-metrics,try-runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
         with:
-          cache-on-failure: true
+          shared-key: "fellowship-cache-tests"
 
       - name: Test
         run: cargo test --workspace --release --locked -q --features=runtime-metrics,try-runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,18 @@ name: "Test all features"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
+
+env:
+  ACTIONS_RUNNER_DEBUG: true
+
+# cancel previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
+        with:
+          cache-on-failure: true
 
       - name: Test
         run: cargo test --workspace --release --locked -q --features=runtime-metrics,try-runtime

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
-env:
-  ACTIONS_RUNNER_DEBUG: true
-
 # cancel previous runs
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
PR removes shared key for rust-cache action. When 2 different workflows use the same shared-key they try to use the same destination for cache which makes it unusable for them (they have race condition who will be the first to write there). Also PR adds cache for migration jobs and cancelling jobs on previous runs.

cc https://github.com/polkadot-fellows/runtimes/issues/134