### PR TITLE
Treasury Pallet Account as destination for XCM fees on System Parachains

### DIFF
--- a/system-parachains/asset-hubs/asset-hub-kusama/tests/tests.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/tests/tests.rs
@@ -21,8 +21,8 @@ use asset_hub_kusama_runtime::{
 	xcm_config::{
 		bridging::{self, XcmBridgeHubRouterFeeAssetId},
 		AssetFeeAsExistentialDepositMultiplierFeeCharger, CheckingAccount,
-		ForeignCreatorsSovereignAccountOf, KsmLocation, LocationToAccountId, TreasuryAccount,
-		TrustBackedAssetsPalletLocation, XcmConfig,
+		ForeignCreatorsSovereignAccountOf, KsmLocation, LocationToAccountId, RelayTreasuryLocation,
+		RelayTreasuryPalletAccount, TrustBackedAssetsPalletLocation, XcmConfig,
 	},
 	AllPalletsWithoutSystem, AssetDeposit, Assets, Balances, ExistentialDeposit, ForeignAssets,
 	ForeignAssetsInstance, MetadataDepositBase, MetadataDepositPerByte, ParachainSystem, Runtime,
@@ -43,7 +43,7 @@ use parachains_common::{AccountId, AssetIdForTrustBackedAssets, AuraId, Balance}
 use sp_runtime::traits::MaybeEquivalence;
 use system_parachains_constants::kusama::fee::WeightToFee;
 use xcm::latest::prelude::*;
-use xcm_executor::traits::{Identity, JustTry, WeightTrader};
+use xcm_executor::traits::{ConvertLocation, Identity, JustTry, WeightTrader};
 
 const ALICE: [u8; 32] = [1u8; 32];
 const SOME_ASSET_ADMIN: [u8; 32] = [5u8; 32];
@@ -693,7 +693,7 @@ fn limited_reserve_transfer_assets_for_native_asset_to_asset_hub_polkadot_works(
 		bridging_to_asset_hub_polkadot,
 		WeightLimit::Unlimited,
 		Some(XcmBridgeHubRouterFeeAssetId::get()),
-		Some(TreasuryAccount::get()),
+		Some(RelayTreasuryPalletAccount::get()),
 	)
 }
 
@@ -800,5 +800,13 @@ fn change_xcm_bridge_hub_router_byte_fee_by_governance_works() {
 				old_value.checked_sub(1).unwrap()
 			}
 		},
+	)
+}
+
+#[test]
+fn treasury_pallet_account_not_non() {
+	assert_eq!(
+		RelayTreasuryPalletAccount::get(),
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get()).unwrap()
 	)
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
@@ -51,7 +51,10 @@ use xcm_builder::{
 	TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 	XcmFeeManagerFromComponents, XcmFeeToAccount,
 };
