### PR TITLE
added action to verify the changelog is updated

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,6 @@
 <!-- Remember that you can run `/merge` to enable auto-merge in the PR -->
+
+<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
+Instead, if you have already modified it, simply delete the following line. -->
+
+- [ ] Does not require a CHANGELOG entry

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,20 @@
+name: Modify Changelog
+
+on:
+  pull_request_target:
+
+jobs:
+
+  verifyChangelogIsUpdated:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Get Changed Files
+        id: changed
+        uses: foodee/pr-includes-file-change@master
+        with:
+          paths: ^CHANGELOG.md
+      - name: Set error
+        if: steps.changed.outputs.matched != 'true' && !contains(github.event.pull_request.body, '[x] Does not require a CHANGELOG entry')
+        run: echo "::error::CHANGELOG.md has not been modified. Either modify the file or check the checkbox in the body" && exit 1


### PR DESCRIPTION
Added a GitHub action that uses [foodee/pr-includes-file-change](https://github.com/marketplace/actions/pr-includes-file-change) to fetch all the changes and verify that the file `CHANGELOG.md` has been modified.

If it has not been modified and the PR body does not include the text `[x] Does not require a CHANGELOG entry`, the action will fail.

This resolves polkadot-fellows/runtimes#143

The template was updated to include a reminder on how to modify the changelog and instructions on how to skip the CI if the PR does not require to modify the changelog