### PR TITLE
bump encointer protocol pallets to 6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3119,9 +3119,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encointer-balances-tx-payment"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab150ba5131d8e59e861d21b900d123cc55604160c118fb8b2293af5a40d3a"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -3136,9 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1086972f2ea49903c0f7051ec6ad0180e81df47c2b6699f1ff279afba749bba6"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -3150,9 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-ceremonies-assignment"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebd5dc49f5f6fb321b2e7315bf29e26f3d5f38a1e344f36213137e58fbd54ea"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -3238,9 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-meetup-validation"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8b43179179d387317d14bd69335aafb7663f49b77203950fe4deadf1439ed7"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -3252,9 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-primitives"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d3adcceca350eed739e9677fae4e1bea6c7ad526eee456ca30037cbcfe9b9a"
+version = "6.1.0"
 dependencies = [
  "bs58 0.5.0",
  "crc",
@@ -3336,8 +3326,6 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 [[package]]
 name = "ep-core"
 version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b20f3b698c54e106bcb0533055bf99d64ae9c53261e7ed24366d1ca729a1259"
 dependencies = [
  "array-bytes 6.2.2",
  "impl-serde",
@@ -7022,9 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e315674885628d9255be6ef76d3a50ef5dbaeaa377955d683754d5b6552a49"
+version = "6.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7042,9 +7028,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ef596e3cd3ef64c238452dbed148a6f021a1861ad9917183099b9ed59c2e55"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -7060,9 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7ad75291b1b151855c615a5cf4036f1468e22d635585f412d10e0453a94948"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -7073,9 +7055,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d55a3cd08fdce58f6a92b373decc3709e5908f490a6e2e59aee7036776a64b"
+version = "6.1.0"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -7099,9 +7079,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7655dd964c160eef8af3cc90a8acb235a4695530ff8e81df5176fd34107b84"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -7112,9 +7090,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4163b2b572515e0424d80deef6582e0b8663f75de2058394700ff0a1f7f5dd2f"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -7132,9 +7108,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc071c9227da132fe57ad496e615695ebcd6a892cc5d2a66d79eb4c3fac5902a"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -7144,9 +7118,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-faucet"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e8faead921402e8ebd73272054a0974af2526e30e74bfb43fccb077aa93149"
+version = "6.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7166,9 +7138,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-reputation-commitments"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5777f365c18c93579880107b08299e77c85254076501130891a71b9be018690a"
+version = "6.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -7189,9 +7159,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26dc40684ab501ad233e5e6da4215a546392b503837a004d97153c482aaa561c"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -15377,3 +15345,23 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "encointer-balances-tx-payment-rpc"
+version = "6.1.0"
+
+[[patch.unused]]
+name = "pallet-encointer-bazaar-rpc"
+version = "6.1.0"
+
+[[patch.unused]]
+name = "pallet-encointer-ceremonies-rpc"
+version = "6.1.0"
+
+[[patch.unused]]
+name = "pallet-encointer-communities-rpc"
+version = "6.1.0"
+
+[[patch.unused]]
+name = "pallet-encointer-democracy"
+version = "6.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,24 @@ opt-level = 3
 inherits = "release"
 lto = true
 codegen-units = 1
+
+[patch.crates-io]
+encointer-balances-tx-payment = { path = "../pallets/balances-tx-payment" }
+encointer-balances-tx-payment-rpc = { path = "../pallets/balances-tx-payment/rpc" }
+encointer-balances-tx-payment-rpc-runtime-api = { path = "../pallets/balances-tx-payment/rpc/runtime-api" }
+encointer-ceremonies-assignment = { path = "../pallets/ceremonies/assignment" }
+encointer-primitives = { path = "../pallets/primitives" }
+pallet-encointer-balances = { path = "../pallets/balances" }
+pallet-encointer-bazaar = { path = "../pallets/bazaar" }
+pallet-encointer-bazaar-rpc = { path = "../pallets/bazaar/rpc" }
+pallet-encointer-bazaar-rpc-runtime-api = { path = "../pallets/bazaar/rpc/runtime-api" }
+pallet-encointer-ceremonies = { path = "../pallets/ceremonies" }
+pallet-encointer-ceremonies-rpc = { path = "../pallets/ceremonies/rpc" }
+pallet-encointer-ceremonies-rpc-runtime-api = { path = "../pallets/ceremonies/rpc/runtime-api" }
+pallet-encointer-communities = { path = "../pallets/communities" }
+pallet-encointer-communities-rpc = { path = "../pallets/communities/rpc" }
+pallet-encointer-communities-rpc-runtime-api = { path = "../pallets/communities/rpc/runtime-api" }
+pallet-encointer-democracy = { path = "../pallets/democracy" }
+pallet-encointer-faucet = { path = "../pallets/faucet" }
+pallet-encointer-reputation-commitments = { path = "../pallets/reputation-commitments" }
+pallet-encointer-scheduler = { path = "../pallets/scheduler" }

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -29,19 +29,19 @@ smallvec = "1.13.1"
 #    * encointer-* 6.1.x (must not be automatically updated from 6.0.x)
 # * patch: ad-lib
 #
-encointer-balances-tx-payment = { default-features = false, version = "~6.0.0" }
-encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-encointer-primitives = { default-features = false, version = "~6.0.2" }
-pallet-encointer-balances = { default-features = false, version = "~6.0.0" }
-pallet-encointer-bazaar = { default-features = false, version = "~6.0.0" }
-pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-pallet-encointer-ceremonies = { default-features = false, version = "~6.0.0" }
-pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-pallet-encointer-communities = { default-features = false, version = "~6.0.0" }
-pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-pallet-encointer-faucet = { default-features = false, version = "~6.0.0" }
-pallet-encointer-reputation-commitments = { default-features = false, version = "~6.0.0" }
-pallet-encointer-scheduler = { default-features = false, version = "~6.0.0" }
+encointer-balances-tx-payment = { default-features = false, version = "~6.1.0" }
+encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+encointer-primitives = { default-features = false, version = "~6.1.0" }
+pallet-encointer-balances = { default-features = false, version = "~6.1.0" }
+pallet-encointer-bazaar = { default-features = false, version = "~6.1.0" }
+pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+pallet-encointer-ceremonies = { default-features = false, version = "~6.1.0" }
+pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+pallet-encointer-communities = { default-features = false, version = "~6.1.0" }
+pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+pallet-encointer-faucet = { default-features = false, version = "~6.1.0" }
+pallet-encointer-reputation-commitments = { default-features = false, version = "~6.1.0" }
+pallet-encointer-scheduler = { default-features = false, version = "~6.1.0" }
 
 
 # Substrate


### PR DESCRIPTION
Upgrade Encointer protocol to the latest enhancements:

noteworthy changes
* tolerate noshows without loss of reputation (https://github.com/encointer/pallets/pull/373)
* protect bootstrapper reputation (https://github.com/encointer/pallets/pull/375)
  * bootstrappers can no longer use their ProofOfAttendance to register a fresh account as this is a vulnerability
  * upon unregistering, reputation is restored for bootstrappers too now