-use xcm_executor::{traits::WithOriginFilter, XcmExecutor};
+use xcm_executor::{
+	traits::{ConvertLocation, WithOriginFilter},
+	XcmExecutor,
+};
 
 parameter_types! {
 	pub const DotLocation: MultiLocation = MultiLocation::parent();
@@ -67,6 +70,11 @@ parameter_types! {
 	pub const GovernanceLocation: MultiLocation = MultiLocation::parent();
 	pub RelayTreasuryLocation: MultiLocation = (Parent, PalletInstance(polkadot_runtime_constants::TREASURY_PALLET_ID)).into();
 	pub TreasuryAccount: AccountId = TREASURY_PALLET_ID.into_account_truncating();
+	// Test [`crate::tests::treasury_pallet_account_not_none`] ensures that the result of location
+	// conversion is not `None`.
+	pub RelayTreasuryPalletAccount: AccountId =
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get())
+			.unwrap_or(TreasuryAccount::get());
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -520,7 +528,7 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetExchanger = ();
 	type FeeManager = XcmFeeManagerFromComponents<
 		WaivedLocations,
-		XcmFeeToAccount<Self::AssetTransactor, AccountId, TreasuryAccount>,
+		XcmFeeToAccount<Self::AssetTransactor, AccountId, RelayTreasuryPalletAccount>,
 	>;
 	type MessageExporter = ();
 	type UniversalAliases = bridging::to_kusama::UniversalAliases;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/tests/tests.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/tests/tests.rs
@@ -21,8 +21,8 @@ use asset_hub_polkadot_runtime::{
 	xcm_config::{
 		bridging::{self, XcmBridgeHubRouterFeeAssetId},
 		AssetFeeAsExistentialDepositMultiplierFeeCharger, CheckingAccount, DotLocation,
-		ForeignCreatorsSovereignAccountOf, LocationToAccountId, TreasuryAccount,
-		TrustBackedAssetsPalletLocation, XcmConfig,
+		ForeignCreatorsSovereignAccountOf, LocationToAccountId, RelayTreasuryLocation,
+		RelayTreasuryPalletAccount, TrustBackedAssetsPalletLocation, XcmConfig,
 	},
 	AllPalletsWithoutSystem, AssetDeposit, Assets, Balances, ExistentialDeposit, ForeignAssets,
 	ForeignAssetsInstance, MetadataDepositBase, MetadataDepositPerByte, ParachainSystem, Runtime,
@@ -45,7 +45,7 @@ use parachains_common::{
 use sp_runtime::traits::MaybeEquivalence;
 use system_parachains_constants::polkadot::fee::WeightToFee;
 use xcm::latest::prelude::*;
-use xcm_executor::traits::{Identity, JustTry, WeightTrader};
+use xcm_executor::traits::{ConvertLocation, Identity, JustTry, WeightTrader};
 
 const ALICE: [u8; 32] = [1u8; 32];
 const SOME_ASSET_ADMIN: [u8; 32] = [5u8; 32];
@@ -719,7 +719,7 @@ fn limited_reserve_transfer_assets_for_native_asset_to_asset_hub_kusama_works() 
 		bridging_to_asset_hub_kusama,
 		WeightLimit::Unlimited,
 		Some(XcmBridgeHubRouterFeeAssetId::get()),
-		Some(TreasuryAccount::get()),
+		Some(RelayTreasuryPalletAccount::get()),
 	)
 }
 #[test]
@@ -825,5 +825,13 @@ fn change_xcm_bridge_hub_router_byte_fee_by_governance_works() {
 				old_value.checked_sub(1).unwrap()
 			}
 		},
+	)
+}
+
+#[test]
+fn treasury_pallet_account_not_non() {
+	assert_eq!(
+		RelayTreasuryPalletAccount::get(),
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get()).unwrap()
 	)
 }

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/xcm_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/xcm_config.rs
@@ -47,7 +47,10 @@ use xcm_builder::{
 	TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 	XcmFeeManagerFromComponents, XcmFeeToAccount,
 };
