### PR TITLE
Triggers the 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.2.0] 28.03.2024
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4201,9 +4201,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "29.0.0"
+version = "29.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b24824d29c43d0af94be3356bbf30338ededed649f6841d315a9ae067ce872"
+checksum = "b8e52c84b611d2049d9253f83a62ab0f093e4be5c42a7ef42ea5bb16d6611e32"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.2",
@@ -7113,9 +7113,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "29.0.0"
+version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942007f4f7aace74b77009db1675e7ca98683a42dde5e2d85bba2a9f404d2e5a"
+checksum = "e27946a57494d7c6231ae8909275bbd3cb5460ee3d27b7a5774a8b8e64d3ab92"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8180,9 +8180,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "29.0.0"
+version = "29.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a94127295cf027a26e933ea6788b0824e9fedd90740013673e2d36b5d707efe"
+checksum = "668b7d28c499f0d9f295fad26cf6c342472e21842e3b13bcaaac8536358b2d6c"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ pallet-authority-discovery = { version = "29.0.1", default-features = false }
 pallet-authorship = { version = "29.0.0", default-features = false }
 pallet-babe = { version = "29.0.0", default-features = false }
 pallet-bags-list = { version = "28.0.0", default-features = false }
-pallet-balances = { version = "32.0.0", default-features = false }
+pallet-balances = { version = "29.0.1", default-features = false }
 pallet-beefy = { version = "29.0.0", default-features = false }
 pallet-beefy-mmr = { version = "29.0.0", default-features = false }
 pallet-bounties = { version = "28.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ frame-benchmarking = { version = "29.0.0", default-features = false }
 frame-election-provider-support = { version = "29.0.0", default-features = false }
 frame-executive = { version = "29.0.0", default-features = false }
 frame-remote-externalities = { version = "0.36.0" }
-frame-support = { version = "29.0.0", default-features = false }
+frame-support = { version = "29.0.2", default-features = false }
 frame-system = { version = "29.0.0", default-features = false }
 frame-system-benchmarking = { version = "29.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "27.0.0", default-features = false }
@@ -60,7 +60,7 @@ pallet-authority-discovery = { version = "29.0.1", default-features = false }
 pallet-authorship = { version = "29.0.0", default-features = false }
 pallet-babe = { version = "29.0.0", default-features = false }
 pallet-bags-list = { version = "28.0.0", default-features = false }
-pallet-balances = { version = "29.0.0", default-features = false }
+pallet-balances = { version = "32.0.0", default-features = false }
 pallet-beefy = { version = "29.0.0", default-features = false }
 pallet-beefy-mmr = { version = "29.0.0", default-features = false }
 pallet-bounties = { version = "28.0.0", default-features = false }
@@ -115,7 +115,7 @@ pallet-scheduler = { version = "30.0.0", default-features = false }
 pallet-session = { version = "29.0.0", default-features = false }
 pallet-session-benchmarking = { version = "29.0.0", default-features = false }
 pallet-society = { version = "29.0.0", default-features = false }
-pallet-staking = { version = "29.0.0", default-features = false }
+pallet-staking = { version = "29.0.2", default-features = false }
 pallet-staking-reward-curve = { version = "11.0.0" }
 pallet-staking-reward-fn = { version = "20.0.0", default-features = false }
 pallet-staking-runtime-api = { version = "15.0.0", default-features = false }

--- a/relay/kusama/src/weights/pallet_staking.rs
+++ b/relay/kusama/src/weights/pallet_staking.rs
@@ -794,4 +794,24 @@ impl<T: frame_system::Config> pallet_staking::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Staking::Bonded` (r:1 w:1)
+	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
+	/// Storage: `Staking::Ledger` (r:1 w:1)
+	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	fn restore_ledger() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1014`
+		//  Estimated: `4764`
+		// Minimum execution time: 40_258_000 picoseconds.
+		Weight::from_parts(41_210_000, 0)
+			.saturating_add(Weight::from_parts(0, 4764))
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(4))
+	}
 }

--- a/relay/polkadot/src/weights/pallet_staking.rs
+++ b/relay/polkadot/src/weights/pallet_staking.rs
@@ -794,4 +794,24 @@ impl<T: frame_system::Config> pallet_staking::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	/// Storage: `Balances::Locks` (r:1 w:1)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
+	/// Storage: `Staking::Bonded` (r:1 w:1)
+	/// Proof: `Staking::Bonded` (`max_values`: None, `max_size`: Some(72), added: 2547, mode: `MaxEncodedLen`)
+	/// Storage: `Staking::Ledger` (r:1 w:1)
+	/// Proof: `Staking::Ledger` (`max_values`: None, `max_size`: Some(1091), added: 3566, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:0)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	fn restore_ledger() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `1014`
+		//  Estimated: `4764`
+		// Minimum execution time: 40_258_000 picoseconds.
+		Weight::from_parts(41_210_000, 0)
+			.saturating_add(Weight::from_parts(0, 4764))
+			.saturating_add(T::DbWeight::get().reads(5))
+			.saturating_add(T::DbWeight::get().writes(4))
+	}
 }


### PR DESCRIPTION
- Triggers the 1.2.0 release
- Bumps the crate version of `pallet-staking`, `pallet-balances` and `frame-support` as per https://github.com/paritytech/polkadot-sdk/pull/3871

`Call::restore_ledger` weights taken from [polkadot-sdk](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/staking/src/weights.rs) (generated with bench bot).