### PR TITLE
restored disable-runtime-api in runtime nodes

### DIFF
--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -9,18 +9,21 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-parity-scale-codec = { features = ["derive", "max-encoded-len"] , workspace = true }
-scale-info = { features = ["derive"] , workspace = true }
+parity-scale-codec = { features = [
+	"derive",
+	"max-encoded-len",
+], workspace = true }
+scale-info = { features = ["derive"], workspace = true }
 log = { workspace = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", default-features = false , version = "27.0.0" }
-babe-primitives = { package = "sp-consensus-babe", default-features = false , version = "0.33.0" }
-beefy-primitives = { package = "sp-consensus-beefy", default-features = false , version = "14.0.0" }
+authority-discovery-primitives = { package = "sp-authority-discovery", default-features = false, version = "27.0.0" }
+babe-primitives = { package = "sp-consensus-babe", default-features = false, version = "0.33.0" }
+beefy-primitives = { package = "sp-consensus-beefy", default-features = false, version = "14.0.0" }
 binary-merkle-tree = { workspace = true }
 kusama-runtime-constants = { package = "kusama-runtime-constants", path = "constants", default-features = false }
 sp-api = { workspace = true }
-inherents = { package = "sp-inherents", default-features = false , version = "27.0.0" }
-offchain-primitives = { package = "sp-offchain", default-features = false , version = "27.0.0" }
+inherents = { package = "sp-inherents", default-features = false, version = "27.0.0" }
+offchain-primitives = { package = "sp-offchain", default-features = false, version = "27.0.0" }
 sp-std = { workspace = true }
 sp-application-crypto = { workspace = true }
 sp-arithmetic = { workspace = true }
@@ -32,8 +35,8 @@ sp-core = { workspace = true }
 sp-session = { workspace = true }
 sp-storage = { workspace = true }
 sp-version = { workspace = true }
-tx-pool-api = { package = "sp-transaction-pool", default-features = false , version = "27.0.0" }
-block-builder-api = { package = "sp-block-builder", default-features = false , version = "27.0.0" }
+tx-pool-api = { package = "sp-transaction-pool", default-features = false, version = "27.0.0" }
+block-builder-api = { package = "sp-block-builder", default-features = false, version = "27.0.0" }
 sp-npos-elections = { workspace = true }
 
 pallet-asset-rate = { workspace = true }
@@ -70,7 +73,7 @@ pallet-referenda = { workspace = true }
 pallet-scheduler = { workspace = true }
 pallet-session = { workspace = true }
 pallet-society = { workspace = true }
-frame-support = { features = [ "tuples-96" ] , workspace = true }
+frame-support = { features = ["tuples-96"], workspace = true }
 pallet-staking = { workspace = true }
 pallet-staking-runtime-api = { workspace = true }
 frame-system = { workspace = true }
@@ -81,25 +84,25 @@ pallet-utility = { workspace = true }
 pallet-vesting = { workspace = true }
 pallet-whitelist = { workspace = true }
 pallet-xcm = { workspace = true }
-pallet-xcm-benchmarks = { optional = true , workspace = true }
+pallet-xcm-benchmarks = { optional = true, workspace = true }
 frame-election-provider-support = { workspace = true }
 
-frame-benchmarking = { optional = true , workspace = true }
-frame-try-runtime = { optional = true , workspace = true }
-pallet-offences-benchmarking = { optional = true , workspace = true }
-pallet-session-benchmarking = { optional = true , workspace = true }
-pallet-nomination-pools-benchmarking = { optional = true , workspace = true }
-frame-system-benchmarking = { optional = true , workspace = true }
-pallet-election-provider-support-benchmarking = { optional = true , workspace = true }
+frame-benchmarking = { optional = true, workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+pallet-offences-benchmarking = { optional = true, workspace = true }
+pallet-session-benchmarking = { optional = true, workspace = true }
+pallet-nomination-pools-benchmarking = { optional = true, workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+pallet-election-provider-support-benchmarking = { optional = true, workspace = true }
 hex-literal = { workspace = true }
 
 runtime-common = { package = "polkadot-runtime-common", default-features = false, version = "8.0.1" }
-runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false , version = "8.0.1" }
-primitives = { package = "polkadot-primitives", default-features = false , version = "8.0.1" }
+runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false, version = "8.0.1" }
+primitives = { package = "polkadot-primitives", default-features = false, version = "8.0.1" }
 
-xcm = { package = "staging-xcm", default-features = false , version = "8.0.1" }
-xcm-executor = { package = "staging-xcm-executor", default-features = false , version = "8.0.1" }
-xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
+xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
+xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 
 sp-debug-derive = { workspace = true }
 
@@ -109,14 +112,14 @@ sp-trie = { workspace = true }
 separator = { workspace = true }
 serde_json = { workspace = true }
 remote-externalities = { package = "frame-remote-externalities", version = "0.36.0" }
-tokio = { features = ["macros"] , workspace = true }
+tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 no_std = []
 only-staking = []
 std = [
@@ -309,14 +312,16 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+disable-runtime-api = []
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = [ "sp-api/disable-logging" ]
+on-chain-release-build = ["sp-api/disable-logging"]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = []
 
-runtime-metrics = [ "runtime-parachains/runtime-metrics", "sp-io/with-tracing" ]
+runtime-metrics = ["runtime-parachains/runtime-metrics", "sp-io/with-tracing"]
 
-force-debug = [ "sp-debug-derive/force-debug" ]
+force-debug = ["sp-debug-derive/force-debug"]

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -8,18 +8,21 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-parity-scale-codec = { features = ["derive", "max-encoded-len"] , workspace = true }
-scale-info = { features = ["derive"] , workspace = true }
+parity-scale-codec = { features = [
+	"derive",
+	"max-encoded-len",
+], workspace = true }
+scale-info = { features = ["derive"], workspace = true }
 log = { workspace = true }
 
-authority-discovery-primitives = { package = "sp-authority-discovery", default-features = false , version = "27.0.0" }
-babe-primitives = { package = "sp-consensus-babe", default-features = false , version = "0.33.0" }
-beefy-primitives = { package = "sp-consensus-beefy", default-features = false , version = "14.0.0" }
+authority-discovery-primitives = { package = "sp-authority-discovery", default-features = false, version = "27.0.0" }
+babe-primitives = { package = "sp-consensus-babe", default-features = false, version = "0.33.0" }
+beefy-primitives = { package = "sp-consensus-beefy", default-features = false, version = "14.0.0" }
 binary-merkle-tree = { workspace = true }
-block-builder-api = { package = "sp-block-builder", default-features = false , version = "27.0.0" }
-inherents = { package = "sp-inherents", default-features = false , version = "27.0.0" }
-offchain-primitives = { package = "sp-offchain", default-features = false , version = "27.0.0" }
-tx-pool-api = { package = "sp-transaction-pool", default-features = false , version = "27.0.0" }
+block-builder-api = { package = "sp-block-builder", default-features = false, version = "27.0.0" }
+inherents = { package = "sp-inherents", default-features = false, version = "27.0.0" }
+offchain-primitives = { package = "sp-offchain", default-features = false, version = "27.0.0" }
+tx-pool-api = { package = "sp-transaction-pool", default-features = false, version = "27.0.0" }
 sp-arithmetic = { workspace = true }
 sp-api = { workspace = true }
 sp-genesis-builder = { workspace = true }
@@ -80,23 +83,23 @@ pallet-vesting = { workspace = true }
 pallet-utility = { workspace = true }
 frame-election-provider-support = { workspace = true }
 pallet-xcm = { workspace = true }
-pallet-xcm-benchmarks = { optional = true , workspace = true }
+pallet-xcm-benchmarks = { optional = true, workspace = true }
 
-frame-benchmarking = { optional = true , workspace = true }
-frame-try-runtime = { optional = true , workspace = true }
-frame-system-benchmarking = { optional = true , workspace = true }
-pallet-election-provider-support-benchmarking = { optional = true , workspace = true }
-pallet-offences-benchmarking = { optional = true , workspace = true }
-pallet-session-benchmarking = { optional = true , workspace = true }
-pallet-nomination-pools-benchmarking = { optional = true , workspace = true }
+frame-benchmarking = { optional = true, workspace = true }
+frame-try-runtime = { optional = true, workspace = true }
+frame-system-benchmarking = { optional = true, workspace = true }
+pallet-election-provider-support-benchmarking = { optional = true, workspace = true }
+pallet-offences-benchmarking = { optional = true, workspace = true }
+pallet-session-benchmarking = { optional = true, workspace = true }
+pallet-nomination-pools-benchmarking = { optional = true, workspace = true }
 
 runtime-common = { package = "polkadot-runtime-common", default-features = false, version = "8.0.1" }
-runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false , version = "8.0.1" }
-primitives = { package = "polkadot-primitives", default-features = false , version = "8.0.1" }
+runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false, version = "8.0.1" }
+primitives = { package = "polkadot-primitives", default-features = false, version = "8.0.1" }
 
