### PR TITLE
Release Kusama Coretime 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.2.3] 29.04.2024
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Add migration to Kusama Coretime to onboard People Chain without long delay ([polkadot-fellows/runtimes#286](https://github.com/polkadot-fellows/runtimes/pull/286))
+
+### Fixed
+
+- Clean up outdated assignment in Kusama Coretime Chain state ([polkadot-fellows/runtimes#286](https://github.com/polkadot-fellows/runtimes/pull/286))
+
 ## [1.2.2] 20.04.2024
 
 ### Fixed

--- a/system-parachains/coretime/coretime-kusama/src/lib.rs
+++ b/system-parachains/coretime/coretime-kusama/src/lib.rs
@@ -109,7 +109,8 @@ pub type UncheckedExtrinsic =
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
 	pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,
-	migrations::bootstrapping::ImportLeases,
+	migrations::bootstrapping::RemoveOutdatedPoolAssignment,
+	migrations::bootstrapping::OnboardPeople,
 );
 
 /// Executive: handles dispatch to the various modules.
@@ -133,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("coretime-kusama"),
 	impl_name: create_runtime_str!("coretime-kusama"),
 	authoring_version: 1,
-	spec_version: 1_002_002,
+	spec_version: 1_002_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,


### PR DESCRIPTION
Cherry pick #286 onto the 1.2.2 release for a clean 1.2.3 release.

This release is the one proposed in https://github.com/polkadot-fellows/runtimes/issues/288

The changelog from main is clipped to only include the relevant changes from the cherry picked commit.
- A migration is added to onboard the people chain without the usual two sale boundary delay that came with the shift to coretime.
- Another migration is added to clean up an outdated assignment in state from the old sale start before the leases were added.

More info in the changelog of this PR and PR #286.

- [ ] Does not require a CHANGELOG entry
