### PR TITLE
Enable Fellowship members of any rank to open retain and promote referendas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove DMP queue and allow `system::authorize_upgrade` in XCM's call filter ([polkadot-fellows/runtimes#280](https://github.com/polkadot-fellows/runtimes/pull/280))
-- Allow fellowship members to open their promotion and retention referendas ([polkadot-fellows/runtimes#302](https://github.com/polkadot-fellows/runtimes/pull/302))
+- Allow fellowship members of any rank to open their promotion and retention referendas ([polkadot-fellows/runtimes#302](https://github.com/polkadot-fellows/runtimes/pull/302))
 
 ## [1.2.3] 29.04.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
 - Add `pallet-vesting` to Asset Hubs ([polkadot-fellows/runtimes#269](https://github.com/polkadot-fellows/runtimes/pull/269))
-- Remove DMP queue and allow `system::authorize_upgrade` in XCM's call filter ([polkadot-fellows/runtimes#280](https://github.com/polkadot-fellows/runtimes/pull/280))
 - Add Pay Salary Collectives test ([polkadot-fellows/runtimes#260](https://github.com/polkadot-fellows/runtimes/pull/260))
+
+### Changed
+
+- Remove DMP queue and allow `system::authorize_upgrade` in XCM's call filter ([polkadot-fellows/runtimes#280](https://github.com/polkadot-fellows/runtimes/pull/280))
+- Allow fellowship members to open their promotion and retention referendas ([polkadot-fellows/runtimes#302](https://github.com/polkadot-fellows/runtimes/pull/302))
 
 ## [1.2.3] 29.04.2024
 


### PR DESCRIPTION
This pull request changes the `FellowshipReferenda::SubmitOrigin` to enable fellowship members to open their own retain and promote referendas.
