### PR TITLE
Pin clippy to 2024-01-31

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -36,6 +36,6 @@ jobs:
           shared-key: "fellowship-cache-clippy"
 
       - name: Clippy
-        run: cargo +nightly clippy --all-targets --locked -q
+        run: cargo +nightly-2024-01-31 clippy --all-targets --locked -q
         env:
           SKIP_WASM_BUILD: 1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2024-01-31
           components: clippy
 
       - name: Checkout


### PR DESCRIPTION
Relates to: https://github.com/polkadot-fellows/runtimes/issues/179

According to the [comment](https://github.com/polkadot-fellows/runtimes/issues/179#issuecomment-1938643068) we pin nightly version to the `2024-01-31`.

Also there will be the follow up PR with unpining the version and when we see that auto-rebase feature rebased that branch and clippy is ok, then we just merge it.


<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [X] Does not require a CHANGELOG entry
