### PR TITLE
Reapply changes since `v1.1.0-rc2` import

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -66,14 +66,15 @@ use frame_election_provider_support::{
 	bounds::ElectionBoundsBuilder, generate_solution_type, onchain, NposSolution,
 	SequentialPhragmen,
 };
+use frame_support::traits::Contains;
 use frame_support::{
 	construct_runtime,
 	genesis_builder_helper::{build_config, create_default_config},
 	parameter_types,
 	traits::{
-		fungible::HoldConsideration, ConstU32, Contains, EitherOf, EitherOfDiverse, InstanceFilter,
-		KeyOwnerProofSystem, LinearStoragePrice, PrivilegeCmp, ProcessMessage, ProcessMessageError,
-		StorageMapShim, WithdrawReasons,
+		fungible::HoldConsideration, ConstU32, EitherOf, EitherOfDiverse, EverythingBut,
+		InstanceFilter, KeyOwnerProofSystem, LinearStoragePrice, PrivilegeCmp, ProcessMessage,
+		ProcessMessageError, StorageMapShim, WithdrawReasons,
 	},
 	weights::{ConstantMultiplier, WeightMeter},
 	PalletId,
@@ -171,11 +172,14 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
-/// We currently allow all calls.
-pub struct BaseFilter;
-impl Contains<RuntimeCall> for BaseFilter {
-	fn contains(_c: &RuntimeCall) -> bool {
-		true
+/// A type to identify calls to the Identity pallet. These will be filtered to prevent invocation,
+/// locking the state of the pallet and preventing further updates to identities and sub-identities.
+/// The locked state will be the genesis state of a new system chain and then removed from the Relay
+/// Chain.
+pub struct IdentityCalls;
+impl Contains<RuntimeCall> for IdentityCalls {
+	fn contains(c: &RuntimeCall) -> bool {
+		matches!(c, RuntimeCall::Identity(_))
 	}
 }
 
@@ -185,7 +189,7 @@ parameter_types! {
 }
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::Everything;
+	type BaseCallFilter = EverythingBut<IdentityCalls>;
 	type BlockWeights = BlockWeights;
 	type BlockLength = BlockLength;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use frame_support::{
 	match_types, parameter_types,
-	traits::{Contains, Equals, Everything, Nothing},
+	traits::{Equals, Everything, Nothing},
 	weights::Weight,
 };
 use frame_system::EnsureRoot;
@@ -173,158 +173,6 @@ pub type Barrier = TrailingSetTopicAsId<(
 	>,
 )>;
 
-/// A call filter for the XCM Transact instruction. This is a temporary measure until we properly
-/// account for proof size weights.
-///
-/// Calls that are allowed through this filter must:
-/// 1. Have a fixed weight;
-/// 2. Cannot lead to another call being made;
-/// 3. Have a defined proof size weight, e.g. no unbounded vecs in call parameters.
-pub struct SafeCallFilter;
-impl Contains<RuntimeCall> for SafeCallFilter {
-	fn contains(call: &RuntimeCall) -> bool {
-		#[cfg(feature = "runtime-benchmarks")]
-		{
-			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
-				return true
-			}
-		}
-
-		match call {
-			RuntimeCall::System(
-				frame_system::Call::kill_prefix { .. } | frame_system::Call::set_heap_pages { .. },
-			) |
-			RuntimeCall::Babe(..) |
-			RuntimeCall::Timestamp(..) |
-			RuntimeCall::Indices(..) |
-			RuntimeCall::Balances(..) |
-			RuntimeCall::Crowdloan(
-				crowdloan::Call::create { .. } |
-				crowdloan::Call::contribute { .. } |
-				crowdloan::Call::withdraw { .. } |
-				crowdloan::Call::refund { .. } |
-				crowdloan::Call::dissolve { .. } |
-				crowdloan::Call::edit { .. } |
-				crowdloan::Call::poke { .. } |
-				crowdloan::Call::contribute_all { .. },
-			) |
-			RuntimeCall::Staking(
-				pallet_staking::Call::bond { .. } |
-				pallet_staking::Call::bond_extra { .. } |
-				pallet_staking::Call::unbond { .. } |
-				pallet_staking::Call::withdraw_unbonded { .. } |
-				pallet_staking::Call::validate { .. } |
-				pallet_staking::Call::nominate { .. } |
-				pallet_staking::Call::chill { .. } |
-				pallet_staking::Call::set_payee { .. } |
-				pallet_staking::Call::set_controller { .. } |
-				pallet_staking::Call::set_validator_count { .. } |
-				pallet_staking::Call::increase_validator_count { .. } |
-				pallet_staking::Call::scale_validator_count { .. } |
-				pallet_staking::Call::force_no_eras { .. } |
-				pallet_staking::Call::force_new_era { .. } |
-				pallet_staking::Call::set_invulnerables { .. } |
-				pallet_staking::Call::force_unstake { .. } |
-				pallet_staking::Call::force_new_era_always { .. } |
-				pallet_staking::Call::payout_stakers { .. } |
-				pallet_staking::Call::rebond { .. } |
-				pallet_staking::Call::reap_stash { .. } |
-				pallet_staking::Call::set_staking_configs { .. } |
-				pallet_staking::Call::chill_other { .. } |
-				pallet_staking::Call::force_apply_min_commission { .. },
-			) |
-			RuntimeCall::Session(pallet_session::Call::purge_keys { .. }) |
-			RuntimeCall::Grandpa(..) |
-			RuntimeCall::ImOnline(..) |
-			RuntimeCall::Treasury(..) |
-			RuntimeCall::ConvictionVoting(..) |
-			RuntimeCall::Referenda(
-				pallet_referenda::Call::place_decision_deposit { .. } |
-				pallet_referenda::Call::refund_decision_deposit { .. } |
-				pallet_referenda::Call::cancel { .. } |
-				pallet_referenda::Call::kill { .. } |
-				pallet_referenda::Call::nudge_referendum { .. } |
-				pallet_referenda::Call::one_fewer_deciding { .. },
-			) |
-			RuntimeCall::FellowshipCollective(..) |
-			RuntimeCall::FellowshipReferenda(
-				pallet_referenda::Call::place_decision_deposit { .. } |
-				pallet_referenda::Call::refund_decision_deposit { .. } |
-				pallet_referenda::Call::cancel { .. } |
-				pallet_referenda::Call::kill { .. } |
-				pallet_referenda::Call::nudge_referendum { .. } |
-				pallet_referenda::Call::one_fewer_deciding { .. },
-			) |
-			RuntimeCall::Claims(
-				super::claims::Call::claim { .. } |
-				super::claims::Call::mint_claim { .. } |
-				super::claims::Call::move_claim { .. },
-			) |
-			RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. }) |
-			RuntimeCall::Identity(
-				pallet_identity::Call::add_registrar { .. } |
-				pallet_identity::Call::set_identity { .. } |
-				pallet_identity::Call::clear_identity { .. } |
-				pallet_identity::Call::request_judgement { .. } |
-				pallet_identity::Call::cancel_request { .. } |
-				pallet_identity::Call::set_fee { .. } |
-				pallet_identity::Call::set_account_id { .. } |
-				pallet_identity::Call::set_fields { .. } |
-				pallet_identity::Call::provide_judgement { .. } |
-				pallet_identity::Call::kill_identity { .. } |
-				pallet_identity::Call::add_sub { .. } |
-				pallet_identity::Call::rename_sub { .. } |
-				pallet_identity::Call::remove_sub { .. } |
-				pallet_identity::Call::quit_sub { .. },
-			) |
-			RuntimeCall::Society(..) |
-			RuntimeCall::Recovery(..) |
-			RuntimeCall::Vesting(..) |
-			RuntimeCall::Bounties(
-				pallet_bounties::Call::propose_bounty { .. } |
-				pallet_bounties::Call::approve_bounty { .. } |
-				pallet_bounties::Call::propose_curator { .. } |
-				pallet_bounties::Call::unassign_curator { .. } |
-				pallet_bounties::Call::accept_curator { .. } |
-				pallet_bounties::Call::award_bounty { .. } |
-				pallet_bounties::Call::claim_bounty { .. } |
-				pallet_bounties::Call::close_bounty { .. },
-			) |
-			RuntimeCall::ChildBounties(..) |
-			RuntimeCall::ElectionProviderMultiPhase(..) |
-			RuntimeCall::VoterList(..) |
-			RuntimeCall::NominationPools(
-				pallet_nomination_pools::Call::join { .. } |
-				pallet_nomination_pools::Call::bond_extra { .. } |
-				pallet_nomination_pools::Call::claim_payout { .. } |
-				pallet_nomination_pools::Call::unbond { .. } |
-				pallet_nomination_pools::Call::pool_withdraw_unbonded { .. } |
-				pallet_nomination_pools::Call::withdraw_unbonded { .. } |
-				pallet_nomination_pools::Call::create { .. } |
-				pallet_nomination_pools::Call::create_with_pool_id { .. } |
-				pallet_nomination_pools::Call::set_state { .. } |
-				pallet_nomination_pools::Call::set_configs { .. } |
-				pallet_nomination_pools::Call::update_roles { .. } |
-				pallet_nomination_pools::Call::chill { .. },
-			) |
-			RuntimeCall::Hrmp(..) |
-			RuntimeCall::Registrar(
-				paras_registrar::Call::deregister { .. } |
-				paras_registrar::Call::swap { .. } |
-				paras_registrar::Call::remove_lock { .. } |
-				paras_registrar::Call::reserve { .. } |
-				paras_registrar::Call::add_lock { .. },
-			) |
-			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
-				..
-			}) |
-			RuntimeCall::Whitelist(pallet_whitelist::Call::whitelist_call { .. }) |
-			RuntimeCall::Proxy(..) => true,
-			_ => false,
-		}
-	}
-}
-
 /// Locations that will not be charged fees in the executor, neither for execution nor delivery.
 /// We only waive fees for system functions, which these locations represent.
 pub type WaivedLocations = (SystemParachains, Equals<RootLocation>, LocalPlurality);
