### PR TITLE
Review Bot version 2.4.0 - Fellow Scores

### DIFF
--- a/.github/review-bot.yml
+++ b/.github/review-bot.yml
@@ -14,7 +14,8 @@ rules:
         - ^CHANGELOG.md$
     type: fellows
     minRank: 2
-    minApprovals: 3
+    minApprovals: 2
+    minTotalScore: 6
   - name: General Files
     condition:
       include:
@@ -26,3 +27,13 @@ rules:
         - ^CHANGELOG.md$
     type: fellows
     minRank: 1
+scores:
+  dan1: 1
+  dan2: 2
+  dan3: 5
+  dan4: 9
+  dan5: 10
+  dan6: 15
+  dan7: 20
+  dan8: 25
+  dan9: 30

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -26,7 +26,7 @@ jobs:
           app_id: ${{ secrets.REVIEW_APP_ID }}
           private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v2.3.1
+        uses: paritytech/review-bot@v2.4.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           team-token: ${{ steps.team_token.outputs.token }}


### PR DESCRIPTION
Updated Review Bot to version 2.4.0 which contains paritytech/review-bot#110 (solved in paritytech/review-bot#113)

This resolves #93 

Updated review bot to latest version which brings new changes to the fellow object:

Added new optional field to the config named `scores` that has the score of each fellow per dan (added up to dan IX).

When the rule of type `fellows` has the optional field of `minTotalScore` it will check that the score of the fellows who approved the PR sums up to that number. If it doesn't sum to that number it will fail with a custom error listing the score of each fellow for reference (and saying how many points are missing).

Find a complete explanation of the new configuration here: [Fellows Rule](https://github.com/paritytech/review-bot/blob/v2.4.0/README.md#fellows-rule)

- [x] Does not require a CHANGELOG entry

I also added some scores to all the dans (feel free to modify them) and updated the `Relay and system files` rule to have a minimum score of 6.