### PR TITLE
set events for changelog action to work on edit

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
 
-  verifyChangelogIsUpdated:
+  verifyChangelog:
+    name: Verify that Changelog is Updated
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,6 +2,9 @@ name: Modify Changelog
 
 on:
   pull_request_target:
+    types:
+      - synchronize
+      - edited
 
 jobs:
 


### PR DESCRIPTION
Enabled events `synchronize` and `edited` for the [changelog action](https://github.com/polkadot-fellows/runtimes/blob/main/.github/workflows/changelog.yml).

`synchronize` works when the branch is modified (commit is pushed).

`edited` works when the description of the PR is modified.

`edited` is not enabled by default, so we had to add it.

- [x] Does not require a CHANGELOG entry
