### PR TITLE
Fix coretime-kusama tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,6 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "emulated-integration-tests-common",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",

--- a/system-parachains/coretime/coretime-kusama/Cargo.toml
+++ b/system-parachains/coretime/coretime-kusama/Cargo.toml
@@ -202,3 +202,8 @@ try-runtime = [
 experimental = ["pallet-aura/experimental"]
 
 fast-runtime = []
+
+# A feature that should be enabled when the runtime should be built for on-chain
+# deployment. This will disable stuff that shouldn't be part of the on-chain wasm
+# to make it smaller, like logging for example.
+on-chain-release-build = [ "sp-api/disable-logging" ]

--- a/system-parachains/coretime/coretime-kusama/Cargo.toml
+++ b/system-parachains/coretime/coretime-kusama/Cargo.toml
@@ -72,7 +72,6 @@ cumulus-pallet-xcmp-queue = { default-features = false , version = "0.8.0" }
 cumulus-primitives-aura = { default-features = false, version = "0.8.0" }
 cumulus-primitives-core = { default-features = false , version = "0.8.0" }
 cumulus-primitives-utility = { default-features = false , version = "0.8.1" }
-emulated-integration-tests-common = { version = "4.0.0" }
 pallet-collator-selection = { default-features = false , version = "10.0.0" }
 parachain-info = { package = "staging-parachain-info", default-features = false , version = "0.8.0" }
 parachains-common = { default-features = false , version = "8.0.0" }

--- a/system-parachains/coretime/coretime-kusama/src/tests.rs
+++ b/system-parachains/coretime/coretime-kusama/src/tests.rs
@@ -22,7 +22,7 @@ use frame_support::{
 	assert_ok,
 	traits::{
 		fungible::{Inspect, Mutate},
-		Get, OnInitialize,
+		OnInitialize,
 	},
 };
 use pallet_broker::{AdaptPrice, ConfigRecordOf, SaleInfo};


### PR DESCRIPTION
Changes:
- Fix coretime-kusama tests
- Add  `on-chain-release-build` feature

- [x] Does not require a CHANGELOG entry
