### PR TITLE
upgraded keep-pr-up-to-date action to 0.2.0

### DIFF
--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   updatePullRequests:
+    name: Keep PRs up to date
     runs-on: ubuntu-latest
     environment: master
     steps:
@@ -17,6 +18,6 @@ jobs:
           app_id: ${{ secrets.MERGE_APP_ID }}
           private_key: ${{ secrets.MERGE_APP_KEY }}
       - name: Update all the PRs
-        uses: paritytech/up-to-date-action@v0.1.0
+        uses: paritytech/up-to-date-action@v0.2.0
         with:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Upgraded the action [paritytech/up-to-date-action](https://github.com/paritytech/up-to-date-action) to version `0.2.0`.

This version brings paritytech/up-to-date-action#9. A feature that, when the action fails with a PR, it comments in it so the user can try to fix the problem instead of silently failing.

- [x] Does not require a CHANGELOG entry