-use xcm_executor::{traits::WithOriginFilter, XcmExecutor};
+use xcm_executor::{
+	traits::{ConvertLocation, WithOriginFilter},
+	XcmExecutor,
+};
 
 parameter_types! {
 	pub const KsmRelayLocation: MultiLocation = MultiLocation::parent();
@@ -61,6 +64,11 @@ parameter_types! {
 	pub const FellowshipLocation: MultiLocation = MultiLocation::parent();
 	pub RelayTreasuryLocation: MultiLocation = (Parent, PalletInstance(kusama_runtime_constants::TREASURY_PALLET_ID)).into();
 	pub TreasuryAccount: AccountId = TREASURY_PALLET_ID.into_account_truncating();
+	// Test [`crate::tests::treasury_pallet_account_not_none`] ensures that the result of location
+	// conversion is not `None`.
+	pub RelayTreasuryPalletAccount: AccountId =
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get())
+			.unwrap_or(TreasuryAccount::get());
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -277,7 +285,7 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetExchanger = ();
 	type FeeManager = XcmFeeManagerFromComponents<
 		WaivedLocations,
-		XcmFeeToAccount<Self::AssetTransactor, AccountId, TreasuryAccount>,
+		XcmFeeToAccount<Self::AssetTransactor, AccountId, RelayTreasuryPalletAccount>,
 	>;
 	type MessageExporter = ToBridgeHubPolkadotHaulBlobExporter;
 	type UniversalAliases = Nothing;
@@ -336,4 +344,12 @@ impl pallet_xcm::Config for Runtime {
 impl cumulus_pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+#[test]
+fn treasury_pallet_account_not_non() {
+	assert_eq!(
+		RelayTreasuryPalletAccount::get(),
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get()).unwrap()
+	)
 }

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/tests/tests.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/tests/tests.rs
@@ -23,7 +23,10 @@ use bridge_hub_kusama_runtime::{
 		WithBridgeHubPolkadotMessageBridge, WithBridgeHubPolkadotMessagesInstance,
 		XCM_LANE_FOR_ASSET_HUB_KUSAMA_TO_ASSET_HUB_POLKADOT,
 	},
-	xcm_config::{KsmRelayLocation, RelayNetwork, XcmConfig},
+	xcm_config::{
+		KsmRelayLocation, LocationToAccountId, RelayNetwork, RelayTreasuryLocation,
+		RelayTreasuryPalletAccount, XcmConfig,
+	},
 	AllPalletsWithoutSystem, BridgeRejectObsoleteHeadersAndMessages, Executive, ExistentialDeposit,
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, SessionKeys, SignedExtra,
 	UncheckedExtrinsic,
@@ -38,6 +41,7 @@ use sp_runtime::{
 	AccountId32,
 };
 use xcm::latest::prelude::*;
+use xcm_executor::traits::ConvertLocation;
 
 const ALICE: [u8; 32] = [1u8; 32];
 
@@ -312,3 +316,11 @@ pub fn can_calculate_fee_for_complex_message_delivery_transaction() {}
 
 #[test]
 pub fn can_calculate_fee_for_complex_message_confirmation_transaction() {}
+
+#[test]
+fn treasury_pallet_account_not_non() {
+	assert_eq!(
+		RelayTreasuryPalletAccount::get(),
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get()).unwrap()
+	)
+}

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/xcm_config.rs
@@ -47,7 +47,10 @@ use xcm_builder::{
 	TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 	XcmFeeManagerFromComponents, XcmFeeToAccount,
 };
