### PR TITLE
Set safe on demand base fee

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1711,11 +1711,10 @@ pub type Migrations = migrations::Unreleased;
 /// The runtime migrations per release.
 #[allow(deprecated, missing_docs)]
 pub mod migrations {
-	use crate::set_safe_on_demand_fee;
 
 	use super::{
-		coretime, parachains_configuration, parachains_scheduler, slots, BlockNumber, LeasePeriod,
-		Leaser, ParaId, Runtime,
+		coretime, parachains_configuration, parachains_scheduler, set_safe_on_demand_fee, slots,
+		BlockNumber, LeasePeriod, Leaser, ParaId, Runtime,
 	};
 
 	// We don't have a limit in the Relay Chain.


### PR DESCRIPTION
Sets the base fee to a minimum of  0.01 KSM per order. This can be lowered later via governance if deemed too high.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [X] Does not require a CHANGELOG entry
