### PR TITLE
fix review bot: updated to `v2.4.1` with fix

### DIFF
--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -21,10 +21,10 @@ jobs:
           artifact-name: pr_number
       - name: Generate token
         id: team_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v1.9.3
         with:
-          app_id: ${{ secrets.REVIEW_APP_ID }}
-          private_key: ${{ secrets.REVIEW_APP_KEY }}
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
         uses: paritytech/review-bot@v2.4.1
         with:

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -26,7 +26,7 @@ jobs:
           app_id: ${{ secrets.REVIEW_APP_ID }}
           private_key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v2.4.0
+        uses: paritytech/review-bot@v2.4.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           team-token: ${{ steps.team_token.outputs.token }}


### PR DESCRIPTION
This contains the fix for paritytech/review-bot#118, which is a breaking change introduced in V1.2.0 which causes the `Identity` object to become a tuple.

The updated code gets the first element of the tuple.

---

Replaced the action `tibdex/github-app-token` for `actions/create-github-app-token` which works the same way but is developed by GitHub (which should make it more secure)

- [x] Does not require a CHANGELOG entry