-xcm = { package = "staging-xcm", default-features = false , version = "8.0.1" }
-xcm-executor = { package = "staging-xcm-executor", default-features = false , version = "8.0.1" }
-xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
+xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
+xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 
 sp-debug-derive = { workspace = true }
 
@@ -106,14 +109,14 @@ sp-trie = { workspace = true }
 serde_json = { workspace = true }
 separator = { workspace = true }
 remote-externalities = { package = "frame-remote-externalities", version = "0.36.0" }
-tokio = { features = ["macros"] , workspace = true }
+tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true }
 
 [features]
-default = [ "std" ]
+default = ["std"]
 no_std = []
 only-staking = []
 std = [
@@ -298,14 +301,16 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+disable-runtime-api = []
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = [ "sp-api/disable-logging" ]
+on-chain-release-build = ["sp-api/disable-logging"]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = []
 
-runtime-metrics = [ "runtime-parachains/runtime-metrics", "sp-io/with-tracing" ]
+runtime-metrics = ["runtime-parachains/runtime-metrics", "sp-io/with-tracing"]
 
-force-debug = [ "sp-debug-derive/force-debug" ]
+force-debug = ["sp-debug-derive/force-debug"]

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -149,6 +149,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	authoring_version: 0,
 	spec_version: 1_002_000,
 	impl_version: 0,
+	#[cfg(not(feature = "disable-runtime-api"))]
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 25,
 	state_version: 1,
@@ -212,7 +213,7 @@ pub struct OriginPrivilegeCmp;
 impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 	fn cmp_privilege(left: &OriginCaller, right: &OriginCaller) -> Option<Ordering> {
 		if left == right {
-			return Some(Ordering::Equal)
+			return Some(Ordering::Equal);
 		}
 
 		match (left, right) {
@@ -462,10 +463,12 @@ impl OpaqueKeys for OldSessionKeys {
 			<<Babe as BoundToRuntimeAppPublic>::Public>::ID => self.babe.as_ref(),
 			sp_core::crypto::key_types::IM_ONLINE => self.im_online.as_ref(),
 			<<Initializer as BoundToRuntimeAppPublic>::Public>::ID => self.para_validator.as_ref(),
-			<<ParaSessionInfo as BoundToRuntimeAppPublic>::Public>::ID =>
-				self.para_assignment.as_ref(),
-			<<AuthorityDiscovery as BoundToRuntimeAppPublic>::Public>::ID =>
-				self.authority_discovery.as_ref(),
+			<<ParaSessionInfo as BoundToRuntimeAppPublic>::Public>::ID => {
+				self.para_assignment.as_ref()
+			},
+			<<AuthorityDiscovery as BoundToRuntimeAppPublic>::Public>::ID => {
+				self.authority_discovery.as_ref()
+			},
 			<<Beefy as BoundToRuntimeAppPublic>::Public>::ID => self.beefy.as_ref(),
 			_ => &[],
 		}
@@ -1213,22 +1216,23 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			),
 			ProxyType::Governance => matches!(
 				c,
-				RuntimeCall::Treasury(..) |
-					RuntimeCall::Bounties(..) |
-					RuntimeCall::Utility(..) |
-					RuntimeCall::ChildBounties(..) |
-					RuntimeCall::ConvictionVoting(..) |
-					RuntimeCall::Referenda(..) |
-					RuntimeCall::Whitelist(..)
+				RuntimeCall::Treasury(..)
+					| RuntimeCall::Bounties(..)
+					| RuntimeCall::Utility(..)
+					| RuntimeCall::ChildBounties(..)
+					| RuntimeCall::ConvictionVoting(..)
+					| RuntimeCall::Referenda(..)
+					| RuntimeCall::Whitelist(..)
 			),
 			ProxyType::Staking => {
 				matches!(
 					c,
-					RuntimeCall::Staking(..) |
-						RuntimeCall::Session(..) | RuntimeCall::Utility(..) |
-						RuntimeCall::FastUnstake(..) |
-						RuntimeCall::VoterList(..) |
-						RuntimeCall::NominationPools(..)
+					RuntimeCall::Staking(..)
+						| RuntimeCall::Session(..)
+						| RuntimeCall::Utility(..)
+						| RuntimeCall::FastUnstake(..)
+						| RuntimeCall::VoterList(..)
+						| RuntimeCall::NominationPools(..)
 				)
 			},
 			ProxyType::NominationPools => {
@@ -1236,18 +1240,18 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			},
 			ProxyType::IdentityJudgement => matches!(
 				c,
-				RuntimeCall::Identity(pallet_identity::Call::provide_judgement { .. }) |
-					RuntimeCall::Utility(..)
+				RuntimeCall::Identity(pallet_identity::Call::provide_judgement { .. })
+					| RuntimeCall::Utility(..)
 			),
 			ProxyType::CancelProxy => {
 				matches!(c, RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }))
 			},
 			ProxyType::Auction => matches!(
 				c,
-				RuntimeCall::Auctions(..) |
-					RuntimeCall::Crowdloan(..) |
-					RuntimeCall::Registrar(..) |
-					RuntimeCall::Slots(..)
+				RuntimeCall::Auctions(..)
+					| RuntimeCall::Crowdloan(..)
+					| RuntimeCall::Registrar(..)
+					| RuntimeCall::Slots(..)
 			),
 		}
 	}
