### PR TITLE
change encointer pallet version requirements to tilde-style (must-not update on minor revisions)

### DIFF
--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -19,7 +19,16 @@ scale-info = { version = "2.10.0", default-features = false, features = [
 ] }
 smallvec = "1.13.1"
 
-# encointer deps
+
+# Encointer pallet versioning follows these rules:
+# ---------------------------------------------------------------------------------------------
+# * major: per polkadot-sdk minor version, always breaking: i.e .
+#    * polkadot-sdk-v1.7.0 => encointer-* 6.x.x
+#    * polkadot-sdk-v1.8.0 => encointer-* 7.x.x
+# * minor: possibly breaking changes in encointer protocol. may require storage migration. i.e
+#    * encointer-* 6.1.x (must not be automatically updated from 6.0.x)
+# * patch: ad-lib
+#
 encointer-balances-tx-payment = { default-features = false, version = "~6.0.0" }
 encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
 encointer-primitives = { default-features = false, version = "~6.0.2" }

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -20,19 +20,19 @@ scale-info = { version = "2.10.0", default-features = false, features = [
 smallvec = "1.13.1"
 
 # encointer deps
-encointer-balances-tx-payment = { default-features = false, version = "6.0.0" }
-encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-encointer-primitives = { default-features = false, version = "6.0.2" }
-pallet-encointer-balances = { default-features = false, version = "6.0.0" }
-pallet-encointer-bazaar = { default-features = false, version = "6.0.0" }
-pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-pallet-encointer-ceremonies = { default-features = false, version = "6.0.0" }
-pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-pallet-encointer-communities = { default-features = false, version = "6.0.0" }
-pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-pallet-encointer-faucet = { default-features = false, version = "6.0.0" }
-pallet-encointer-reputation-commitments = { default-features = false, version = "6.0.0" }
-pallet-encointer-scheduler = { default-features = false, version = "6.0.0" }
+encointer-balances-tx-payment = { default-features = false, version = "~6.0.0" }
+encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+encointer-primitives = { default-features = false, version = "~6.0.2" }
+pallet-encointer-balances = { default-features = false, version = "~6.0.0" }
+pallet-encointer-bazaar = { default-features = false, version = "~6.0.0" }
+pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+pallet-encointer-ceremonies = { default-features = false, version = "~6.0.0" }
+pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+pallet-encointer-communities = { default-features = false, version = "~6.0.0" }
+pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+pallet-encointer-faucet = { default-features = false, version = "~6.0.0" }
+pallet-encointer-reputation-commitments = { default-features = false, version = "~6.0.0" }
+pallet-encointer-scheduler = { default-features = false, version = "~6.0.0" }
 
 
 # Substrate


### PR DESCRIPTION
We propose that encointer is allowed encointer-internal breaking changes with minor revisions because that will make the crate version more meaningful (we'll have to accept that polkadot-sdk isn't semver-compliant, so we must define reasonable best-practices when encointer is async upstream of *runtimes*, but downstream of *polkadot-sdk*)

encointer pallet versioning (suggestion):
* **major: a breaking change in polkadot**. per polkadot-sdk minor version, always assumed breaking: i.e .
   * polkadot-sdk-v1.7.0 => encointer-* 6.x.x
   * polkadot-sdk-v1.8.0 => encointer-* 7.x.x (already released)
* **minor: a (possibly) breaking change in encointer protocol**. may require storage migration. i.e 
   * encointer-* 6.1.x (may not be automatically updated from 6.0.x)
* **patch: ad-lib** non-breaking

In order to prevent `cargo update` to accidentally update minor versions (which may be breaking and require storage migration), we propose to use [tilde version requirements](https://carols10cents.github.io/cargo/specifying-dependencies.html#tilde-requirements) with this PR

Without this change, encointer will only be able to propose protocol upgrade PR's once per new *runtimes* releases because we can never be sure that no one runs `cargo update` between releases. And we can not rely on a specific PR making it into `main` before the next release.

The only alternative is to bump major with every possibly breaking change in either encointer OR polkadot-sdk. This, however, will lead to pretty meaningless version numbers.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
