### PR TITLE
Add `fast-runtime` feature to chain-spec-generator

### DIFF
--- a/chain-spec-generator/Cargo.toml
+++ b/chain-spec-generator/Cargo.toml
@@ -44,6 +44,10 @@ glutton-kusama-runtime = { path = "../system-parachains/gluttons/glutton-kusama"
 sp-core-encointer-compatible = { package = "sp-core",  version = "25.0.0" }
 
 [features]
+fast-runtime = [
+	"kusama-runtime/fast-runtime",
+	"polkadot-runtime/fast-runtime",
+]
 runtime-benchmarks = [
 	"asset-hub-polkadot-runtime/runtime-benchmarks",
 	"asset-hub-kusama-runtime/runtime-benchmarks",


### PR DESCRIPTION
Not sure if it would make sense to add this. Opening this PR to get feedback on it.

It would help us with the zombienet testing for the P<>K bridge.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