@@ -1796,7 +1800,7 @@ pub mod migrations {
 		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
 			if System::last_runtime_upgrade_spec_version() > UPGRADE_SESSION_KEYS_FROM_SPEC {
 				log::warn!(target: "runtime::session_keys", "Skipping session keys migration pre-upgrade check due to spec version (already applied?)");
-				return Ok(Vec::new())
+				return Ok(Vec::new());
 			}
 
 			log::info!(target: "runtime::session_keys", "Collecting pre-upgrade session keys state");
@@ -1828,7 +1832,7 @@ pub mod migrations {
 		fn on_runtime_upgrade() -> Weight {
 			if System::last_runtime_upgrade_spec_version() > UPGRADE_SESSION_KEYS_FROM_SPEC {
 				log::info!("Skipping session keys upgrade: already applied");
-				return <Runtime as frame_system::Config>::DbWeight::get().reads(1)
+				return <Runtime as frame_system::Config>::DbWeight::get().reads(1);
 			}
 			log::trace!("Upgrading session keys");
 			Session::upgrade_keys::<OldSessionKeys, _>(transform_session_keys);
@@ -1841,7 +1845,7 @@ pub mod migrations {
 		) -> Result<(), sp_runtime::TryRuntimeError> {
 			if System::last_runtime_upgrade_spec_version() > UPGRADE_SESSION_KEYS_FROM_SPEC {
 				log::warn!(target: "runtime::session_keys", "Skipping session keys migration post-upgrade check due to spec version (already applied?)");
-				return Ok(())
+				return Ok(());
 			}
 
 			let key_ids = SessionKeys::key_ids();
@@ -1960,6 +1964,7 @@ mod benches {
 	);
 }
 
+#[cfg(not(feature = "disable-runtime-api"))]
 sp_api::impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {
 		fn version() -> RuntimeVersion {
@@ -2838,8 +2843,8 @@ mod test_fees {
 		};
 
 		let mut active = target_voters;
-		while weight_with(active).all_lte(OffchainSolutionWeightLimit::get()) ||
-			active == target_voters
+		while weight_with(active).all_lte(OffchainSolutionWeightLimit::get())
+			|| active == target_voters
 		{
 			active += 1;
 		}
@@ -2952,8 +2957,8 @@ mod multiplier_tests {
 	#[test]
 	fn multiplier_can_grow_from_zero() {
 		let minimum_multiplier = MinimumMultiplier::get();
-		let target = TargetBlockFullness::get() *
-			BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
+		let target = TargetBlockFullness::get()
+			* BlockWeights::get().get(DispatchClass::Normal).max_total.unwrap();
 		// if the min is too small, then this will not change, and we are doomed forever.
 		// the weight is 1/100th bigger than target.
 		run_with_system_weight(target.saturating_mul(101) / 100, || {
@@ -3095,7 +3100,7 @@ mod remote_tests {
 	#[tokio::test]
 	async fn dispatch_all_proposals() {
 		if var("RUN_OPENGOV_TEST").is_err() {
-			return
+			return;
 		}
 
 		sp_tracing::try_init_simple();
@@ -3141,7 +3146,7 @@ mod remote_tests {
 	#[tokio::test]
 	async fn run_migrations() {
 		if var("RUN_MIGRATION_TESTS").is_err() {
-			return
+			return;
 		}
 
 		sp_tracing::try_init_simple();
@@ -3192,20 +3197,20 @@ mod init_state_migration {
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
 			use parity_scale_codec::Encode;
-			let migration_should_start = AutoLimits::<Runtime>::get().is_none() &&
-				MigrationProcess::<Runtime>::get() == Default::default();
+			let migration_should_start = AutoLimits::<Runtime>::get().is_none()
+				&& MigrationProcess::<Runtime>::get() == Default::default();
 			Ok(migration_should_start.encode())
 		}
 
 		fn on_runtime_upgrade() -> frame_support::weights::Weight {
 			if AutoLimits::<Runtime>::get().is_some() {
 				log::warn!("Automatic trie migration already started, not proceeding.");
-				return <Runtime as frame_system::Config>::DbWeight::get().reads(1)
+				return <Runtime as frame_system::Config>::DbWeight::get().reads(1);
 			};
 
 			if MigrationProcess::<Runtime>::get() != Default::default() {
 				log::warn!("MigrationProcess is not Default. Not proceeding.");
-				return <Runtime as frame_system::Config>::DbWeight::get().reads(2)
+				return <Runtime as frame_system::Config>::DbWeight::get().reads(2);
 			};
 
 			// Migration is not already running and `MigraitonProcess` is Default. Ready to run


### PR DESCRIPTION
<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [ x] Does not require a CHANGELOG entry

Closes [issue on SDK](https://github.com/paritytech/polkadot-sdk/issues/1621).