### PR TITLE
Bump versions for sessions keys migration

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1860,7 +1860,7 @@ pub mod migrations {
 	/// Upgrade Session keys to exclude `ImOnline` key.
 	/// When this is removed, should also remove `OldSessionKeys`.
 	pub struct UpgradeSessionKeys;
-	const UPGRADE_SESSION_KEYS_FROM_SPEC: u32 = 1001002;
+	const UPGRADE_SESSION_KEYS_FROM_SPEC: u32 = 1001003;
 
 	impl OnRuntimeUpgrade for UpgradeSessionKeys {
 		#[cfg(feature = "try-runtime")]

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1789,7 +1789,7 @@ pub mod migrations {
 	/// Upgrade Session keys to exclude `ImOnline` key.
 	/// When this is removed, should also remove `OldSessionKeys`.
 	pub struct UpgradeSessionKeys;
-	const UPGRADE_SESSION_KEYS_FROM_SPEC: u32 = 1001002;
+	const UPGRADE_SESSION_KEYS_FROM_SPEC: u32 = 1001003;
 
 	impl frame_support::traits::OnRuntimeUpgrade for UpgradeSessionKeys {
 		#[cfg(feature = "try-runtime")]


### PR DESCRIPTION
Fixes #262

CC @bkchr 

- [x] Does not require a CHANGELOG entry

