### PR TITLE
updated auto-merge to v1.1.2

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
     steps:
       - name: Get the GitHub handle of the fellows
-        uses: paritytech/get-fellows-action@v1.1.1
+        uses: paritytech/get-fellows-action@v1.1.2
         id: fellows
       - name: Generate a token
         id: merge_token


### PR DESCRIPTION
Updated the action to version `1.1.2` which includes paritytech/get-fellows-action#23 which is a fix for the breaking change in V1.2.0 which causes the `Identity` object to become a tuple.

The updated code gets the first element of the tuple.

This also updates PAPI to version `0.4.0`.

- [x] Does not require a CHANGELOG entry