@@ -359,8 +207,8 @@ impl xcm_executor::Config for XcmConfig {
 	// No bridges yet...
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
-	type CallDispatcher = WithOriginFilter<SafeCallFilter>;
-	type SafeCallFilter = SafeCallFilter;
+	type CallDispatcher = RuntimeCall;
+	type SafeCallFilter = Everything;
 	type Aliasers = Nothing;
 }
 

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -57,13 +57,14 @@ use frame_support::{
 	genesis_builder_helper::{build_config, create_default_config},
 	parameter_types,
 	traits::{
-		fungible::HoldConsideration, ConstU32, EitherOf, EitherOfDiverse, Get, InstanceFilter,
-		KeyOwnerProofSystem, LinearStoragePrice, PrivilegeCmp, ProcessMessage, ProcessMessageError,
-		WithdrawReasons,
+		fungible::HoldConsideration, ConstU32, EitherOf, EitherOfDiverse, EverythingBut, Get,
+		InstanceFilter, KeyOwnerProofSystem, LinearStoragePrice, PrivilegeCmp, ProcessMessage,
+		ProcessMessageError, WithdrawReasons,
 	},
 	weights::{ConstantMultiplier, WeightMeter},
 	PalletId,
 };
+use frame_support::traits::Contains;
 use frame_system::EnsureRoot;
 use pallet_grandpa::{fg_primitives, AuthorityId as GrandpaId};
 use pallet_identity::simple::IdentityInfo;
