### PR TITLE
[v1.1.3] Release Staking Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.1.3] 15.03.2024
+
+### Fixed
+
+- Bumps staking pallet version which applies a patch to prevent staking controllers from becoming stashes which may lead to ledger inconsistencies. Patch and context: [paritytech/polkadot-sdk#3639](https://github.com/paritytech/polkadot-sdk/pull/3639).
+
 ## [1.1.2] 31.01.2024
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Bumps staking pallet version which applies a patch to prevent staking controllers from becoming stashes which may lead to ledger inconsistencies. Patch and context: [paritytech/polkadot-sdk#3639](https://github.com/paritytech/polkadot-sdk/pull/3639).
+- Bumps Staking pallet version. This patch prevents staking controllers from becoming stashes, which may lead to ledger inconsistencies. Patch and context: [paritytech/polkadot-sdk#3639](https://github.com/paritytech/polkadot-sdk/pull/3639).
 
 ## [1.1.2] 31.01.2024
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7453,9 +7453,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "25.0.0"
+version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed335abd32d357dd9750dae7fb87b01dfd8fe69faadcb94a6e0e0a43057d923"
+checksum = "d6829cbaae2a8d23d4a7db159192297728df40d51f4555bd8a6ea4374aad62f5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -83,7 +83,7 @@ pallet-scheduler = { default-features = false , version = "26.0.0" }
 pallet-session = { default-features = false , version = "25.0.0" }
 pallet-society = { default-features = false, version = "25.0.0" }
 frame-support = { default-features = false , version = "25.0.0" }
-pallet-staking = { default-features = false , version = "25.0.0" }
+pallet-staking = { default-features = false , version = "25.0.1" }
 pallet-state-trie-migration = { default-features = false , version = "26.0.0" }
 pallet-staking-runtime-api = { default-features = false , version = "11.0.0" }
 frame-system = { default-features = false , version = "25.0.0" }

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -149,7 +149,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1_001_002,
+	spec_version: 1_001_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 25,

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -77,7 +77,7 @@ pallet-referenda = { default-features = false , version = "25.0.0" }
 pallet-scheduler = { default-features = false , version = "26.0.0" }
 pallet-session = { default-features = false , version = "25.0.0" }
 frame-support = { default-features = false , version = "25.0.0" }
-pallet-staking = { default-features = false , version = "25.0.0" }
+pallet-staking = { default-features = false , version = "25.0.1" }
 pallet-staking-reward-fn = { default-features = false, version = "16.0.0" }
 pallet-staking-reward-curve = { version = "10.0.0" }
 pallet-staking-runtime-api = { default-features = false , version = "11.0.0" }

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -144,7 +144,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("polkadot"),
 	impl_name: create_runtime_str!("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 1_001_002,
+	spec_version: 1_001_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 25,


### PR DESCRIPTION
Updating 1.1.2 runtimes with staking patch https://github.com/paritytech/polkadot-sdk/pull/3639 from @gpestana.

To be released immediately after merge.