### PR TITLE
`up-to-date`: Removed subscription to `auto-merge-bot`

### DIFF
--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_run:
-    workflows: [Auto Merge Bot]
-    types: [completed]
 
 jobs:
   updatePullRequests:
@@ -16,7 +13,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v1.9.3
+        uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}


### PR DESCRIPTION
As explained in https://github.com/paritytech/up-to-date-action/issues/18#issuecomment-2122673176, the issue is caused because the `skipped` event is treated as `completed`. Until a better solution is generated, let's remove this event and triggered it only in pushes.

This reverts #272

- [x] Does not require a CHANGELOG entry