@@ -164,13 +165,24 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
+/// A type to identify calls to the Identity pallet. These will be filtered to prevent invocation,
+/// locking the state of the pallet and preventing further updates to identities and sub-identities.
+/// The locked state will be the genesis state of a new system chain and then removed from the Relay
+/// Chain.
+pub struct IdentityCalls;
+impl Contains<RuntimeCall> for IdentityCalls {
+	fn contains(c: &RuntimeCall) -> bool {
+		matches!(c, RuntimeCall::Identity(_))
+	}
+}
+
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const SS58Prefix: u8 = 0;
 }
 
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::Everything;
+	type BaseCallFilter = EverythingBut<IdentityCalls>;
 	type BlockWeights = BlockWeights;
 	type BlockLength = BlockLength;
 	type RuntimeOrigin = RuntimeOrigin;

--- a/relay/polkadot/src/xcm_config.rs
+++ b/relay/polkadot/src/xcm_config.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use frame_support::{
 	match_types, parameter_types,
-	traits::{Contains, Equals, Everything, Nothing},
+	traits::{Equals, Everything, Nothing},
 	weights::Weight,
 };
 use frame_system::EnsureRoot;
@@ -34,7 +34,6 @@ use polkadot_runtime_constants::{
 	xcm::body::{FELLOWSHIP_ADMIN_INDEX, TREASURER_INDEX},
 };
 use runtime_common::{
-	crowdloan, paras_registrar,
 	xcm_sender::{ChildParachainRouter, ExponentialPrice},
 	ToAuthor,
 };
@@ -49,7 +48,6 @@ use xcm_builder::{
 	TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 	XcmFeesToAccount,
 };
