### PR TITLE
Add a Root Signaller Track

### DIFF
--- a/relay/kusama/src/governance/origins.rs
+++ b/relay/kusama/src/governance/origins.rs
@@ -86,6 +86,8 @@ pub mod pallet_custom_origins {
 		Fellowship8Dan,
 		/// Origin commanded by rank 9 of the Polkadot Fellowship and with a success of 9.
 		Fellowship9Dan,
+		/// Origin for signaling wishes of the network.
+		RootSignaller,
 	}
 
 	macro_rules! decl_unit_ensures {
@@ -128,6 +130,7 @@ pub mod pallet_custom_origins {
 		ReferendumCanceller,
 		ReferendumKiller,
 		WhitelistedCaller,
+		RootSignaller,
 		FellowshipInitiates: u16 = 0,
 		Fellows: u16 = 3,
 		FellowshipExperts: u16 = 5,

--- a/relay/kusama/src/governance/tracks.rs
+++ b/relay/kusama/src/governance/tracks.rs
@@ -65,7 +65,7 @@ const APP_WHITELISTED_CALLER: Curve =
 const SUP_WHITELISTED_CALLER: Curve =
 	Curve::make_reciprocal(1, 28, percent(20), percent(5), percent(50));
 
-const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15] = [
+const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 16] = [
 	(
 		0,
 		pallet_referenda::TrackInfo {
@@ -92,6 +92,20 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 			min_enactment_period: 10 * MINUTES,
 			min_approval: APP_WHITELISTED_CALLER,
 			min_support: SUP_WHITELISTED_CALLER,
+		},
+	),
+	(
+		2,
+		pallet_referenda::TrackInfo {
+			name: "root_signaller",
+			max_deciding: 10,
+			decision_deposit: 20 * GRAND,
+			prepare_period: 2 * HOURS,
+			decision_period: 28 * DAYS,
+			confirm_period: 24 * HOURS,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: APP_ROOT,
+			min_support: SUP_ROOT,
 		},
 	),
 	(
@@ -294,6 +308,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 		} else if let Ok(custom_origin) = origins::Origin::try_from(id.clone()) {
 			match custom_origin {
 				origins::Origin::WhitelistedCaller => Ok(1),
+				origins::Origin::RootSignaller => Ok(2),
 				// General admin
 				origins::Origin::StakingAdmin => Ok(10),
 				origins::Origin::Treasurer => Ok(11),

--- a/relay/polkadot/src/governance/origins.rs
+++ b/relay/polkadot/src/governance/origins.rs
@@ -61,6 +61,8 @@ pub mod pallet_custom_origins {
 		BigSpender,
 		/// Origin able to dispatch a whitelisted call.
 		WhitelistedCaller,
+		/// Origin for signaling wishes of the network.
+		RootSignaller,
 	}
 
 	macro_rules! decl_unit_ensures {
@@ -103,6 +105,7 @@ pub mod pallet_custom_origins {
 		ReferendumCanceller,
 		ReferendumKiller,
 		WhitelistedCaller,
+		RootSignaller,
 	);
 
 	macro_rules! decl_ensure {

--- a/relay/polkadot/src/governance/tracks.rs
+++ b/relay/polkadot/src/governance/tracks.rs
@@ -65,7 +65,7 @@ const APP_WHITELISTED_CALLER: Curve =
 const SUP_WHITELISTED_CALLER: Curve =
 	Curve::make_reciprocal(1, 28, percent(20), percent(5), percent(50));
 
-const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15] = [
+const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 16] = [
 	(
 		0,
 		pallet_referenda::TrackInfo {
@@ -92,6 +92,20 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 15
 			min_enactment_period: 10 * MINUTES,
 			min_approval: APP_WHITELISTED_CALLER,
 			min_support: SUP_WHITELISTED_CALLER,
+		},
+	),
+	(
+		2,
+		pallet_referenda::TrackInfo {
+			name: "root_signaller",
+			max_deciding: 10,
+			decision_deposit: 20 * GRAND,
+			prepare_period: 2 * HOURS,
+			decision_period: 28 * DAYS,
+			confirm_period: 24 * HOURS,
+			min_enactment_period: 10 * MINUTES,
+			min_approval: APP_ROOT,
+			min_support: SUP_ROOT,
 		},
 	),
 	(
@@ -294,6 +308,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 		} else if let Ok(custom_origin) = origins::Origin::try_from(id.clone()) {
 			match custom_origin {
 				origins::Origin::WhitelistedCaller => Ok(1),
+				origins::Origin::RootSignaller => Ok(2),
 				// General admin
 				origins::Origin::StakingAdmin => Ok(10),
 				origins::Origin::Treasurer => Ok(11),


### PR DESCRIPTION
Posting this PR for discussion, but perhaps people have other solutions in mind.

The Root track was designed to handle only one referendum at a time, because calls requiring Root are usually sensitive and should be evaluated one at a time. However, we have also used the Root track to make remarks to signal desires/wishes of the network to various bodies in the network (e.g. RFC-12, instructing the Fellowship to add a collective).

These statements do not execute any stateful logic that would affect the network, and in my opinion more than one could be evaluated at a time. These referenda should not hold up voting on proposals that actually do require Root, nor be forced to queue (for example, it should be possible to propose two new collectives in parallel).

The approval/support requirements are the same as Root, but the origin does not map to any privilege. Passing something on the track is merely a signal.