### PR TITLE
Unified tests into final step ✅ 

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -80,7 +80,7 @@ jobs:
 
   confirmMigrationsPassed:
     runs-on: ubuntu-latest
-    name: Confirms that all migrations passed
+    name: All migrations passed
     # If any new job gets added, be sure to add it to this list
     needs: [check-migrations]
     steps:

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -16,6 +16,7 @@ concurrency:
 permissions: {}
 
 jobs:
+  # This generates a matrix with all the required jobs which will be run in the next step
   runtime-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -36,6 +37,8 @@ jobs:
           TASKS=$(echo $TASKS | jq -c .)
           echo "runtime=$TASKS" >> $GITHUB_OUTPUT
 
+  # This runs all the jobs in the matrix. It is required by the "confirmMigrationsPassed" job, so
+  # if they all pass, that job will pass too.
   check-migrations:
     needs: [runtime-matrix]
     continue-on-error: true
@@ -78,10 +81,14 @@ jobs:
           checks: "pre-and-post"
           extra-args: ${{ env.EXTRA_ARGS }}
 
+  # This will only run if all the tests in its "needs" array passed.
+  # Add this as your required job, becuase if the matrix changes size (new things get added)
+  # it will still require all the steps to succeed.
+  # If you add more jobs, remember to add them to the "needs" array.
   confirmMigrationsPassed:
     runs-on: ubuntu-latest
     name: All migrations passed
-    # If any new job gets added, be sure to add it to this list
+    # If any new job gets added, be sure to add it to this array
     needs: [check-migrations]
     steps:
       - run: echo '### Good job! All the migrations passed 🚀' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -77,3 +77,11 @@ jobs:
           node-uri: ${{ matrix.runtime.uri }}
           checks: "pre-and-post"
           extra-args: ${{ env.EXTRA_ARGS }}
+
+  confirmMigrationsPassed:
+    runs-on: ubuntu-latest
+    name: Confirms that all migrations passed
+    # If any new job gets added, be sure to add it to this list
+    needs: [check-migrations]
+    steps:
+      - run: echo '### Good job! All the migrations passed 🚀' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -1,5 +1,8 @@
 name: Check Migrations
 
+# If you modify more jobs, ensure that you add them as required to the job "confirmMigrationsPassed"
+# which is located at the end of this file (more info in the job)
+
 on:
   push:
     branches: ["main", "release-*"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,7 @@ jobs:
           RUSTFLAGS: "-C debug-assertions -D warnings"
           SKIP_WASM_BUILD: 1
 
+  # Job required by "confirmTestPassed"
   zombienet-smoke:
     needs: [build-chain-spec-generator]
     runs-on: ubuntu-latest
@@ -260,5 +261,6 @@ jobs:
       - runtime-test
       - integration-test
       - build-chain-spec-generator
+      - zombienet-smoke
     steps:
       - run: echo '### Good job! All the tests passed 🚀' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,7 @@ jobs:
   confirmTestPassed:
     runs-on: ubuntu-latest
     name: Confirms that all test passed
+    # If any new job gets added, be sure to add it to this list
     needs:
       - runtime-matrix
       - integration-test-matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,3 +240,16 @@ jobs:
         run: |
           export PATH=$(pwd)/target/release:$PATH
           cargo test --manifest-path integration-tests/zombienet/Cargo.toml
+
+  confirmTestPassed:
+    runs-on: ubuntu-latest
+    name: Confirms that all test passed
+    needs:
+      - runtime-matrix
+      - integration-test-matrix
+      - runtime-test
+      - integration-test
+      - build-chain-spec-generator
+    steps:
+      - run: echo "Good job! All the tests passed!"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,8 +246,6 @@ jobs:
     name: Confirms that all tests passed
     # If any new job gets added, be sure to add it to this list
     needs:
-      - runtime-matrix
-      - integration-test-matrix
       - runtime-test
       - integration-test
       - build-chain-spec-generator

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: "Test all features"
 
+# If you modify more test jobs, ensure that you add them as required to the job "confirmTestPassed"
+# which is located at the end of this file (more info in the job)
+
 on:
   push:
     branches: ["main", "release-*"]
@@ -248,7 +251,7 @@ jobs:
   # This will only run if all the tests in its "needs" array passed.
   # Add this as your required job, becuase if the matrix changes size (new things get added)
   # it will still require all the steps to succeed.
-  # If you add more tests, remember to add them to the "needs" array.
+  # If you add more jobs, remember to add them to the "needs" array.
   confirmTestPassed:
     runs-on: ubuntu-latest
     name: All tests passed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,5 +250,4 @@ jobs:
       - integration-test
       - build-chain-spec-generator
     steps:
-      - run: echo "Good job! All the tests passed!"
-
+      - run: echo '### Good job! All the tests passed 🚀' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # This generates a matrix with all the required jobs which will be run in the next step
   runtime-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -38,6 +39,7 @@ jobs:
           echo $TASKS
           echo "itest=$TASKS" >> $GITHUB_OUTPUT
 
+  # Job required by "confirmTestPassed"
   runtime-test:
     needs: [runtime-matrix]
     continue-on-error: true
@@ -94,6 +96,7 @@ jobs:
           RUSTFLAGS: "-C debug-assertions -D warnings"
           SKIP_WASM_BUILD: 1
 
+  # Job required by "confirmTestPassed"
   integration-test:
     needs: [integration-test-matrix]
     continue-on-error: true
@@ -144,6 +147,7 @@ jobs:
         env:
           RUSTFLAGS: "-C debug-assertions -D warnings"
 
+  # Job required by "confirmTestPassed"
   build-chain-spec-generator:
     runs-on: ubuntu-latest
     steps:
@@ -241,6 +245,10 @@ jobs:
           export PATH=$(pwd)/target/release:$PATH
           cargo test --manifest-path integration-tests/zombienet/Cargo.toml
 
+  # This will only run if all the tests in its "needs" array passed.
+  # Add this as your required job, becuase if the matrix changes size (new things get added)
+  # it will still require all the steps to succeed.
+  # If you add more tests, remember to add them to the "needs" array.
   confirmTestPassed:
     runs-on: ubuntu-latest
     name: All tests passed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
 
   confirmTestPassed:
     runs-on: ubuntu-latest
-    name: Confirms that all tests passed
+    name: All tests passed
     # If any new job gets added, be sure to add it to this list
     needs:
       - runtime-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
 
   confirmTestPassed:
     runs-on: ubuntu-latest
-    name: Confirms that all test passed
+    name: Confirms that all tests passed
     # If any new job gets added, be sure to add it to this list
     needs:
       - runtime-matrix


### PR DESCRIPTION
Unified all the tests into having one final step at the end.

<img width="803" alt="image" src="https://github.com/polkadot-fellows/runtimes/assets/8524599/5269a2c1-eae0-481c-b13c-d5b9e2957bbf">

This step will only run if all the previous steps have ran. If any of these tests fail, it will fail.

All the status checks will still appear in the PR, so the user can see any failed case:
<img width="855" alt="image" src="https://github.com/polkadot-fellows/runtimes/assets/8524599/2b5e6f9c-5304-4bc8-b7b9-15d99df0d07d">

But, by adding this last test as the only requirement, the list to block the branch becomes significantly smaller.

- [x] Does not require a CHANGELOG entry