-use xcm_executor::traits::WithOriginFilter;
 
 parameter_types! {
 	pub const RootLocation: MultiLocation = Here.into_location();
@@ -187,147 +185,6 @@ pub type Barrier = TrailingSetTopicAsId<(
 	>,
 )>;
 
-/// A call filter for the XCM Transact instruction. This is a temporary measure until we
-/// properly account for proof size weights.
-///
-/// Calls that are allowed through this filter must:
-/// 1. Have a fixed weight;
-/// 2. Cannot lead to another call being made;
-/// 3. Have a defined proof size weight, e.g. no unbounded vecs in call parameters.
-pub struct SafeCallFilter;
-impl Contains<RuntimeCall> for SafeCallFilter {
-	fn contains(call: &RuntimeCall) -> bool {
-		#[cfg(feature = "runtime-benchmarks")]
-		{
-			if matches!(call, RuntimeCall::System(frame_system::Call::remark_with_event { .. })) {
-				return true
-			}
-		}
-
-		match call {
-			RuntimeCall::System(
-				frame_system::Call::kill_prefix { .. } | frame_system::Call::set_heap_pages { .. },
-			) |
-			RuntimeCall::Babe(..) |
-			RuntimeCall::Timestamp(..) |
-			RuntimeCall::Indices(..) |
-			RuntimeCall::Balances(..) |
-			RuntimeCall::Crowdloan(
-				crowdloan::Call::create { .. } |
-				crowdloan::Call::contribute { .. } |
-				crowdloan::Call::withdraw { .. } |
-				crowdloan::Call::refund { .. } |
-				crowdloan::Call::dissolve { .. } |
-				crowdloan::Call::edit { .. } |
-				crowdloan::Call::poke { .. } |
-				crowdloan::Call::contribute_all { .. },
-			) |
-			RuntimeCall::Staking(
-				pallet_staking::Call::bond { .. } |
-				pallet_staking::Call::bond_extra { .. } |
-				pallet_staking::Call::unbond { .. } |
-				pallet_staking::Call::withdraw_unbonded { .. } |
-				pallet_staking::Call::validate { .. } |
-				pallet_staking::Call::nominate { .. } |
-				pallet_staking::Call::chill { .. } |
-				pallet_staking::Call::set_payee { .. } |
-				pallet_staking::Call::set_controller { .. } |
-				pallet_staking::Call::set_validator_count { .. } |
-				pallet_staking::Call::increase_validator_count { .. } |
-				pallet_staking::Call::scale_validator_count { .. } |
-				pallet_staking::Call::force_no_eras { .. } |
-				pallet_staking::Call::force_new_era { .. } |
-				pallet_staking::Call::set_invulnerables { .. } |
-				pallet_staking::Call::force_unstake { .. } |
-				pallet_staking::Call::force_new_era_always { .. } |
-				pallet_staking::Call::payout_stakers { .. } |
-				pallet_staking::Call::rebond { .. } |
-				pallet_staking::Call::reap_stash { .. } |
-				pallet_staking::Call::set_staking_configs { .. } |
-				pallet_staking::Call::chill_other { .. } |
-				pallet_staking::Call::force_apply_min_commission { .. },
-			) |
-			RuntimeCall::Session(pallet_session::Call::purge_keys { .. }) |
-			RuntimeCall::Grandpa(..) |
-			RuntimeCall::ImOnline(..) |
-			RuntimeCall::Treasury(..) |
-			RuntimeCall::ConvictionVoting(..) |
-			RuntimeCall::Referenda(
-				pallet_referenda::Call::place_decision_deposit { .. } |
-				pallet_referenda::Call::refund_decision_deposit { .. } |
-				pallet_referenda::Call::cancel { .. } |
-				pallet_referenda::Call::kill { .. } |
-				pallet_referenda::Call::nudge_referendum { .. } |
-				pallet_referenda::Call::one_fewer_deciding { .. },
-			) |
-			RuntimeCall::Claims(
-				super::claims::Call::claim { .. } |
-				super::claims::Call::mint_claim { .. } |
-				super::claims::Call::move_claim { .. },
-			) |
-			RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. }) |
-			RuntimeCall::Identity(
-				pallet_identity::Call::add_registrar { .. } |
-				pallet_identity::Call::set_identity { .. } |
-				pallet_identity::Call::clear_identity { .. } |
-				pallet_identity::Call::request_judgement { .. } |
-				pallet_identity::Call::cancel_request { .. } |
-				pallet_identity::Call::set_fee { .. } |
-				pallet_identity::Call::set_account_id { .. } |
-				pallet_identity::Call::set_fields { .. } |
-				pallet_identity::Call::provide_judgement { .. } |
-				pallet_identity::Call::kill_identity { .. } |
-				pallet_identity::Call::add_sub { .. } |
-				pallet_identity::Call::rename_sub { .. } |
-				pallet_identity::Call::remove_sub { .. } |
-				pallet_identity::Call::quit_sub { .. },
-			) |
-			RuntimeCall::Vesting(..) |
-			RuntimeCall::Bounties(
-				pallet_bounties::Call::propose_bounty { .. } |
-				pallet_bounties::Call::approve_bounty { .. } |
-				pallet_bounties::Call::propose_curator { .. } |
-				pallet_bounties::Call::unassign_curator { .. } |
-				pallet_bounties::Call::accept_curator { .. } |
-				pallet_bounties::Call::award_bounty { .. } |
-				pallet_bounties::Call::claim_bounty { .. } |
-				pallet_bounties::Call::close_bounty { .. },
-			) |
-			RuntimeCall::ChildBounties(..) |
-			RuntimeCall::ElectionProviderMultiPhase(..) |
-			RuntimeCall::VoterList(..) |
-			RuntimeCall::NominationPools(
-				pallet_nomination_pools::Call::join { .. } |
-				pallet_nomination_pools::Call::bond_extra { .. } |
-				pallet_nomination_pools::Call::claim_payout { .. } |
-				pallet_nomination_pools::Call::unbond { .. } |
-				pallet_nomination_pools::Call::pool_withdraw_unbonded { .. } |
-				pallet_nomination_pools::Call::withdraw_unbonded { .. } |
-				pallet_nomination_pools::Call::create { .. } |
-				pallet_nomination_pools::Call::create_with_pool_id { .. } |
-				pallet_nomination_pools::Call::set_state { .. } |
-				pallet_nomination_pools::Call::set_configs { .. } |
-				pallet_nomination_pools::Call::update_roles { .. } |
-				pallet_nomination_pools::Call::chill { .. },
-			) |
-			RuntimeCall::Hrmp(..) |
-			RuntimeCall::Registrar(
-				paras_registrar::Call::deregister { .. } |
-				paras_registrar::Call::swap { .. } |
-				paras_registrar::Call::remove_lock { .. } |
-				paras_registrar::Call::reserve { .. } |
-				paras_registrar::Call::add_lock { .. },
-			) |
-			RuntimeCall::XcmPallet(pallet_xcm::Call::limited_reserve_transfer_assets {
-				..
-			}) |
-			RuntimeCall::Whitelist(pallet_whitelist::Call::whitelist_call { .. }) |
-			RuntimeCall::Proxy(..) => true,
-			_ => false,
-		}
-	}
-}
-
 /// Locations that will not be charged fees in the executor, neither for execution nor delivery.
 /// We only waive fees for system functions, which these locations represent.
 pub type WaivedLocations = (SystemParachains, Equals<RootLocation>, LocalPlurality);