-use xcm_executor::{traits::WithOriginFilter, XcmExecutor};
+use xcm_executor::{
+	traits::{ConvertLocation, WithOriginFilter},
+	XcmExecutor,
+};
 
 parameter_types! {
 	pub const DotRelayLocation: MultiLocation = MultiLocation::parent();
@@ -61,6 +64,11 @@ parameter_types! {
 	pub const GovernanceLocation: MultiLocation = MultiLocation::parent();
 	pub RelayTreasuryLocation: MultiLocation = (Parent, PalletInstance(polkadot_runtime_constants::TREASURY_PALLET_ID)).into();
 	pub TreasuryAccount: AccountId = TREASURY_PALLET_ID.into_account_truncating();
+	// Test [`crate::tests::treasury_pallet_account_not_none`] ensures that the result of location
+	// conversion is not `None`.
+	pub RelayTreasuryPalletAccount: AccountId =
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get())
+			.unwrap_or(TreasuryAccount::get());
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -284,7 +292,7 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetExchanger = ();
 	type FeeManager = XcmFeeManagerFromComponents<
 		WaivedLocations,
-		XcmFeeToAccount<Self::AssetTransactor, AccountId, TreasuryAccount>,
+		XcmFeeToAccount<Self::AssetTransactor, AccountId, RelayTreasuryPalletAccount>,
 	>;
 	type MessageExporter = ToBridgeHubKusamaHaulBlobExporter;
 	type UniversalAliases = Nothing;

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/tests.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/tests.rs
@@ -23,7 +23,10 @@ use bridge_hub_polkadot_runtime::{
 		WithBridgeHubKusamaMessageBridge, WithBridgeHubKusamaMessagesInstance,
 		XCM_LANE_FOR_ASSET_HUB_POLKADOT_TO_ASSET_HUB_KUSAMA,
 	},
-	xcm_config::{DotRelayLocation, RelayNetwork, XcmConfig},
+	xcm_config::{
+		DotRelayLocation, LocationToAccountId, RelayNetwork, RelayTreasuryLocation,
+		RelayTreasuryPalletAccount, XcmConfig,
+	},
 	AllPalletsWithoutSystem, BridgeRejectObsoleteHeadersAndMessages, Executive, ExistentialDeposit,
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, SessionKeys, SignedExtra,
 	UncheckedExtrinsic,
@@ -38,6 +41,7 @@ use sp_runtime::{
 	AccountId32,
 };
 use xcm::latest::prelude::*;
+use xcm_executor::traits::ConvertLocation;
 
 const ALICE: [u8; 32] = [1u8; 32];
 
@@ -312,3 +316,11 @@ pub fn can_calculate_fee_for_complex_message_delivery_transaction() {}
 
 #[test]
 pub fn can_calculate_fee_for_complex_message_confirmation_transaction() {}
+
+#[test]
+fn treasury_pallet_account_not_non() {
+	assert_eq!(
+		RelayTreasuryPalletAccount::get(),
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get()).unwrap()
+	)
+}

--- a/system-parachains/collectives/collectives-polkadot/src/xcm_config.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/xcm_config.rs
@@ -45,7 +45,10 @@ use xcm_builder::{
 	TrailingSetTopicAsId, UsingComponents, WithComputedOrigin, WithUniqueTopic,
 	XcmFeeManagerFromComponents, XcmFeeToAccount,
 };
-use xcm_executor::{traits::WithOriginFilter, XcmExecutor};
+use xcm_executor::{
+	traits::{ConvertLocation, WithOriginFilter},
+	XcmExecutor,
+};
 
 parameter_types! {
 	pub const RootLocation: MultiLocation = MultiLocation::here();
@@ -59,6 +62,11 @@ parameter_types! {
 	pub RelayTreasuryLocation: MultiLocation = (Parent, PalletInstance(polkadot_runtime_constants::TREASURY_PALLET_ID)).into();
 	pub TreasuryAccount: AccountId = TREASURY_PALLET_ID.into_account_truncating();
 	pub const TreasurerBodyId: BodyId = BodyId::Index(xcm_constants::body::TREASURER_INDEX);
+	// Test [`treasury_pallet_account_not_none`] ensures that the result of location conversion is
+	// not `None`.
+	pub RelayTreasuryPalletAccount: AccountId =
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get())
+			.unwrap_or(TreasuryAccount::get());
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -304,7 +312,7 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetExchanger = ();
 	type FeeManager = XcmFeeManagerFromComponents<
 		WaivedLocations,
-		XcmFeeToAccount<Self::AssetTransactor, AccountId, TreasuryAccount>,
+		XcmFeeToAccount<Self::AssetTransactor, AccountId, RelayTreasuryPalletAccount>,
 	>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
@@ -362,4 +370,12 @@ impl pallet_xcm::Config for Runtime {
 impl cumulus_pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
+}
+
+#[test]
+fn treasury_pallet_account_not_non() {
+	assert_eq!(
+		RelayTreasuryPalletAccount::get(),
+		LocationToAccountId::convert_location(&RelayTreasuryLocation::get()).unwrap()
+	)
 }


### PR DESCRIPTION
Designates the Treasury Pallet Account as the destination for XCM fees on System Parachains. 

This ensures that assets accumulated in the pallet's account can be spent by Treasury Origins from Relay Chains. 