### PR TITLE
PoC for short benchmarking in CI with `frame-omni-bencher`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
           ls -lrt $RUNTIME_BLOB_PATH
           # TODO: get `frame-omni-bencher` somehow - GHA? or download released binary? or whatever?
           # TODO: we just try to build in-place
-          git clone https://github.com/paritytech/polkadot-sdk
+          git clone https://github.com/paritytech/polkadot-sdk --branch master --depth 1
           git branch
           cd ./polkadot-sdk
           cargo build --locked --release -p frame-omni-bencher

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,30 @@ jobs:
           RUSTFLAGS: "-C debug-assertions -D warnings"
           SKIP_WASM_BUILD: 1
 
+      - name: Test benchmarks ${{ matrix.runtime.name }}
+        run: |
+          PACKAGE_NAME=${{ matrix.runtime.package }}
+          RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
+          RUNTIME_BLOB_PATH=./target/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
+          # TODO: remove
+          echo "Running benchmarking for RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
+          # build wasm
+          cargo build --profile production -p ${{ matrix.runtime.package }} --features=runtime-benchmarks -q --locked
+          # TODO: remove
+          ls -lrt $RUNTIME_BLOB_PATH
+          # TODO: get `frame-omni-bencher` somehow - GHA? or download released binary? or whatever?
+          # TODO: we just try to build in-place
+          git clone https://github.com/paritytech/polkadot-sdk
+          git branch
+          cd ./polkadot-sdk
+          cargo build --locked --release -p frame-omni-bencher
+          cd ..
+          # run benchmarking
+          echo "Running benchmarking for RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
+          ./polkadot-sdk/target/release/frame-omni-bencher v1 benchmark pallet --runtime $RUNTIME_BLOB_PATH --all --steps 2 --repeat 1
+        env:
+          RUSTFLAGS: "-C debug-assertions -D warnings"
+
   integration-test:
     needs: [integration-test-matrix]
     continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,10 +107,10 @@ jobs:
           ls -lrt $RUNTIME_BLOB_PATH
           # TODO: get `frame-omni-bencher` somehow - GHA? or download released binary? or whatever?
           # TODO: we just try to build in-place
-          git clone https://github.com/paritytech/polkadot-sdk --branch master --depth 1
+          time git clone https://github.com/paritytech/polkadot-sdk --branch master --depth 1
           git branch
           cd ./polkadot-sdk
-          cargo build --locked --release -p frame-omni-bencher
+          time cargo build --locked --release -p frame-omni-bencher
           cd ..
           # run benchmarking
           echo "Running benchmarking for RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"


### PR DESCRIPTION
Closes: https://github.com/polkadot-fellows/runtimes/issues/197

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [ ] bump `sp-genesis-builder` and add `get_preset` feature to the runtimes
   ```
   [2024-04-30T11:14:22Z WARN  frame_omni_bencher] The FRAME omni-bencher is not yet battle tested - double check the results.
   [2024-04-30T11:14:22Z INFO  frame_benchmarking_cli::pallet::command] Loading WASM from ./target/production/wbuild/asset-hub-kusama-runtime/asset_hub_kusama_runtime.compact.compressed.wasm
   Error: Input("Could not call runtime API to build the genesis spec: Other: Exported method GenesisBuilder_get_preset is not found")
   ```
- [ ] find out how to use `frame-omni-bencher` - GHA? or download released binary? or whatever?
- [x] Does not require a CHANGELOG entry
