### PR TITLE
Fix people chain spec parsing in chainspec generator

### DIFF
--- a/chain-spec-generator/src/common.rs
+++ b/chain-spec-generator/src/common.rs
@@ -20,7 +20,7 @@ use crate::{
 	system_parachains_specs::{
 		AssetHubKusamaChainSpec, AssetHubPolkadotChainSpec, BridgeHubKusamaChainSpec,
 		BridgeHubPolkadotChainSpec, CollectivesPolkadotChainSpec, EncointerKusamaChainSpec,
-		GluttonKusamaChainSpec,
+		GluttonKusamaChainSpec, PeopleKusamaChainSpec,
 	},
 	ChainSpec,
 };
@@ -90,6 +90,8 @@ pub fn from_json_file(filepath: &str, supported: String) -> Result<Box<dyn Chain
 			Ok(Box::new(GluttonKusamaChainSpec::from_json_file(path)?)),
 		x if x.starts_with("encointer-kusama") =>
 			Ok(Box::new(EncointerKusamaChainSpec::from_json_file(path)?)),
+		x if x.starts_with("people-kusama") =>
+			Ok(Box::new(PeopleKusamaChainSpec::from_json_file(path)?)),
 		_ => Err(format!("Unknown chain 'id' in json file. Only supported: {supported}'")),
 	}
 }


### PR DESCRIPTION
I think it was just forgotten when people chain was added.

- [x] Does not require a CHANGELOG entry