@@ -363,8 +220,8 @@ impl xcm_executor::Config for XcmConfig {
 	// No bridges yet...
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
-	type CallDispatcher = WithOriginFilter<SafeCallFilter>;
-	type SafeCallFilter = SafeCallFilter;
+	type CallDispatcher = RuntimeCall;
+	type SafeCallFilter = Everything;
 	type Aliasers = Nothing;
 }
 


### PR DESCRIPTION
We imported the runtimes into this repo at tag [`v1.1.0-rc2`](https://github.com/paritytech/polkadot-sdk/commits/v1.1.0-rc2/) but still merged stuff until they got remoted in [#1731](https://github.com/paritytech/polkadot-sdk/pull/1731).  
This re-applies all changes in that commit range [`v1.1.0-rc2..bf90cb0b`](https://github.com/paritytech/polkadot-sdk/compare/v1.1.0-rc2...bf90cb0b73a2d2e0b3e79b2956256831ae79c9f7) checked in the SDK with  
`git log v1.1.0-rc2^..bf90cb0b -- polkadot/runtime/`.

Most changes got applied as part of https://github.com/polkadot-fellows/runtimes/pull/56, but two were missing:
- https://github.com/paritytech/polkadot-sdk/pull/1303
- https://github.com/paritytech/polkadot-sdk/pull/1476

One [open Q](https://github.com/polkadot-fellows/runtimes/pull/67#discussion_r1471033155) since there was a difference between [#1291](https://github.com/paritytech/polkadot-sdk/pull/1291) and #67.