### PR TITLE
Update Identity Patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9170,9 +9170,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "29.0.0"
+version = "29.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e1cae19e30e7dc822c419988b30bb1318d79a8d5da92733822d0e84fe760ca"
+checksum = "452bba25325b7f0148eeecbde13e7c26dfb677ad46b3f160b359d7643b44c94b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ pallet-encointer-scheduler = { version = "~6.1.0", default-features = false }
 pallet-fast-unstake = { version = "28.0.0", default-features = false }
 pallet-glutton = { version = "15.0.0", default-features = false }
 pallet-grandpa = { version = "29.0.0", default-features = false }
-pallet-identity = { version = "29.0.0", default-features = false }
+pallet-identity = { version = "29.0.1", default-features = false }
 pallet-indices = { version = "29.0.0", default-features = false }
 pallet-insecure-randomness-collective-flip = { version = "17.0.0", default-features = false }
 pallet-membership = { version = "29.0.0", default-features = false }


### PR DESCRIPTION
Updates Identity to latest patch to support enabling usernames on Polkadot.

- [x] Does not require a CHANGELOG entry
