### PR TITLE
Lift external deps to the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8425,9 +8425,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0493c09d29fefc62579284b596618fcceb68fdb3dd38de79fe3c922a19916249"
+checksum = "c13f5c598737e84294880333170d1df3868a11ad7ee79d0b1d1af37365e1c277"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8425,9 +8425,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.4"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13f5c598737e84294880333170d1df3868a11ad7ee79d0b1d1af37365e1c277"
+checksum = "0493c09d29fefc62579284b596618fcceb68fdb3dd38de79fe3c922a19916249"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ pallet-uniques = { version = "29.0.0", default-features = false }
 pallet-utility = { version = "29.0.0", default-features = false }
 pallet-vesting = { version = "29.0.0", default-features = false }
 pallet-whitelist = { version = "28.0.0", default-features = false }
-pallet-xcm = { version = "8.0.3", default-features = false }
+pallet-xcm = { version = "8.0.4", default-features = false }
 pallet-xcm-benchmarks = { version = "8.0.2", default-features = false }
 pallet-xcm-bridge-hub = { version = "0.3.0", default-features = false }
 pallet-xcm-bridge-hub-router = { version = "0.6.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,199 @@ edition = "2021"
 repository = "https://github.com/polkadot-fellows/runtimes.git"
 license = "GPL-3.0-only" # TODO <https://github.com/polkadot-fellows/runtimes/issues/29>
 
+[workspace.dependencies]
+assert_matches = { version = "1.5.0" }
+asset-test-utils = { version = "8.0.1" }
+assets-common = { version = "0.8.0", default-features = false }
+binary-merkle-tree = { version = "14.0.0", default-features = false }
+bp-bridge-hub-cumulus = { version = "0.8.0", default-features = false }
+bp-header-chain = { version = "0.8.0", default-features = false }
+bp-kusama = { version = "0.6.0", default-features = false }
+bp-messages = { version = "0.8.0", default-features = false }
+bp-parachains = { version = "0.8.0", default-features = false }
+bp-polkadot = { version = "0.6.0", default-features = false }
+bp-polkadot-core = { version = "0.8.0", default-features = false }
+bp-relayers = { version = "0.8.0", default-features = false }
+bp-runtime = { version = "0.8.0", default-features = false }
+bp-xcm-bridge-hub-router = { version = "0.7.0", default-features = false }
+bridge-hub-common = { version = "0.1.0", default-features = false }
+bridge-hub-test-utils = { version = "0.8.0" }
+bridge-runtime-common = { version = "0.8.0", default-features = false }
+clap = { version = "4.5.0" }
+cumulus-pallet-aura-ext = { version = "0.8.0", default-features = false }
+cumulus-pallet-dmp-queue = { version = "0.8.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.8.1", default-features = false }
+cumulus-pallet-session-benchmarking = { version = "10.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.8.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.8.0", default-features = false }
+cumulus-primitives-aura = { version = "0.8.0", default-features = false }
+cumulus-primitives-core = { version = "0.8.0", default-features = false }
+cumulus-primitives-utility = { version = "0.8.1", default-features = false }
+emulated-integration-tests-common = { version = "4.0.0" }
+encointer-balances-tx-payment = { version = "~6.1.0", default-features = false }
+encointer-balances-tx-payment-rpc-runtime-api = { version = "~6.1.0", default-features = false }
+encointer-primitives = { version = "~6.1.0", default-features = false }
+enumflags2 = { version = "0.7.7" }
+frame-benchmarking = { version = "29.0.0", default-features = false }
+frame-election-provider-support = { version = "29.0.0", default-features = false }
+frame-executive = { version = "29.0.0", default-features = false }
+frame-remote-externalities = { version = "0.36.0" }
+frame-support = { version = "29.0.0", default-features = false }
+frame-system = { version = "29.0.0", default-features = false }
+frame-system-benchmarking = { version = "29.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "27.0.0", default-features = false }
+frame-try-runtime = { version = "0.35.0", default-features = false }
+hex-literal = { version = "0.4.1" }
+log = { version = "0.4.20", default-features = false }
+pallet-alliance = { version = "28.0.0", default-features = false }
+pallet-asset-conversion = { version = "11.0.0", default-features = false }
+pallet-asset-conversion-tx-payment = { version = "11.0.0", default-features = false }
+pallet-asset-rate = { version = "8.0.0", default-features = false }
+pallet-asset-tx-payment = { version = "29.0.0", default-features = false }
+pallet-assets = { version = "30.0.0", default-features = false }
+pallet-aura = { version = "28.0.0", default-features = false }
+pallet-authority-discovery = { version = "29.0.1", default-features = false }
+pallet-authorship = { version = "29.0.0", default-features = false }
+pallet-babe = { version = "29.0.0", default-features = false }
+pallet-bags-list = { version = "28.0.0", default-features = false }
+pallet-balances = { version = "29.0.0", default-features = false }
+pallet-beefy = { version = "29.0.0", default-features = false }
+pallet-beefy-mmr = { version = "29.0.0", default-features = false }
+pallet-bounties = { version = "28.0.0", default-features = false }
+pallet-bridge-grandpa = { version = "0.8.0", default-features = false }
+pallet-bridge-messages = { version = "0.8.0", default-features = false }
+pallet-bridge-parachains = { version = "0.8.0", default-features = false }
+pallet-bridge-relayers = { version = "0.8.0", default-features = false }
+pallet-broker = { version = "0.7.0", default-features = false }
+pallet-child-bounties = { version = "28.0.0", default-features = false }
+pallet-collator-selection = { version = "10.0.0", default-features = false }
+pallet-collective = { version = "29.0.0", default-features = false }
+pallet-conviction-voting = { version = "29.0.0", default-features = false }
+pallet-core-fellowship = { version = "13.0.0", default-features = false }
+pallet-election-provider-multi-phase = { version = "28.0.0", default-features = false }
+pallet-election-provider-support-benchmarking = { version = "28.0.0", default-features = false }
+pallet-encointer-balances = { version = "~6.1.0", default-features = false }
+pallet-encointer-bazaar = { version = "~6.1.0", default-features = false }
+pallet-encointer-bazaar-rpc-runtime-api = { version = "~6.1.0", default-features = false }
+pallet-encointer-ceremonies = { version = "~6.1.0", default-features = false }
+pallet-encointer-ceremonies-rpc-runtime-api = { version = "~6.1.0", default-features = false }
+pallet-encointer-communities = { version = "~6.1.0", default-features = false }
+pallet-encointer-communities-rpc-runtime-api = { version = "~6.1.0", default-features = false }
+pallet-encointer-faucet = { version = "~6.1.0", default-features = false }
+pallet-encointer-reputation-commitments = { version = "~6.1.0", default-features = false }
+pallet-encointer-scheduler = { version = "~6.1.0", default-features = false }
+pallet-fast-unstake = { version = "28.0.0", default-features = false }
+pallet-glutton = { version = "15.0.0", default-features = false }
+pallet-grandpa = { version = "29.0.0", default-features = false }
+pallet-identity = { version = "29.0.0", default-features = false }
+pallet-indices = { version = "29.0.0", default-features = false }
+pallet-insecure-randomness-collective-flip = { version = "17.0.0", default-features = false }
+pallet-membership = { version = "29.0.0", default-features = false }
+pallet-message-queue = { version = "32.0.0", default-features = false }
+pallet-mmr = { version = "28.0.0", default-features = false }
+pallet-multisig = { version = "29.0.0", default-features = false }
+pallet-nft-fractionalization = { version = "11.0.0", default-features = false }
+pallet-nfts = { version = "23.0.0", default-features = false }
+pallet-nfts-runtime-api = { version = "15.0.0", default-features = false }
+pallet-nis = { version = "29.0.0", default-features = false }
+pallet-nomination-pools = { version = "26.0.0", default-features = false }
+pallet-nomination-pools-benchmarking = { version = "27.0.0", default-features = false }
+pallet-nomination-pools-runtime-api = { version = "24.0.0", default-features = false }
+pallet-offences = { version = "28.0.0", default-features = false }
+pallet-offences-benchmarking = { version = "29.0.0", default-features = false }
+pallet-preimage = { version = "29.0.0", default-features = false }
+pallet-proxy = { version = "29.0.0", default-features = false }
+pallet-ranked-collective = { version = "29.0.0", default-features = false }
+pallet-recovery = { version = "29.0.0", default-features = false }
+pallet-referenda = { version = "29.0.0", default-features = false }
+pallet-salary = { version = "14.0.0", default-features = false }
+pallet-scheduler = { version = "30.0.0", default-features = false }
+pallet-session = { version = "29.0.0", default-features = false }
+pallet-session-benchmarking = { version = "29.0.0", default-features = false }
+pallet-society = { version = "29.0.0", default-features = false }
+pallet-staking = { version = "29.0.0", default-features = false }
+pallet-staking-reward-curve = { version = "11.0.0" }
+pallet-staking-reward-fn = { version = "20.0.0", default-features = false }
+pallet-staking-runtime-api = { version = "15.0.0", default-features = false }
+pallet-state-trie-migration = { version = "30.0.0", default-features = false }
+pallet-sudo = { version = "29.0.0", default-features = false }
+pallet-timestamp = { version = "28.0.0", default-features = false }
+pallet-transaction-payment = { version = "29.0.0", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { version = "29.0.0", default-features = false }
+pallet-treasury = { version = "28.0.0", default-features = false }
+pallet-uniques = { version = "29.0.0", default-features = false }
+pallet-utility = { version = "29.0.0", default-features = false }
+pallet-vesting = { version = "29.0.0", default-features = false }
+pallet-whitelist = { version = "28.0.0", default-features = false }
+pallet-xcm = { version = "8.0.3", default-features = false }
+pallet-xcm-benchmarks = { version = "8.0.2", default-features = false }
+pallet-xcm-bridge-hub = { version = "0.3.0", default-features = false }
+pallet-xcm-bridge-hub-router = { version = "0.6.0", default-features = false }
+parachains-common = { version = "8.0.0", default-features = false }
+parachains-runtimes-test-utils = { version = "8.0.0" }
+parity-scale-codec = { version = "3.6.9", default-features = false }
+paste = { version = "1.0.14" }
+penpal-runtime = { version = "0.15.1" }
+polkadot-core-primitives = { version = "8.0.0", default-features = false }
+polkadot-parachain-primitives = { version = "7.0.0", default-features = false }
+polkadot-primitives = { version = "8.0.1", default-features = false }
+polkadot-runtime-common = { version = "8.0.1", default-features = false }
+polkadot-runtime-parachains = { version = "8.0.1", default-features = false }
+primitive-types = { version = "0.12.2", default-features = false }
+sc-chain-spec = { version = "28.0.0" }
+sc-consensus-grandpa = { version = "0.20.0" }
+scale-info = { version = "2.10.0", default-features = false }
+separator = { version = "0.4.1" }
+serde = { version = "1.0.196" }
+serde_json = { version = "1.0.113" }
+smallvec = { version = "1.13.1" }
+snowbridge-beacon-primitives = { version = "0.1.0", default-features = false }
+snowbridge-core = { version = "0.1.1", default-features = false }
+snowbridge-outbound-queue-runtime-api = { version = "0.1.1", default-features = false }
+snowbridge-pallet-ethereum-client = { version = "0.1.1", default-features = false }
+snowbridge-pallet-inbound-queue = { version = "0.1.1", default-features = false }
+snowbridge-pallet-inbound-queue-fixtures = { version = "0.9.0" }
+snowbridge-pallet-outbound-queue = { version = "0.1.1", default-features = false }
+snowbridge-pallet-system = { version = "0.1.1", default-features = false }
+snowbridge-router-primitives = { version = "0.1.0", default-features = false }
+snowbridge-runtime-common = { version = "0.1.0", default-features = false }
+snowbridge-runtime-test-common = { version = "0.1.0" }
+snowbridge-system-runtime-api = { version = "0.1.0", default-features = false }
+sp-api = { version = "27.0.0", default-features = false }
+sp-application-crypto = { version = "31.0.0", default-features = false }
+sp-arithmetic = { version = "24.0.0", default-features = false }
+sp-authority-discovery = { version = "27.0.0", default-features = false }
+sp-block-builder = { version = "27.0.0", default-features = false }
+sp-consensus-aura = { version = "0.33.0", default-features = false }
+sp-consensus-babe = { version = "0.33.0", default-features = false }
+sp-consensus-beefy = { version = "14.0.0", default-features = false }
+sp-core = { version = "29.0.0", default-features = false }
+sp-debug-derive = { version = "14.0.0", default-features = false }
+sp-genesis-builder = { version = "0.8.0", default-features = false }
+sp-inherents = { version = "27.0.0", default-features = false }
+sp-io = { version = "31.0.0", default-features = false }
+sp-keyring = { version = "32.0.0" }
+sp-npos-elections = { version = "27.0.0", default-features = false }
+sp-offchain = { version = "27.0.0", default-features = false }
+sp-runtime = { version = "32.0.0", default-features = false }
+sp-session = { version = "28.0.0", default-features = false }
+sp-staking = { version = "27.0.0", default-features = false }
+sp-std = { version = "14.0.0", default-features = false }
+sp-storage = { version = "20.0.0", default-features = false }
+sp-tracing = { version = "16.0.0", default-features = false }
+sp-transaction-pool = { version = "27.0.0", default-features = false }
+sp-trie = { version = "30.0.0" }
+sp-version = { version = "30.0.0", default-features = false }
+sp-weights = { version = "28.0.0", default-features = false }
+staging-parachain-info = { version = "0.8.0", default-features = false }
+staging-xcm = { version = "8.0.1", default-features = false }
+staging-xcm-builder = { version = "8.0.1", default-features = false }
+staging-xcm-executor = { version = "8.0.1", default-features = false }
+static_assertions = { version = "1.1.0" }
+substrate-wasm-builder = { version = "18.0.0" }
+tokio = { version = "1.36.0" }
+xcm-emulator = { version = "0.6.0" }
+
 [workspace]
 resolver = "2"
 

--- a/chain-spec-generator/Cargo.toml
+++ b/chain-spec-generator/Cargo.toml
@@ -7,28 +7,28 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-clap = { version = "4.5.0", features = [ "derive" ] }
-serde_json = "1.0.113"
-serde = { version = "1.0.196", features = ["derive"] }
+clap = { features = [ "derive" ] , workspace = true }
+serde_json = { workspace = true }
+serde = { features = ["derive"] , workspace = true }
 
 polkadot-runtime = { path = "../relay/polkadot" }
 polkadot-runtime-constants = { path = "../relay/polkadot/constants" }
 kusama-runtime = { package = "staging-kusama-runtime", path = "../relay/kusama" }
 kusama-runtime-constants = { path = "../relay/kusama/constants" }
 
-sc-chain-spec = "28.0.0"
-polkadot-runtime-parachains = "8.0.1"
-polkadot-primitives = "8.0.1"
-sp-consensus-babe = "0.33.0"
-sp-authority-discovery = "27.0.0"
-sp-core = "29.0.0"
-pallet-staking = "29.0.0"
-sc-consensus-grandpa = "0.20.0"
-sp-runtime = "32.0.0"
-sp-consensus-beefy = "14.0.0"
+sc-chain-spec = { workspace = true }
+polkadot-runtime-parachains = { workspace = true, default-features = true }
+polkadot-primitives = { workspace = true, default-features = true }
+sp-consensus-babe = { workspace = true, default-features = true }
+sp-authority-discovery = { workspace = true, default-features = true }
+sp-core = { workspace = true, default-features = true }
+pallet-staking = { workspace = true, default-features = true }
+sc-consensus-grandpa = { workspace = true }
+sp-runtime = { workspace = true, default-features = true }
+sp-consensus-beefy = { workspace = true, default-features = true }
 xcm = { package = "staging-xcm", version = "8.0.1" }
-parachains-common = { version = "8.0.0" }
-cumulus-primitives-core = { version = "0.8.0" }
+parachains-common = { workspace = true, default-features = true }
+cumulus-primitives-core = { workspace = true, default-features = true }
 
 asset-hub-polkadot-runtime = { path = "../system-parachains/asset-hubs/asset-hub-polkadot" }
 asset-hub-kusama-runtime = { path = "../system-parachains/asset-hubs/asset-hub-kusama" }

--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-frame-support = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-cumulus-primitives-core = { version = "0.8.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+cumulus-primitives-core = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 asset-hub-kusama-runtime = { path = "../../../../../../system-parachains/asset-hubs/asset-hub-kusama" }

--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-frame-support = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-cumulus-primitives-core = { version = "0.8.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+cumulus-primitives-core = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 asset-hub-polkadot-runtime = { path = "../../../../../../system-parachains/asset-hubs/asset-hub-polkadot" }

--- a/integration-tests/emulated/chains/parachains/bridges/bridge-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/bridges/bridge-hub-kusama/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-frame-support = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-bridge-hub-common = { version = "0.1.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+bridge-hub-common = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 bridge-hub-kusama-runtime = { path = "../../../../../../system-parachains/bridge-hubs/bridge-hub-kusama" }

--- a/integration-tests/emulated/chains/parachains/bridges/bridge-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/bridges/bridge-hub-polkadot/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-frame-support = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-bridge-hub-common = { version = "0.1.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+bridge-hub-common = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 bridge-hub-polkadot-runtime = { path = "../../../../../../system-parachains/bridge-hubs/bridge-hub-polkadot" }

--- a/integration-tests/emulated/chains/parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/collectives/collectives-polkadot/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-frame-support = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-cumulus-primitives-core = { version = "0.8.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+cumulus-primitives-core = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 collectives-polkadot-runtime = { path = "../../../../../../system-parachains/collectives/collectives-polkadot" }

--- a/integration-tests/emulated/chains/parachains/people/people-kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/people/people-kusama/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-frame-support = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-cumulus-primitives-core = { version = "0.8.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+cumulus-primitives-core = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Local
 people-kusama-runtime = { path = "../../../../../../system-parachains/people/people-kusama" }

--- a/integration-tests/emulated/chains/parachains/testing/penpal/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/testing/penpal/Cargo.toml
@@ -10,14 +10,14 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-frame-support = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-cumulus-primitives-core = { version = "0.8.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
-penpal-runtime = { version = "0.15.1", features = ["experimental"] }
+parachains-common = { workspace = true, default-features = true }
+cumulus-primitives-core = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
+penpal-runtime = { features = ["experimental"] , workspace = true }
 
 # Runtimes
 kusama-emulated-chain = { path = "../../../relays/kusama" }

--- a/integration-tests/emulated/chains/relays/kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/relays/kusama/Cargo.toml
@@ -10,18 +10,18 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
+sp-core = { workspace = true, default-features = true }
 authority-discovery-primitives = { package = "sp-authority-discovery", version = "27.0.0" }
 babe-primitives = { package = "sp-consensus-babe", version = "0.33.0" }
 beefy-primitives = { package = "sp-consensus-beefy", version = "14.0.0" }
 grandpa = { package = "sc-consensus-grandpa", version = "0.20.0" }
 
 # Polkadot
-polkadot-primitives = { version = "8.0.1" }
+polkadot-primitives = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 kusama-runtime-constants = { path = "../../../../../relay/kusama/constants" }

--- a/integration-tests/emulated/chains/relays/polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/relays/polkadot/Cargo.toml
@@ -10,20 +10,20 @@ publish = false
 [dependencies]
 
 # Substrate
-sp-core = { version = "29.0.0" }
-sp-runtime = { version = "32.0.0" }
+sp-core = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
 authority-discovery-primitives = { package = "sp-authority-discovery", version = "27.0.0" }
 babe-primitives = { package = "sp-consensus-babe", version = "0.33.0" }
 beefy-primitives = { package = "sp-consensus-beefy", version = "14.0.0" }
 grandpa = { package = "sc-consensus-grandpa", version = "0.20.0" }
-pallet-staking = { version = "29.0.0" }
+pallet-staking = { workspace = true, default-features = true }
 
 # Polkadot
-polkadot-primitives = { version = "8.0.1" }
+polkadot-primitives = { workspace = true, default-features = true }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
+parachains-common = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 polkadot-runtime-constants = { path = "../../../../../relay/polkadot/constants" }

--- a/integration-tests/emulated/helpers/Cargo.toml
+++ b/integration-tests/emulated/helpers/Cargo.toml
@@ -8,17 +8,17 @@ description = "Emulated integration tests helpers"
 publish = false
 
 [dependencies]
-paste = "1.0.14"
+paste = { workspace = true }
 
 # Substrate
-pallet-balances = { version = "29.0.0" }
-pallet-message-queue = { version = "32.0.0" }
+pallet-balances = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.3" }
+pallet-xcm = { workspace = true, default-features = true }
 
 # Cumulus
-xcm-emulator = { version = "0.6.0" }
-cumulus-pallet-xcmp-queue = { version = "0.8.0" }
-asset-test-utils = { version = "8.0.1" }
+xcm-emulator = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true, default-features = true }
+asset-test-utils = { workspace = true }

--- a/integration-tests/emulated/helpers/Cargo.toml
+++ b/integration-tests/emulated/helpers/Cargo.toml
@@ -16,7 +16,7 @@ pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.4" }
+pallet-xcm = { version = "8.0.3" }
 
 # Cumulus
 xcm-emulator = { version = "0.6.0" }

--- a/integration-tests/emulated/networks/kusama-polkadot-system/Cargo.toml
+++ b/integration-tests/emulated/networks/kusama-polkadot-system/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 
 # Cumulus
-emulated-integration-tests-common = { version = "4.0.0" }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 asset-hub-kusama-emulated-chain = { path = "../../chains/parachains/assets/asset-hub-kusama" }

--- a/integration-tests/emulated/networks/kusama-system/Cargo.toml
+++ b/integration-tests/emulated/networks/kusama-system/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 
 # Cumulus
-emulated-integration-tests-common = { version = "4.0.0" }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 asset-hub-kusama-emulated-chain = { path = "../../chains/parachains/assets/asset-hub-kusama" }

--- a/integration-tests/emulated/networks/polkadot-system/Cargo.toml
+++ b/integration-tests/emulated/networks/polkadot-system/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 
 # Cumulus
-emulated-integration-tests-common = { version = "4.0.0" }
+emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 asset-hub-polkadot-emulated-chain = { path = "../../chains/parachains/assets/asset-hub-polkadot" }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
@@ -9,29 +9,29 @@ publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9" }
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 
 # Substrate
-sp-runtime = { version = "32.0.0" }
-frame-support = { version = "29.0.0" }
-pallet-assets = { version = "30.0.0" }
-pallet-balances = { version = "29.0.0" }
-pallet-asset-conversion = { version = "11.0.0" }
-pallet-treasury = { version = "28.0.0" }
-pallet-message-queue = { version = "32.0.0" }
-pallet-utility = { version = "29.0.0" }
+sp-runtime = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+pallet-assets = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-asset-conversion = { workspace = true, default-features = true }
+pallet-treasury = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
+pallet-utility = { workspace = true, default-features = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
-pallet-xcm = { version = "8.0.3" }
+pallet-xcm = { workspace = true, default-features = true }
 runtime-common = { package = "polkadot-runtime-common", default-features = false, version = "8.0.1" }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
-asset-test-utils = { version = "8.0.1" }
-cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], version = "0.8.1" }
+parachains-common = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
+asset-test-utils = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], workspace = true, default-features = true }
 
 # Local
 asset-hub-kusama-runtime = { path = "../../../../../system-parachains/asset-hubs/asset-hub-kusama" }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
@@ -24,7 +24,7 @@ pallet-utility = { version = "29.0.0" }
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
-pallet-xcm = { version = "8.0.4" }
+pallet-xcm = { version = "8.0.3" }
 runtime-common = { package = "polkadot-runtime-common", default-features = false, version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
@@ -9,29 +9,29 @@ publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9" }
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 
 # Substrate
-sp-runtime = { version = "32.0.0" }
-frame-support = { version = "29.0.0" }
-pallet-balances = { version = "29.0.0" }
-pallet-assets = { version = "30.0.0" }
-pallet-asset-conversion = { version = "11.0.0" }
-pallet-treasury = { version = "28.0.0" }
-pallet-message-queue = { version = "32.0.0" }
+sp-runtime = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-assets = { workspace = true, default-features = true }
+pallet-asset-conversion = { workspace = true, default-features = true }
+pallet-treasury = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
 
 # Polkadot
-polkadot-runtime-common = { version = "8.0.1" }
+polkadot-runtime-common = { workspace = true, default-features = true }
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.3" }
+pallet-xcm = { workspace = true, default-features = true }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus
-asset-test-utils = { version = "8.0.1" }
-emulated-integration-tests-common = { version = "4.0.0" }
-parachains-common = { version = "8.0.0" }
-cumulus-pallet-xcmp-queue = { version = "0.8.0" }
-cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], version = "0.8.1" }
+asset-test-utils = { workspace = true }
+emulated-integration-tests-common = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
+cumulus-pallet-xcmp-queue = { workspace = true, default-features = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], workspace = true, default-features = true }
 
 # Local
 asset-hub-polkadot-runtime = { path = "../../../../../system-parachains/asset-hubs/asset-hub-polkadot" }

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
@@ -23,7 +23,7 @@ pallet-message-queue = { version = "32.0.0" }
 # Polkadot
 polkadot-runtime-common = { version = "8.0.1" }
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.4" }
+pallet-xcm = { version = "8.0.3" }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
@@ -9,31 +9,31 @@ publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9" }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-hex-literal = "0.4.1"
+scale-info = { features = ["derive"] , workspace = true }
+hex-literal = { workspace = true }
 
 # Substrate
-sp-core = { version = "29.0.0" }
-sp-runtime = { version = "32.0.0" }
-frame-support = { version = "29.0.0" }
-pallet-balances = { version = "29.0.0" }
-pallet-asset-conversion = { version = "11.0.0" }
-pallet-assets = { version = "30.0.0" }
-pallet-message-queue = { version = "32.0.0" }
+sp-core = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-asset-conversion = { workspace = true, default-features = true }
+pallet-assets = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.3" }
+pallet-xcm = { workspace = true, default-features = true }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus
-emulated-integration-tests-common = { version = "4.0.0" }
-parachains-common = { version = "8.0.0" }
-cumulus-pallet-xcmp-queue = { version = "0.8.0" }
+emulated-integration-tests-common = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
+cumulus-pallet-xcmp-queue = { workspace = true, default-features = true }
 
 # Bridges
-bp-messages = { version = "0.8.0" }
-pallet-bridge-messages = { version = "0.8.0" }
+bp-messages = { workspace = true, default-features = true }
+pallet-bridge-messages = { workspace = true, default-features = true }
 
 # Local
 bp-bridge-hub-kusama = { path = "../../../../../system-parachains/bridge-hubs/bridge-hub-kusama/primitives"}
@@ -45,9 +45,9 @@ kusama-system-emulated-network = { path = "../../../networks/kusama-system" }
 system-parachains-constants = { path = "../../../../../system-parachains/constants" }
 
 # Snowbridge
-snowbridge-beacon-primitives = { version = "0.1.0" }
-snowbridge-core = { version = "0.1.1" }
-snowbridge-router-primitives = { version = "0.1.0" }
-snowbridge-pallet-system = { version = "0.1.1" }
-snowbridge-pallet-outbound-queue = { version = "0.1.1" }
-snowbridge-pallet-inbound-queue-fixtures = { version = "0.9.0" }
+snowbridge-beacon-primitives = { workspace = true, default-features = true }
+snowbridge-core = { workspace = true, default-features = true }
+snowbridge-router-primitives = { workspace = true, default-features = true }
+snowbridge-pallet-system = { workspace = true, default-features = true }
+snowbridge-pallet-outbound-queue = { workspace = true, default-features = true }
+snowbridge-pallet-inbound-queue-fixtures = { workspace = true }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
@@ -23,7 +23,7 @@ pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.4" }
+pallet-xcm = { version = "8.0.3" }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
@@ -23,7 +23,7 @@ pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.4" }
+pallet-xcm = { version = "8.0.3" }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
@@ -9,31 +9,31 @@ publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9" }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-hex-literal = "0.4.1"
+scale-info = { features = ["derive"] , workspace = true }
+hex-literal = { workspace = true }
 
 # Substrate
-sp-core = { version = "29.0.0" }
-sp-runtime = { version = "32.0.0" }
-frame-support = { version = "29.0.0" }
-pallet-balances = { version = "29.0.0" }
-pallet-asset-conversion = { version = "11.0.0" }
-pallet-assets = { version = "30.0.0" }
-pallet-message-queue = { version = "32.0.0" }
+sp-core = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-asset-conversion = { workspace = true, default-features = true }
+pallet-assets = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.3" }
+pallet-xcm = { workspace = true, default-features = true }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus
-emulated-integration-tests-common = { version = "4.0.0" }
-parachains-common = { version = "8.0.0" }
-cumulus-pallet-xcmp-queue = { version = "0.8.0" }
+emulated-integration-tests-common = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
+cumulus-pallet-xcmp-queue = { workspace = true, default-features = true }
 
 # Bridges
-bp-messages = { version = "0.8.0" }
-pallet-bridge-messages = { version = "0.8.0" }
+bp-messages = { workspace = true, default-features = true }
+pallet-bridge-messages = { workspace = true, default-features = true }
 
 # Local
 bp-bridge-hub-polkadot = { path = "../../../../../system-parachains/bridge-hubs/bridge-hub-polkadot/primitives"}
@@ -45,9 +45,9 @@ polkadot-system-emulated-network = { path = "../../../networks/polkadot-system" 
 system-parachains-constants = { path = "../../../../../system-parachains/constants" }
 
 # Snowbridge
-snowbridge-beacon-primitives = { version = "0.1.0" }
-snowbridge-core = { version = "0.1.1" }
-snowbridge-router-primitives = { version = "0.1.0" }
-snowbridge-pallet-system = { version = "0.1.1" }
-snowbridge-pallet-outbound-queue = { version = "0.1.1" }
-snowbridge-pallet-inbound-queue-fixtures = { version = "0.9.0" }
+snowbridge-beacon-primitives = { workspace = true, default-features = true }
+snowbridge-core = { workspace = true, default-features = true }
+snowbridge-router-primitives = { workspace = true, default-features = true }
+snowbridge-pallet-system = { workspace = true, default-features = true }
+snowbridge-pallet-outbound-queue = { workspace = true, default-features = true }
+snowbridge-pallet-inbound-queue-fixtures = { workspace = true }

--- a/integration-tests/emulated/tests/collectives/collectives-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/collectives/collectives-polkadot/Cargo.toml
@@ -9,30 +9,30 @@ publish = false
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9" }
-assert_matches = "1.5.0"
+assert_matches = { workspace = true }
 
 # Substrate
-sp-runtime = { version = "32.0.0" }
-frame-support = { version = "29.0.0" }
-pallet-balances = { version = "29.0.0" }
-pallet-asset-rate = { version = "8.0.0" }
-pallet-assets = { version = "30.0.0" }
-pallet-treasury = { version = "28.0.0" }
-pallet-message-queue = { version = "32.0.0" }
-pallet-utility = { version = "29.0.0" }
+sp-runtime = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-asset-rate = { workspace = true, default-features = true }
+pallet-assets = { workspace = true, default-features = true }
+pallet-treasury = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
+pallet-utility = { workspace = true, default-features = true }
 
 # Polkadot
-polkadot-runtime-common = { version = "8.0.1" }
+polkadot-runtime-common = { workspace = true, default-features = true }
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.3" }
+pallet-xcm = { workspace = true, default-features = true }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus
-asset-test-utils = { version = "8.0.1" }
-emulated-integration-tests-common = { version = "4.0.0" }
-parachains-common = { version = "8.0.0" }
-cumulus-pallet-xcmp-queue = { version = "0.8.0" }
-cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], version = "0.8.1" }
+asset-test-utils = { workspace = true }
+emulated-integration-tests-common = { workspace = true }
+parachains-common = { workspace = true, default-features = true }
+cumulus-pallet-xcmp-queue = { workspace = true, default-features = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], workspace = true, default-features = true }
 
 # Local
 asset-hub-polkadot-runtime = { path = "../../../../../system-parachains/asset-hubs/asset-hub-polkadot" }

--- a/integration-tests/emulated/tests/collectives/collectives-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/collectives/collectives-polkadot/Cargo.toml
@@ -24,7 +24,7 @@ pallet-utility = { version = "29.0.0" }
 # Polkadot
 polkadot-runtime-common = { version = "8.0.1" }
 xcm = { package = "staging-xcm", version = "8.0.1" }
-pallet-xcm = { version = "8.0.4" }
+pallet-xcm = { version = "8.0.3" }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/people/people-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/people/people-kusama/Cargo.toml
@@ -11,22 +11,22 @@ publish = false
 codec = { package = "parity-scale-codec", version = "3.6.9" }
 
 # Substrate
-sp-runtime = { version = "32.0.0" }
-frame-support = { version = "29.0.0" }
-pallet-balances = { version = "29.0.0" }
-pallet-message-queue = { version = "32.0.0" }
-pallet-identity = { version = "29.0.0" }
+sp-runtime = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
+pallet-identity = { workspace = true, default-features = true }
 
 # Polkadot
-polkadot-runtime-common = { version = "8.0.1" }
+polkadot-runtime-common = { workspace = true, default-features = true }
 xcm = { package = "staging-xcm", version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-parachains-common = { version = "8.0.0" }
-emulated-integration-tests-common = { version = "4.0.0" }
-asset-test-utils = { version = "8.0.1" }
-cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], version = "0.8.1" }
+parachains-common = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
+asset-test-utils = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook"], workspace = true, default-features = true }
 
 # Local
 kusama-runtime-constants = { path = "../../../../../relay/kusama/constants" }

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -9,89 +9,89 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-parity-scale-codec = { version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-log = { version = "0.4.20", default-features = false }
+parity-scale-codec = { features = ["derive", "max-encoded-len"] , workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
+log = { workspace = true }
 
 authority-discovery-primitives = { package = "sp-authority-discovery", default-features = false , version = "27.0.0" }
 babe-primitives = { package = "sp-consensus-babe", default-features = false , version = "0.33.0" }
 beefy-primitives = { package = "sp-consensus-beefy", default-features = false , version = "14.0.0" }
-binary-merkle-tree = { default-features = false , version = "14.0.0" }
+binary-merkle-tree = { workspace = true }
 kusama-runtime-constants = { package = "kusama-runtime-constants", path = "constants", default-features = false }
-sp-api = { default-features = false , version = "27.0.0" }
+sp-api = { workspace = true }
 inherents = { package = "sp-inherents", default-features = false , version = "27.0.0" }
 offchain-primitives = { package = "sp-offchain", default-features = false , version = "27.0.0" }
-sp-std = { package = "sp-std", default-features = false , version = "14.0.0" }
-sp-application-crypto = { default-features = false , version = "31.0.0" }
-sp-arithmetic = { default-features = false , version = "24.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-io = { default-features = false , version = "31.0.0" }
-sp-runtime = { default-features = false , version = "32.0.0" }
-sp-staking = { default-features = false , version = "27.0.0" }
-sp-core = { default-features = false , version = "29.0.0" }
-sp-session = { default-features = false , version = "28.0.0" }
-sp-storage = { default-features = false , version = "20.0.0" }
-sp-version = { default-features = false , version = "30.0.0" }
+sp-std = { package = "sp-std", workspace = true }
+sp-application-crypto = { workspace = true }
+sp-arithmetic = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+sp-core = { workspace = true }
+sp-session = { workspace = true }
+sp-storage = { workspace = true }
+sp-version = { workspace = true }
 tx-pool-api = { package = "sp-transaction-pool", default-features = false , version = "27.0.0" }
 block-builder-api = { package = "sp-block-builder", default-features = false , version = "27.0.0" }
-sp-npos-elections = { default-features = false , version = "27.0.0" }
+sp-npos-elections = { workspace = true }
 
-pallet-asset-rate = { default-features = false , version = "8.0.0" }
-pallet-authority-discovery = { default-features = false , version = "29.0.1" }
-pallet-authorship = { default-features = false , version = "29.0.0" }
-pallet-babe = { default-features = false , version = "29.0.0" }
-pallet-bags-list = { default-features = false , version = "28.0.0" }
-pallet-balances = { default-features = false , version = "29.0.0" }
-pallet-beefy = { default-features = false , version = "29.0.0" }
-pallet-beefy-mmr = { default-features = false , version = "29.0.0" }
-pallet-bounties = { default-features = false , version = "28.0.0" }
-pallet-child-bounties = { default-features = false , version = "28.0.0" }
-pallet-transaction-payment = { default-features = false , version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false , version = "29.0.0" }
-pallet-nomination-pools-runtime-api = { default-features = false , version = "24.0.0" }
-pallet-conviction-voting = { default-features = false , version = "29.0.0" }
-pallet-election-provider-multi-phase = { default-features = false , version = "28.0.0" }
-pallet-fast-unstake = { default-features = false , version = "28.0.0" }
-frame-executive = { default-features = false , version = "29.0.0" }
-pallet-grandpa = { default-features = false , version = "29.0.0" }
-pallet-nis = { default-features = false , version = "29.0.0" }
-pallet-identity = { default-features = false , version = "29.0.0" }
-pallet-indices = { default-features = false , version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-mmr = { default-features = false , version = "28.0.0" }
-pallet-multisig = { default-features = false , version = "29.0.0" }
-pallet-nomination-pools = { default-features = false , version = "26.0.0" }
-pallet-offences = { default-features = false , version = "28.0.0" }
-pallet-preimage = { default-features = false , version = "29.0.0" }
-pallet-proxy = { default-features = false , version = "29.0.0" }
-pallet-ranked-collective = { default-features = false , version = "29.0.0" }
-pallet-recovery = { default-features = false , version = "29.0.0" }
-pallet-referenda = { default-features = false , version = "29.0.0" }
-pallet-scheduler = { default-features = false , version = "30.0.0" }
-pallet-session = { default-features = false , version = "29.0.0" }
-pallet-society = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false , features = [ "tuples-96" ] , version = "29.0.0" }
-pallet-staking = { default-features = false , version = "29.0.0" }
-pallet-staking-runtime-api = { default-features = false , version = "15.0.0" }
-frame-system = { default-features = false , version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false , version = "27.0.0" }
-pallet-timestamp = { default-features = false , version = "28.0.0" }
-pallet-treasury = { default-features = false , version = "28.0.0" }
-pallet-utility = { default-features = false , version = "29.0.0" }
-pallet-vesting = { default-features = false , version = "29.0.0" }
-pallet-whitelist = { default-features = false , version = "28.0.0" }
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
-frame-election-provider-support = { default-features = false , version = "29.0.0" }
+pallet-asset-rate = { workspace = true }
+pallet-authority-discovery = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-babe = { workspace = true }
+pallet-bags-list = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-beefy = { workspace = true }
+pallet-beefy-mmr = { workspace = true }
+pallet-bounties = { workspace = true }
+pallet-child-bounties = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-nomination-pools-runtime-api = { workspace = true }
+pallet-conviction-voting = { workspace = true }
+pallet-election-provider-multi-phase = { workspace = true }
+pallet-fast-unstake = { workspace = true }
+frame-executive = { workspace = true }
+pallet-grandpa = { workspace = true }
+pallet-nis = { workspace = true }
+pallet-identity = { workspace = true }
+pallet-indices = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-mmr = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-nomination-pools = { workspace = true }
+pallet-offences = { workspace = true }
+pallet-preimage = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-ranked-collective = { workspace = true }
+pallet-recovery = { workspace = true }
+pallet-referenda = { workspace = true }
+pallet-scheduler = { workspace = true }
+pallet-session = { workspace = true }
+pallet-society = { workspace = true }
+frame-support = { features = [ "tuples-96" ] , workspace = true }
+pallet-staking = { workspace = true }
+pallet-staking-runtime-api = { workspace = true }
+frame-system = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-treasury = { workspace = true }
+pallet-utility = { workspace = true }
+pallet-vesting = { workspace = true }
+pallet-whitelist = { workspace = true }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
+frame-election-provider-support = { workspace = true }
 
-frame-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-frame-try-runtime = { default-features = false, optional = true , version = "0.35.0" }
-pallet-offences-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-pallet-session-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-pallet-nomination-pools-benchmarking = { default-features = false, optional = true , version = "27.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-pallet-election-provider-support-benchmarking = { default-features = false, optional = true , version = "28.0.0" }
-hex-literal = "0.4.1"
+frame-benchmarking = { optional = true , workspace = true }
+frame-try-runtime = { optional = true , workspace = true }
+pallet-offences-benchmarking = { optional = true , workspace = true }
+pallet-session-benchmarking = { optional = true , workspace = true }
+pallet-nomination-pools-benchmarking = { optional = true , workspace = true }
+frame-system-benchmarking = { optional = true , workspace = true }
+pallet-election-provider-support-benchmarking = { optional = true , workspace = true }
+hex-literal = { workspace = true }
 
 runtime-common = { package = "polkadot-runtime-common", default-features = false, version = "8.0.1" }
 runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false , version = "8.0.1" }
@@ -101,19 +101,19 @@ xcm = { package = "staging-xcm", default-features = false , version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false , version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
 
-sp-debug-derive = { default-features = false, version = "14.0.0" }
+sp-debug-derive = { workspace = true }
 
 [dev-dependencies]
 keyring = { package = "sp-keyring", version = "32.0.0" }
-sp-trie = { version = "30.0.0" }
-separator = "0.4.1"
-serde_json = "1.0.113"
+sp-trie = { workspace = true }
+separator = { workspace = true }
+serde_json = { workspace = true }
 remote-externalities = { package = "frame-remote-externalities", version = "0.36.0" }
-tokio = { version = "1.36.0", features = ["macros"] }
-sp-tracing = { default-features = false , version = "16.0.0" }
+tokio = { features = ["macros"] , workspace = true }
+sp-tracing = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "18.0.0" }
+substrate-wasm-builder = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -80,7 +80,7 @@ pallet-treasury = { default-features = false , version = "28.0.0" }
 pallet-utility = { default-features = false , version = "29.0.0" }
 pallet-vesting = { default-features = false , version = "29.0.0" }
 pallet-whitelist = { default-features = false , version = "28.0.0" }
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 frame-election-provider-support = { default-features = false , version = "29.0.0" }
 

--- a/relay/kusama/constants/Cargo.toml
+++ b/relay/kusama/constants/Cargo.toml
@@ -7,14 +7,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-smallvec = "1.13.1"
+smallvec = { workspace = true }
 
-frame-support = { default-features = false , version = "29.0.0" }
+frame-support = { workspace = true }
 primitives = { package = "polkadot-primitives", default-features = false , version = "8.0.1" }
 runtime-common = { package = "polkadot-runtime-common", default-features = false , version = "8.0.1" }
-sp-runtime = { default-features = false , version = "32.0.0" }
-sp-weights = { default-features = false , version = "28.0.0" }
-sp-core = { default-features = false , version = "29.0.0" }
+sp-runtime = { workspace = true }
+sp-weights = { workspace = true }
+sp-core = { workspace = true }
 
 xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
 

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -8,87 +8,87 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-parity-scale-codec = { version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-log = { version = "0.4.20", default-features = false }
+parity-scale-codec = { features = ["derive", "max-encoded-len"] , workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
+log = { workspace = true }
 
 authority-discovery-primitives = { package = "sp-authority-discovery", default-features = false , version = "27.0.0" }
 babe-primitives = { package = "sp-consensus-babe", default-features = false , version = "0.33.0" }
 beefy-primitives = { package = "sp-consensus-beefy", default-features = false , version = "14.0.0" }
-binary-merkle-tree = { default-features = false , version = "14.0.0" }
+binary-merkle-tree = { workspace = true }
 block-builder-api = { package = "sp-block-builder", default-features = false , version = "27.0.0" }
 inherents = { package = "sp-inherents", default-features = false , version = "27.0.0" }
 offchain-primitives = { package = "sp-offchain", default-features = false , version = "27.0.0" }
 tx-pool-api = { package = "sp-transaction-pool", default-features = false , version = "27.0.0" }
-sp-arithmetic = { default-features = false , version = "24.0.0" }
-sp-api = { default-features = false , version = "27.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-std = { default-features = false , version = "14.0.0" }
-sp-application-crypto = { default-features = false , version = "31.0.0" }
-sp-io = { default-features = false , version = "31.0.0" }
-sp-runtime = { default-features = false , version = "32.0.0" }
-sp-staking = { default-features = false , version = "27.0.0" }
-sp-core = { default-features = false , version = "29.0.0" }
-sp-session = { default-features = false , version = "28.0.0" }
-sp-storage = { default-features = false , version = "20.0.0" }
-sp-version = { default-features = false , version = "30.0.0" }
-sp-npos-elections = { default-features = false , version = "27.0.0" }
+sp-arithmetic = { workspace = true }
+sp-api = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-std = { workspace = true }
+sp-application-crypto = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+sp-core = { workspace = true }
+sp-session = { workspace = true }
+sp-storage = { workspace = true }
+sp-version = { workspace = true }
+sp-npos-elections = { workspace = true }
 
-pallet-asset-rate = { default-features = false , version = "8.0.0" }
-pallet-authority-discovery = { default-features = false , version = "29.0.1" }
-pallet-authorship = { default-features = false , version = "29.0.0" }
-pallet-babe = { default-features = false , version = "29.0.0" }
-pallet-bags-list = { default-features = false , version = "28.0.0" }
-pallet-balances = { default-features = false , version = "29.0.0" }
-pallet-beefy = { default-features = false , version = "29.0.0" }
-pallet-beefy-mmr = { default-features = false , version = "29.0.0" }
-pallet-bounties = { default-features = false , version = "28.0.0" }
-pallet-child-bounties = { default-features = false , version = "28.0.0" }
-pallet-transaction-payment = { default-features = false , version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false , version = "29.0.0" }
-pallet-conviction-voting = { default-features = false , version = "29.0.0" }
-pallet-election-provider-multi-phase = { default-features = false , version = "28.0.0" }
-pallet-fast-unstake = { default-features = false , version = "28.0.0" }
-frame-executive = { default-features = false , version = "29.0.0" }
-pallet-grandpa = { default-features = false , version = "29.0.0" }
-pallet-identity = { default-features = false , version = "29.0.0" }
-pallet-indices = { default-features = false , version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-mmr = { default-features = false , version = "28.0.0" }
-pallet-multisig = { default-features = false , version = "29.0.0" }
-pallet-nomination-pools = { default-features = false , version = "26.0.0" }
-pallet-nomination-pools-runtime-api = { default-features = false , version = "24.0.0" }
-pallet-offences = { default-features = false , version = "28.0.0" }
-pallet-preimage = { default-features = false , version = "29.0.0" }
-pallet-proxy = { default-features = false , version = "29.0.0" }
-pallet-referenda = { default-features = false , version = "29.0.0" }
-pallet-scheduler = { default-features = false , version = "30.0.0" }
-pallet-session = { default-features = false , version = "29.0.0" }
-frame-support = { default-features = false , version = "29.0.0" }
-pallet-staking = { default-features = false , version = "29.0.0" }
-pallet-staking-reward-fn = { default-features = false, version = "20.0.0" }
-pallet-staking-reward-curve = { version = "11.0.0" }
-pallet-staking-runtime-api = { default-features = false , version = "15.0.0" }
-pallet-state-trie-migration = { default-features = false , version = "30.0.0" }
-frame-system = { default-features = false , version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false , version = "27.0.0" }
+pallet-asset-rate = { workspace = true }
+pallet-authority-discovery = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-babe = { workspace = true }
+pallet-bags-list = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-beefy = { workspace = true }
+pallet-beefy-mmr = { workspace = true }
+pallet-bounties = { workspace = true }
+pallet-child-bounties = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-conviction-voting = { workspace = true }
+pallet-election-provider-multi-phase = { workspace = true }
+pallet-fast-unstake = { workspace = true }
+frame-executive = { workspace = true }
+pallet-grandpa = { workspace = true }
+pallet-identity = { workspace = true }
+pallet-indices = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-mmr = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-nomination-pools = { workspace = true }
+pallet-nomination-pools-runtime-api = { workspace = true }
+pallet-offences = { workspace = true }
+pallet-preimage = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-referenda = { workspace = true }
+pallet-scheduler = { workspace = true }
+pallet-session = { workspace = true }
+frame-support = { workspace = true }
+pallet-staking = { workspace = true }
+pallet-staking-reward-fn = { workspace = true }
+pallet-staking-reward-curve = { workspace = true }
+pallet-staking-runtime-api = { workspace = true }
+pallet-state-trie-migration = { workspace = true }
+frame-system = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
 polkadot-runtime-constants = { package = "polkadot-runtime-constants", path = "constants", default-features = false }
-pallet-timestamp = { default-features = false , version = "28.0.0" }
-pallet-treasury = { default-features = false , version = "28.0.0" }
-pallet-whitelist = { default-features = false , version = "28.0.0" }
-pallet-vesting = { default-features = false , version = "29.0.0" }
-pallet-utility = { default-features = false , version = "29.0.0" }
-frame-election-provider-support = { default-features = false , version = "29.0.0" }
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
+pallet-timestamp = { workspace = true }
+pallet-treasury = { workspace = true }
+pallet-whitelist = { workspace = true }
+pallet-vesting = { workspace = true }
+pallet-utility = { workspace = true }
+frame-election-provider-support = { workspace = true }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
 
-frame-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-frame-try-runtime = { default-features = false, optional = true , version = "0.35.0" }
-frame-system-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-pallet-election-provider-support-benchmarking = { default-features = false, optional = true , version = "28.0.0" }
-pallet-offences-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-pallet-session-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-pallet-nomination-pools-benchmarking = { default-features = false, optional = true , version = "27.0.0" }
+frame-benchmarking = { optional = true , workspace = true }
+frame-try-runtime = { optional = true , workspace = true }
+frame-system-benchmarking = { optional = true , workspace = true }
+pallet-election-provider-support-benchmarking = { optional = true , workspace = true }
+pallet-offences-benchmarking = { optional = true , workspace = true }
+pallet-session-benchmarking = { optional = true , workspace = true }
+pallet-nomination-pools-benchmarking = { optional = true , workspace = true }
 
 runtime-common = { package = "polkadot-runtime-common", default-features = false, version = "8.0.1" }
 runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false , version = "8.0.1" }
@@ -98,19 +98,19 @@ xcm = { package = "staging-xcm", default-features = false , version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false , version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
 
-sp-debug-derive = { default-features = false, version = "14.0.0" }
+sp-debug-derive = { workspace = true }
 
 [dev-dependencies]
 keyring = { package = "sp-keyring", version = "32.0.0" }
-sp-trie = { version = "30.0.0" }
-serde_json = "1.0.113"
-separator = "0.4.1"
+sp-trie = { workspace = true }
+serde_json = { workspace = true }
+separator = { workspace = true }
 remote-externalities = { package = "frame-remote-externalities", version = "0.36.0" }
-tokio = { version = "1.36.0", features = ["macros"] }
-sp-tracing = { default-features = false , version = "16.0.0" }
+tokio = { features = ["macros"] , workspace = true }
+sp-tracing = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "18.0.0" }
+substrate-wasm-builder = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -79,7 +79,7 @@ pallet-whitelist = { default-features = false , version = "28.0.0" }
 pallet-vesting = { default-features = false , version = "29.0.0" }
 pallet-utility = { default-features = false , version = "29.0.0" }
 frame-election-provider-support = { default-features = false , version = "29.0.0" }
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 
 frame-benchmarking = { default-features = false, optional = true , version = "29.0.0" }

--- a/relay/polkadot/constants/Cargo.toml
+++ b/relay/polkadot/constants/Cargo.toml
@@ -7,14 +7,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-smallvec = "1.13.1"
+smallvec = { workspace = true }
 
-frame-support = { default-features = false , version = "29.0.0" }
+frame-support = { workspace = true }
 primitives = { package = "polkadot-primitives", default-features = false , version = "8.0.1" }
 runtime-common = { package = "polkadot-runtime-common", default-features = false , version = "8.0.1" }
-sp-runtime = { default-features = false , version = "32.0.0" }
-sp-weights = { default-features = false , version = "28.0.0" }
-sp-core = { default-features = false , version = "29.0.0" }
+sp-runtime = { workspace = true }
+sp-weights = { workspace = true }
+sp-core = { workspace = true }
 
 xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
 

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -10,9 +10,9 @@ version.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-hex-literal = { version = "0.4.1" }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+hex-literal = { workspace = true }
+log = { workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
 
 # Local
 bp-asset-hub-kusama = { path = "./primitives", default-features = false}
@@ -23,86 +23,86 @@ kusama-runtime-constants = { path = "../../../relay/kusama/constants", default-f
 polkadot-runtime-constants = { path = "../../../relay/polkadot/constants", default-features = false}
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-asset-conversion-tx-payment = { default-features = false, version = "11.0.0" }
-pallet-assets = { default-features = false, version = "30.0.0" }
-pallet-asset-conversion = { default-features = false, version = "11.0.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-authorship = { default-features = false, version = "29.0.0" }
-pallet-balances = { default-features = false, version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-multisig = { default-features = false, version = "29.0.0" }
-pallet-nft-fractionalization = { default-features = false, version = "11.0.0" }
-pallet-nfts = { default-features = false, version = "23.0.0" }
-pallet-nfts-runtime-api = { default-features = false, version = "15.0.0" }
-pallet-proxy = { default-features = false, version = "29.0.0" }
-pallet-session = { default-features = false, version = "29.0.0" }
-pallet-state-trie-migration = { default-features = false, optional = true , version = "30.0.0" }
-pallet-timestamp = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment = { default-features = false, version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
-pallet-uniques = { default-features = false, version = "29.0.0" }
-pallet-utility = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
-sp-weights = { default-features = false, version = "28.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-asset-conversion-tx-payment = { workspace = true }
+pallet-assets = { workspace = true }
+pallet-asset-conversion = { workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-nft-fractionalization = { workspace = true }
+pallet-nfts = { workspace = true }
+pallet-nfts-runtime-api = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-session = { workspace = true }
+pallet-state-trie-migration = { optional = true , workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-uniques = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
+sp-weights = { workspace = true }
 # num-traits feature needed for dex integer sq root:
-primitive-types = { version = "0.12.2", default-features = false, features = ["codec", "scale-info", "num-traits"] }
+primitive-types = { features = ["codec", "scale-info", "num-traits"] , workspace = true }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-pallet-aura-ext = { default-features = false , version = "0.8.0" }
-cumulus-pallet-dmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-session-benchmarking = { default-features = false, version = "10.0.0" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false , features = ["bridging"] , version = "0.8.0" }
-cumulus-primitives-aura = { default-features = false , version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-pallet-collator-selection = { default-features = false , version = "10.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-session-benchmarking = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { features = ["bridging"] , workspace = true }
+cumulus-primitives-aura = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+pallet-collator-selection = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 system-parachains-constants = { path = "../../constants", default-features = false }
-assets-common = { default-features = false , version = "0.8.0" }
+assets-common = { workspace = true }
 
 # Bridges
-pallet-xcm-bridge-hub-router = { default-features = false , version = "0.6.0" }
-snowbridge-router-primitives = { default-features = false , version = "0.1.0" }
+pallet-xcm-bridge-hub-router = { workspace = true }
+snowbridge-router-primitives = { workspace = true }
 
 [dev-dependencies]
-asset-test-utils = { version = "8.0.1" }
-parachains-runtimes-test-utils = { version = "8.0.0" }
-sp-io = { version = "31.0.0" }
+asset-test-utils = { workspace = true }
+parachains-runtimes-test-utils = { workspace = true }
+sp-io = { workspace = true, default-features = true }
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , version = "18.0.0" }
+substrate-wasm-builder = { optional = true , workspace = true }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -67,7 +67,7 @@ sp-weights = { default-features = false, version = "28.0.0" }
 primitive-types = { version = "0.12.2", default-features = false, features = ["codec", "scale-info", "num-traits"] }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }

--- a/system-parachains/asset-hubs/asset-hub-kusama/primitives/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/primitives/Cargo.toml
@@ -9,17 +9,17 @@ license.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { features = ["derive"] , workspace = true }
 
 # Local
 system-parachains-constants = { path = "../../../constants", default-features = false }
 
 # Bridge Dependencies
-bp-xcm-bridge-hub-router = { default-features = false , version = "0.7.0" }
+bp-xcm-bridge-hub-router = { workspace = true }
 
 # Substrate Based Dependencies
-frame-support = { default-features = false, version = "29.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
+frame-support = { workspace = true }
+sp-std = { workspace = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -10,9 +10,9 @@ version.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-hex-literal = { version = "0.4.1", optional = true }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+hex-literal = { optional = true , workspace = true }
+log = { workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
 
 # Local
 bp-asset-hub-kusama = { path = "../asset-hub-kusama/primitives", default-features = false}
@@ -24,85 +24,85 @@ kusama-runtime-constants = { path = "../../../relay/kusama/constants", default-f
 polkadot-runtime-constants = { path = "../../../relay/polkadot/constants", default-features = false}
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-asset-conversion-tx-payment = { default-features = false, version = "11.0.0" }
-pallet-asset-conversion = { default-features = false, version = "11.0.0" }
-pallet-assets = { default-features = false, version = "30.0.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-authorship = { default-features = false, version = "29.0.0" }
-pallet-balances = { default-features = false, version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-multisig = { default-features = false, version = "29.0.0" }
-pallet-nfts = { default-features = false, version = "23.0.0" }
-pallet-nfts-runtime-api = { default-features = false, version = "15.0.0" }
-pallet-proxy = { default-features = false, version = "29.0.0" }
-pallet-session = { default-features = false, version = "29.0.0" }
-pallet-timestamp = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment = { default-features = false, version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
-pallet-uniques = { default-features = false, version = "29.0.0" }
-pallet-utility = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-io = { default-features = false , version = "31.0.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
-sp-weights = { default-features = false, version = "28.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-asset-conversion-tx-payment = { workspace = true }
+pallet-asset-conversion = { workspace = true }
+pallet-assets = { workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-nfts = { workspace = true }
+pallet-nfts-runtime-api = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-uniques = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-io = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
+sp-weights = { workspace = true }
 # num-traits feature needed for dex integer sq root:
-primitive-types = { version = "0.12.2", default-features = false, features = ["codec", "scale-info", "num-traits"] }
+primitive-types = { features = ["codec", "scale-info", "num-traits"] , workspace = true }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-pallet-aura-ext = { default-features = false , version = "0.8.0" }
-cumulus-pallet-dmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-session-benchmarking = { default-features = false, version = "10.0.0" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false , features = ["bridging"] , version = "0.8.0" }
-cumulus-primitives-aura = { default-features = false , version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-pallet-collator-selection = { default-features = false , version = "10.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-session-benchmarking = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { features = ["bridging"] , workspace = true }
+cumulus-primitives-aura = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+pallet-collator-selection = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 system-parachains-constants = { path = "../../constants", default-features = false }
-assets-common = { default-features = false , version = "0.8.0" }
+assets-common = { workspace = true }
 
 # Bridges
-pallet-xcm-bridge-hub-router = { default-features = false , version = "0.6.0" }
-snowbridge-router-primitives = { default-features = false, version = "0.1.0" }
+pallet-xcm-bridge-hub-router = { workspace = true }
+snowbridge-router-primitives = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.4.1"
-asset-test-utils = { version = "8.0.1" }
-parachains-runtimes-test-utils = { version = "8.0.0" }
+hex-literal = { workspace = true }
+asset-test-utils = { workspace = true }
+parachains-runtimes-test-utils = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , version = "18.0.0" }
+substrate-wasm-builder = { optional = true , workspace = true }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -67,7 +67,7 @@ sp-weights = { default-features = false, version = "28.0.0" }
 primitive-types = { version = "0.12.2", default-features = false, features = ["codec", "scale-info", "num-traits"] }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/primitives/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/primitives/Cargo.toml
@@ -9,17 +9,17 @@ license.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { features = ["derive"] , workspace = true }
 
 # Local
 system-parachains-constants = { path = "../../../constants", default-features = false }
 
 # Bridge Dependencies
-bp-xcm-bridge-hub-router = { default-features = false , version = "0.7.0" }
+bp-xcm-bridge-hub-router = { workspace = true }
 
 # Substrate Based Dependencies
-frame-support = { default-features = false, version = "29.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
+frame-support = { workspace = true }
+sp-std = { workspace = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -9,14 +9,14 @@ repository.workspace = true
 version.workspace = true
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , version = "18.0.0" }
+substrate-wasm-builder = { optional = true , workspace = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
-hex-literal = { version = "0.4.1" }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.196", optional = true, features = ["derive"] }
+hex-literal = { workspace = true }
+log = { workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
+serde = { optional = true, features = ["derive"] , workspace = true }
 
 # Local
 bp-asset-hub-kusama = { path = "../../asset-hubs/asset-hub-kusama/primitives", default-features = false}
@@ -27,99 +27,99 @@ kusama-runtime-constants = { path = "../../../relay/kusama/constants", default-f
 polkadot-runtime-constants = { path = "../../../relay/polkadot/constants", default-features = false}
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-authorship = { default-features = false, version = "29.0.0" }
-pallet-balances = { default-features = false, version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-multisig = { default-features = false, version = "29.0.0" }
-pallet-session = { default-features = false, version = "29.0.0" }
-pallet-timestamp = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment = { default-features = false, version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
-pallet-utility = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-io = { default-features = false, version = "31.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-inherents = { workspace = true }
+sp-io = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-pallet-aura-ext = { default-features = false , version = "0.8.0" }
-cumulus-pallet-dmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-session-benchmarking = { default-features = false, version = "10.0.0" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false , features = ["bridging"] , version = "0.8.0" }
-cumulus-primitives-aura = { default-features = false , version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-pallet-collator-selection = { default-features = false , version = "10.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-session-benchmarking = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { features = ["bridging"] , workspace = true }
+cumulus-primitives-aura = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+pallet-collator-selection = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 system-parachains-constants = { path = "../../constants", default-features = false }
 
 # Bridges
-bp-header-chain = { default-features = false , version = "0.8.0" }
-bp-messages = { default-features = false , version = "0.8.0" }
-bp-parachains = { default-features = false , version = "0.8.0" }
-bp-polkadot-core = { default-features = false , version = "0.8.0" }
-bp-relayers = { default-features = false , version = "0.8.0" }
-bp-runtime = { default-features = false , version = "0.8.0" }
-bp-kusama = { default-features = false , version = "0.6.0" }
-bp-polkadot = { default-features = false , version = "0.6.0" }
-bridge-hub-common = { default-features = false , version = "0.1.0" }
-bridge-runtime-common = { default-features = false , version = "0.8.0" }
-pallet-bridge-grandpa = { default-features = false , version = "0.8.0" }
-pallet-bridge-messages = { default-features = false , version = "0.8.0" }
-pallet-bridge-parachains = { default-features = false , version = "0.8.0" }
-pallet-bridge-relayers = { default-features = false , version = "0.8.0" }
-pallet-xcm-bridge-hub =  { default-features = false , version = "0.3.0" }
+bp-header-chain = { workspace = true }
+bp-messages = { workspace = true }
+bp-parachains = { workspace = true }
+bp-polkadot-core = { workspace = true }
+bp-relayers = { workspace = true }
+bp-runtime = { workspace = true }
+bp-kusama = { workspace = true }
+bp-polkadot = { workspace = true }
+bridge-hub-common = { workspace = true }
+bridge-runtime-common = { workspace = true }
+pallet-bridge-grandpa = { workspace = true }
+pallet-bridge-messages = { workspace = true }
+pallet-bridge-parachains = { workspace = true }
+pallet-bridge-relayers = { workspace = true }
+pallet-xcm-bridge-hub =  { workspace = true }
 
 # Ethereum Bridge (Snowbridge)
-snowbridge-beacon-primitives = { default-features = false , version = "0.1.0" }
-snowbridge-pallet-system = { default-features = false , version = "0.1.1" }
-snowbridge-system-runtime-api = { default-features = false , version = "0.1.0" }
-snowbridge-core = { default-features = false , version = "0.1.1" }
-snowbridge-pallet-ethereum-client = { default-features = false , version = "0.1.1" }
-snowbridge-pallet-inbound-queue = { default-features = false , version = "0.1.1" }
-snowbridge-pallet-outbound-queue = { default-features = false , version = "0.1.1" }
-snowbridge-outbound-queue-runtime-api = { default-features = false , version = "0.1.1" }
-snowbridge-router-primitives = { default-features = false , version = "0.1.0" }
-snowbridge-runtime-common = { default-features = false, version = "0.1.0" }
+snowbridge-beacon-primitives = { workspace = true }
+snowbridge-pallet-system = { workspace = true }
+snowbridge-system-runtime-api = { workspace = true }
+snowbridge-core = { workspace = true }
+snowbridge-pallet-ethereum-client = { workspace = true }
+snowbridge-pallet-inbound-queue = { workspace = true }
+snowbridge-pallet-outbound-queue = { workspace = true }
+snowbridge-outbound-queue-runtime-api = { workspace = true }
+snowbridge-router-primitives = { workspace = true }
+snowbridge-runtime-common = { workspace = true }
 
 [dev-dependencies]
-bridge-hub-test-utils = { version = "0.8.0" }
-bridge-runtime-common = { version = "0.8.0", features = ["integrity-test"] }
-sp-keyring = { version = "32.0.0" }
-static_assertions = { version = "1.1.0" }
-snowbridge-runtime-test-common = { version = "0.1.0" }
-parachains-runtimes-test-utils = { version = "8.0.0" }
+bridge-hub-test-utils = { workspace = true }
+bridge-runtime-common = { features = ["integrity-test"] , workspace = true, default-features = true }
+sp-keyring = { workspace = true }
+static_assertions = { workspace = true }
+snowbridge-runtime-test-common = { workspace = true }
+parachains-runtimes-test-utils = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -60,7 +60,7 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/primitives/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/primitives/Cargo.toml
@@ -15,16 +15,16 @@ polkadot-runtime-constants = { path = "../../../../relay/polkadot/constants", de
 system-parachains-constants = { path = "../../../constants", default-features = false }
 
 # Bridge Dependencies
-bp-bridge-hub-cumulus = { default-features = false , version = "0.8.0" }
-bp-runtime = { default-features = false , version = "0.8.0" }
-bp-messages = { default-features = false , version = "0.8.0" }
-snowbridge-core = { default-features = false , version = "0.1.1" }
+bp-bridge-hub-cumulus = { workspace = true }
+bp-runtime = { workspace = true }
+bp-messages = { workspace = true }
+snowbridge-core = { workspace = true }
 
 # Substrate Based Dependencies
-frame-support = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-std = { default-features = false , version = "14.0.0" }
+frame-support = { workspace = true }
+sp-api = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -9,14 +9,14 @@ repository.workspace = true
 version.workspace = true
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , version = "18.0.0" }
+substrate-wasm-builder = { optional = true , workspace = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
-hex-literal = { version = "0.4.1" }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.196", optional = true, features = ["derive"] }
+hex-literal = { workspace = true }
+log = { workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
+serde = { optional = true, features = ["derive"] , workspace = true }
 
 # Local
 bp-asset-hub-kusama = { path = "../../asset-hubs/asset-hub-kusama/primitives", default-features = false}
@@ -27,99 +27,99 @@ kusama-runtime-constants = { path = "../../../relay/kusama/constants", default-f
 polkadot-runtime-constants = { path = "../../../relay/polkadot/constants", default-features = false}
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-authorship = { default-features = false, version = "29.0.0" }
-pallet-balances = { default-features = false, version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-multisig = { default-features = false, version = "29.0.0" }
-pallet-session = { default-features = false, version = "29.0.0" }
-pallet-timestamp = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment = { default-features = false, version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
-pallet-utility = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-io = { default-features = false, version = "31.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-inherents = { workspace = true }
+sp-io = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-pallet-aura-ext = { default-features = false , version = "0.8.0" }
-cumulus-pallet-dmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-session-benchmarking = { default-features = false, version = "10.0.0" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false , features = ["bridging"] , version = "0.8.0" }
-cumulus-primitives-aura = { default-features = false , version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-pallet-collator-selection = { default-features = false , version = "10.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-session-benchmarking = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { features = ["bridging"] , workspace = true }
+cumulus-primitives-aura = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+pallet-collator-selection = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 system-parachains-constants = { path = "../../constants", default-features = false }
 
 # Bridges
-bp-header-chain = { default-features = false , version = "0.8.0" }
-bp-messages = { default-features = false , version = "0.8.0" }
-bp-parachains = { default-features = false , version = "0.8.0" }
-bp-polkadot-core = { default-features = false , version = "0.8.0" }
-bp-relayers = { default-features = false , version = "0.8.0" }
-bp-runtime = { default-features = false , version = "0.8.0" }
-bp-kusama = { default-features = false , version = "0.6.0" }
-bp-polkadot = { default-features = false , version = "0.6.0" }
-bridge-hub-common = { default-features = false , version = "0.1.0" }
-bridge-runtime-common = { default-features = false , version = "0.8.0" }
-pallet-bridge-grandpa = { default-features = false , version = "0.8.0" }
-pallet-bridge-messages = { default-features = false , version = "0.8.0" }
-pallet-bridge-parachains = { default-features = false , version = "0.8.0" }
-pallet-bridge-relayers = { default-features = false , version = "0.8.0" }
-pallet-xcm-bridge-hub =  { default-features = false , version = "0.3.0" }
+bp-header-chain = { workspace = true }
+bp-messages = { workspace = true }
+bp-parachains = { workspace = true }
+bp-polkadot-core = { workspace = true }
+bp-relayers = { workspace = true }
+bp-runtime = { workspace = true }
+bp-kusama = { workspace = true }
+bp-polkadot = { workspace = true }
+bridge-hub-common = { workspace = true }
+bridge-runtime-common = { workspace = true }
+pallet-bridge-grandpa = { workspace = true }
+pallet-bridge-messages = { workspace = true }
+pallet-bridge-parachains = { workspace = true }
+pallet-bridge-relayers = { workspace = true }
+pallet-xcm-bridge-hub =  { workspace = true }
 
 # Ethereum Bridge (Snowbridge)
-snowbridge-beacon-primitives = { default-features = false , version = "0.1.0" }
-snowbridge-pallet-system = { default-features = false , version = "0.1.1" }
-snowbridge-system-runtime-api = { default-features = false , version = "0.1.0" }
-snowbridge-core = { default-features = false , version = "0.1.1" }
-snowbridge-pallet-ethereum-client = { default-features = false , version = "0.1.1" }
-snowbridge-pallet-inbound-queue = { default-features = false , version = "0.1.1" }
-snowbridge-pallet-outbound-queue = { default-features = false , version = "0.1.1" }
-snowbridge-outbound-queue-runtime-api = { default-features = false , version = "0.1.1" }
-snowbridge-router-primitives = { default-features = false , version = "0.1.0" }
-snowbridge-runtime-common = { default-features = false, version = "0.1.0" }
+snowbridge-beacon-primitives = { workspace = true }
+snowbridge-pallet-system = { workspace = true }
+snowbridge-system-runtime-api = { workspace = true }
+snowbridge-core = { workspace = true }
+snowbridge-pallet-ethereum-client = { workspace = true }
+snowbridge-pallet-inbound-queue = { workspace = true }
+snowbridge-pallet-outbound-queue = { workspace = true }
+snowbridge-outbound-queue-runtime-api = { workspace = true }
+snowbridge-router-primitives = { workspace = true }
+snowbridge-runtime-common = { workspace = true }
 
 [dev-dependencies]
-bridge-hub-test-utils = { version = "0.8.0" }
-bridge-runtime-common = { version = "0.8.0", features = ["integrity-test"] }
-sp-keyring = { version = "32.0.0" }
-static_assertions = { version = "1.1.0" }
-snowbridge-runtime-test-common = { version = "0.1.0" }
-parachains-runtimes-test-utils = { version = "8.0.0" }
+bridge-hub-test-utils = { workspace = true }
+bridge-runtime-common = { features = ["integrity-test"] , workspace = true, default-features = true }
+sp-keyring = { workspace = true }
+static_assertions = { workspace = true }
+snowbridge-runtime-test-common = { workspace = true }
+parachains-runtimes-test-utils = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -60,7 +60,7 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/Cargo.toml
@@ -15,16 +15,16 @@ polkadot-runtime-constants = { path = "../../../../relay/polkadot/constants", de
 system-parachains-constants = { path = "../../../constants", default-features = false }
 
 # Bridge Dependencies
-bp-bridge-hub-cumulus = { default-features = false , version = "0.8.0" }
-bp-runtime = { default-features = false , version = "0.8.0" }
-bp-messages = { default-features = false , version = "0.8.0" }
-snowbridge-core = { default-features = false , version = "0.1.1" }
+bp-bridge-hub-cumulus = { workspace = true }
+bp-runtime = { workspace = true }
+bp-messages = { workspace = true }
+snowbridge-core = { workspace = true }
 
 # Substrate Based Dependencies
-frame-support = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-std = { default-features = false , version = "14.0.0" }
+frame-support = { workspace = true }
+sp-api = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }

--- a/system-parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/system-parachains/collectives/collectives-polkadot/Cargo.toml
@@ -10,84 +10,84 @@ version.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-hex-literal = { version = "0.4.1" }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+hex-literal = { workspace = true }
+log = { workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-asset-rate = { default-features = false , version = "8.0.0" }
-pallet-alliance = { default-features = false, version = "28.0.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-authorship = { default-features = false, version = "29.0.0" }
-pallet-balances = { default-features = false, version = "29.0.0" }
-pallet-collective = { default-features = false, version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-multisig = { default-features = false, version = "29.0.0" }
-pallet-preimage = { default-features = false , version = "29.0.0" }
-pallet-proxy = { default-features = false, version = "29.0.0" }
-pallet-scheduler = { default-features = false , version = "30.0.0" }
-pallet-session = { default-features = false, version = "29.0.0" }
-pallet-timestamp = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment = { default-features = false, version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
-pallet-treasury = { default-features = false , version = "28.0.0" }
-pallet-utility = { default-features = false, version = "29.0.0" }
-pallet-referenda = { default-features = false, version = "29.0.0" }
-pallet-ranked-collective = { default-features = false, version = "29.0.0" }
-pallet-core-fellowship = { default-features = false, version = "13.0.0" }
-pallet-salary = { default-features = false, version = "14.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-arithmetic = { default-features = false , version = "24.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-asset-rate = { workspace = true }
+pallet-alliance = { workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-collective = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-preimage = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-scheduler = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-treasury = { workspace = true }
+pallet-utility = { workspace = true }
+pallet-referenda = { workspace = true }
+pallet-ranked-collective = { workspace = true }
+pallet-core-fellowship = { workspace = true }
+pallet-salary = { workspace = true }
+sp-api = { workspace = true }
+sp-arithmetic = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.3" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 polkadot-runtime-constants = { path = "../../../relay/polkadot/constants", default-features = false}
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-pallet-aura-ext = { default-features = false , version = "0.8.0" }
-cumulus-pallet-dmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-session-benchmarking = { default-features = false, version = "10.0.0" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-primitives-aura = { default-features = false , version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-pallet-collator-selection = { default-features = false , version = "10.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-session-benchmarking = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-aura = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+pallet-collator-selection = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 system-parachains-constants = { path = "../../constants", default-features = false }
 
 [dev-dependencies]
 collectives-polkadot-runtime-constants = { path = "constants" }
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , version = "18.0.0" }
+substrate-wasm-builder = { optional = true , workspace = true }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/system-parachains/collectives/collectives-polkadot/Cargo.toml
@@ -59,7 +59,7 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }

--- a/system-parachains/constants/Cargo.toml
+++ b/system-parachains/constants/Cargo.toml
@@ -8,15 +8,15 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-smallvec = "1.13.1"
+smallvec = { workspace = true }
 
-frame-support = { default-features = false , version = "29.0.0" }
+frame-support = { workspace = true }
 kusama-runtime-constants = { path = "../../relay/kusama/constants", default-features = false}
-parachains-common = { default-features = false , version = "8.0.0" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0"}
-polkadot-primitives = { default-features = false , version = "8.0.1" }
+parachains-common = { workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-primitives = { workspace = true }
 polkadot-runtime-constants = { path = "../../relay/polkadot/constants", default-features = false}
-sp-runtime = { default-features = false , version = "32.0.0" }
+sp-runtime = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/coretime/coretime-kusama/Cargo.toml
+++ b/system-parachains/coretime/coretime-kusama/Cargo.toml
@@ -10,77 +10,77 @@ build = "build.rs"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
-hex-literal = "0.4.1"
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.196", optional = true, features = ["derive"] }
+hex-literal = { workspace = true }
+log = { workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
+serde = { optional = true, features = ["derive"] , workspace = true }
 
 # Local
 kusama-runtime-constants = { path = "../../../relay/kusama/constants", default-features = false}
 system-parachains-constants = { path = "../../constants", default-features = false }
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false , version = "29.0.0" }
-frame-support = { default-features = false , version = "29.0.0" }
-frame-system = { default-features = false , version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false , version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true , version = "0.35.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-authorship = { default-features = false , version = "29.0.0" }
-pallet-balances = { default-features = false , version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-broker = { version = "0.7.0", default-features = false }
-pallet-multisig = { default-features = false , version = "29.0.0" }
-pallet-proxy = { default-features = false, version = "29.0.0" }
-pallet-session = { default-features = false , version = "29.0.0" }
-pallet-timestamp = { default-features = false , version = "28.0.0" }
-pallet-transaction-payment = { default-features = false , version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false , version = "29.0.0" }
-pallet-utility = { default-features = false , version = "29.0.0" }
-sp-api = { default-features = false , version = "27.0.0" }
-sp-block-builder = { version = "27.0.0", default-features = false }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true , workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true , workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-broker = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-pallet-aura-ext = { default-features = false , version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-session-benchmarking = { default-features = false, version = "10.0.0" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-primitives-aura = { default-features = false, version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-pallet-collator-selection = { default-features = false , version = "10.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-session-benchmarking = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-aura = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+pallet-collator-selection = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 
 [dev-dependencies]
-parachains-runtimes-test-utils = { version = "8.0.0" }
+parachains-runtimes-test-utils = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , version = "18.0.0" }
+substrate-wasm-builder = { optional = true , workspace = true }
 
 [features]
 default = ["std"]

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -12,12 +12,12 @@ version.workspace = true
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = [
   "derive",
 ] }
-hex-literal = { version = "0.4.1", optional = true }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = [
+hex-literal = { optional = true , workspace = true }
+log = { workspace = true }
+scale-info = { features = [
   "derive",
-] }
-smallvec = "1.13.1"
+] , workspace = true }
+smallvec = { workspace = true }
 
 
 # Encointer pallet versioning follows these rules:
@@ -29,82 +29,82 @@ smallvec = "1.13.1"
 #    * encointer-* 6.1.x (must not be automatically updated from 6.0.x)
 # * patch: ad-lib
 #
-encointer-balances-tx-payment = { default-features = false, version = "~6.1.0" }
-encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
-encointer-primitives = { default-features = false, version = "~6.1.0" }
-pallet-encointer-balances = { default-features = false, version = "~6.1.0" }
-pallet-encointer-bazaar = { default-features = false, version = "~6.1.0" }
-pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
-pallet-encointer-ceremonies = { default-features = false, version = "~6.1.0" }
-pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
-pallet-encointer-communities = { default-features = false, version = "~6.1.0" }
-pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
-pallet-encointer-faucet = { default-features = false, version = "~6.1.0" }
-pallet-encointer-reputation-commitments = { default-features = false, version = "~6.1.0" }
-pallet-encointer-scheduler = { default-features = false, version = "~6.1.0" }
+encointer-balances-tx-payment = { workspace = true }
+encointer-balances-tx-payment-rpc-runtime-api = { workspace = true }
+encointer-primitives = { workspace = true }
+pallet-encointer-balances = { workspace = true }
+pallet-encointer-bazaar = { workspace = true }
+pallet-encointer-bazaar-rpc-runtime-api = { workspace = true }
+pallet-encointer-ceremonies = { workspace = true }
+pallet-encointer-ceremonies-rpc-runtime-api = { workspace = true }
+pallet-encointer-communities = { workspace = true }
+pallet-encointer-communities-rpc-runtime-api = { workspace = true }
+pallet-encointer-faucet = { workspace = true }
+pallet-encointer-reputation-commitments = { workspace = true }
+pallet-encointer-scheduler = { workspace = true }
 
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-asset-tx-payment = { default-features = false, version = "29.0.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-balances = { default-features = false, version = "29.0.0" }
-pallet-collective = { default-features = false, version = "29.0.0" }
-pallet-insecure-randomness-collective-flip = { default-features = false, version = "17.0.0" }
-pallet-membership = { default-features = false, version = "29.0.0" }
-pallet-message-queue = { default-features = false, version = "32.0.0" }
-pallet-proxy = { default-features = false, version = "29.0.0" }
-pallet-scheduler = { default-features = false, version = "30.0.0" }
-pallet-timestamp = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment = { default-features = false, version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
-pallet-treasury = { default-features = false, version = "28.0.0" }
-pallet-utility = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
-sp-genesis-builder = { default-features = false, version = "0.8.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-asset-tx-payment = { workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-balances = { workspace = true }
+pallet-collective = { workspace = true }
+pallet-insecure-randomness-collective-flip = { workspace = true }
+pallet-membership = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-scheduler = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-treasury = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
+sp-genesis-builder = { workspace = true }
 
 # Polkadot dependencies
-pallet-xcm = { default-features = false, version = "8.0.3" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = { default-features = false, version = "0.8.0" }
-cumulus-pallet-dmp-queue = { default-features = false, version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = [
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { features = [
   "parameterized-consensus-hook",
-], version = "0.8.1" }
-cumulus-pallet-xcm = { default-features = false, version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false, version = "0.8.0" }
-cumulus-primitives-aura = { default-features = false, version = "0.8.0" }
-cumulus-primitives-core = { default-features = false, version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false, version = "0.8.1" }
+], workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-aura = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false, version = "0.8.0" }
-parachains-common = { default-features = false, version = "8.0.0" }
-polkadot-core-primitives = { default-features = false, version = "8.0.0" }
-polkadot-primitives = { default-features = false, version = "8.0.1" }
+parachains-common = { workspace = true }
+polkadot-core-primitives = { workspace = true }
+polkadot-primitives = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true, version = "18.0.0" }
+substrate-wasm-builder = { optional = true, workspace = true }
 
 [dev-dependencies]
 # The Encointer pallets might not have compatible versions of `polkadot-sdk` with the rest of the system parachains,

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -80,7 +80,7 @@ sp-version = { default-features = false, version = "30.0.0" }
 sp-genesis-builder = { default-features = false, version = "0.8.0" }
 
 # Polkadot dependencies
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }

--- a/system-parachains/gluttons/glutton-kusama/Cargo.toml
+++ b/system-parachains/gluttons/glutton-kusama/Cargo.toml
@@ -10,31 +10,31 @@ version.workspace = true
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+scale-info = { features = ["derive"] , workspace = true }
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-glutton = { default-features = false, optional = true, version = "15.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-sudo = { default-features = false, optional = true, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-glutton = { optional = true, workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-sudo = { optional = true, workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-core = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Polkadot
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
@@ -42,15 +42,15 @@ xcm-builder = { package = "staging-xcm-builder", default-features = false, versi
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-primitives-core = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 system-parachains-constants = { path = "../../constants", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { version = "18.0.0" }
+substrate-wasm-builder = { workspace = true }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/people/people-kusama/Cargo.toml
+++ b/system-parachains/people/people-kusama/Cargo.toml
@@ -9,73 +9,73 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-enumflags2 = { version = "0.7.7" }
-serde = { version = "1.0.196", optional = true, features = ["derive"] }
+enumflags2 = { workspace = true }
+serde = { optional = true, features = ["derive"] , workspace = true }
 codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive", "max-encoded-len"] }
-hex-literal = { version = "0.4.1" }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+hex-literal = { workspace = true }
+log = { workspace = true }
+scale-info = { features = ["derive"] , workspace = true }
 
 # Substrate
-frame-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-executive = { default-features = false, version = "29.0.0" }
-frame-support = { default-features = false, version = "29.0.0" }
-frame-system = { default-features = false, version = "29.0.0" }
-frame-system-benchmarking = { default-features = false, optional = true, version = "29.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
-frame-try-runtime = { default-features = false, optional = true, version = "0.35.0" }
-pallet-aura = { default-features = false, version = "28.0.0", features = ["experimental"] }
-pallet-authorship = { default-features = false, version = "29.0.0" }
-pallet-balances = { default-features = false, version = "29.0.0" }
-pallet-identity = { default-features = false, version = "29.0.0" }
-pallet-message-queue = { default-features = false , version = "32.0.0" }
-pallet-multisig = { default-features = false, version = "29.0.0" }
-pallet-proxy = { default-features = false, version = "29.0.0" }
-pallet-session = { default-features = false, version = "29.0.0" }
-pallet-timestamp = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment = { default-features = false, version = "29.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
-pallet-utility = { default-features = false, version = "29.0.0" }
-sp-api = { default-features = false, version = "27.0.0" }
-sp-block-builder = { default-features = false, version = "27.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.33.0" }
-sp-core = { default-features = false, version = "29.0.0" }
-sp-genesis-builder = { default-features = false , version = "0.8.0" }
-sp-inherents = { default-features = false, version = "27.0.0" }
-sp-offchain = { default-features = false, version = "27.0.0" }
-sp-runtime = { default-features = false, version = "32.0.0" }
-sp-session = { default-features = false, version = "28.0.0" }
-sp-std = { default-features = false, version = "14.0.0" }
-sp-storage = { default-features = false, version = "20.0.0" }
-sp-transaction-pool = { default-features = false, version = "27.0.0" }
-sp-version = { default-features = false, version = "30.0.0" }
+frame-benchmarking = { optional = true, workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-aura = { features = ["experimental"] , workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-identity = { workspace = true }
+pallet-message-queue = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-utility = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-genesis-builder = { workspace = true }
+sp-inherents = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-storage = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.3" }
-pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
-polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
-polkadot-runtime-common = { default-features = false, version = "8.0.1" }
+pallet-xcm = { workspace = true }
+pallet-xcm-benchmarks = { optional = true , workspace = true }
+polkadot-parachain-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
 kusama-runtime-constants = { path = "../../../relay/kusama/constants", default-features = false}
 xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 
 # Cumulus
-cumulus-primitives-aura = { default-features = false , version = "0.8.0" }
-cumulus-pallet-aura-ext = { default-features = false , version = "0.8.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook",] , version = "0.8.1" }
-cumulus-pallet-session-benchmarking = { default-features = false, version = "10.0.0" }
-cumulus-pallet-xcm = { default-features = false , version = "0.8.0" }
-cumulus-pallet-xcmp-queue = { default-features = false , version = "0.8.0" }
-cumulus-primitives-core = { default-features = false , version = "0.8.0" }
-cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-pallet-collator-selection = { default-features = false , version = "10.0.0" }
+cumulus-primitives-aura = { workspace = true }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-parachain-system = { features = ["parameterized-consensus-hook",] , workspace = true }
+cumulus-pallet-session-benchmarking = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+pallet-collator-selection = { workspace = true }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
-parachains-common = { default-features = false , version = "8.0.0" }
+parachains-common = { workspace = true }
 system-parachains-constants = { path = "../../constants", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { optional = true , version = "18.0.0" }
+substrate-wasm-builder = { optional = true , workspace = true }
 
 [features]
 default = ["std"]

--- a/system-parachains/people/people-kusama/Cargo.toml
+++ b/system-parachains/people/people-kusama/Cargo.toml
@@ -51,7 +51,7 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.4" }
+pallet-xcm = { default-features = false, version = "8.0.3" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }


### PR DESCRIPTION
Pulling up all external deps to the workspace. Can be reproduced with the latest version of Zepter (1.3.1):

```sh
cargo upgrade -p pallet-xcm@8.0.4
zepter transpose dependency lift-to-workspace "regex:.*" --fix --version-resolver=unambiguous --source-location=remote
```

This is a No-OP change and can be verified with:
```sh
git checkout -q main
cargo tree -e features > main.out

git checkout -q oty-lift-deps-to-workspace
cargo tree -e features | diff main.out -

# No print - empty diff
```

- [x] Does not require a CHANGELOG entry
