### PR TITLE
Short benchmarking in CI with `frame-omni-bencher` + extract `chain-spec-builder` stuff to `get_preset`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  FRAME_OMNI_BENCHER_RELEASE_VERSION: polkadot-v1.11.0
+
 # cancel previous runs
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -88,6 +91,13 @@ jobs:
         with:
           shared-key: "fellowship-cache-tests"
 
+      - name: Download frame-omni-bencher
+        run: |
+          curl -sL https://github.com/paritytech/polkadot-sdk/releases/download/$FRAME_OMNI_BENCHER_RELEASE_VERSION/frame-omni-bencher -o frame-omni-bencher
+          chmod +x ./frame-omni-bencher
+          ./frame-omni-bencher --version
+        shell: bash
+
       - name: Test ${{ matrix.runtime.name }}
         run: cargo test -p ${{ matrix.runtime.package }} --release --locked -q
         env:
@@ -104,22 +114,13 @@ jobs:
           PACKAGE_NAME=${{ matrix.runtime.package }}
           RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
           RUNTIME_BLOB_PATH=./target/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
-          # TODO: remove
-          echo "Running benchmarking for RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
           # build wasm
+          echo "Preparing wasm for benchmarking RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
           cargo build --profile production -p ${{ matrix.runtime.package }} --features=runtime-benchmarks -q --locked
-          # TODO: remove
           ls -lrt $RUNTIME_BLOB_PATH
-          # TODO: get `frame-omni-bencher` somehow - GHA? or download released binary? or whatever?
-          # TODO: we just try to build in-place
-          time git clone https://github.com/paritytech/polkadot-sdk --branch master --depth 1
-          git branch
-          cd ./polkadot-sdk
-          time cargo build --locked --release -p frame-omni-bencher
-          cd ..
           # run benchmarking
           echo "Running benchmarking for RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
-          ./polkadot-sdk/target/release/frame-omni-bencher v1 benchmark pallet --runtime $RUNTIME_BLOB_PATH --all --steps 2 --repeat 1
+          ./frame-omni-bencher v1 benchmark pallet --runtime $RUNTIME_BLOB_PATH --all --steps 2 --repeat 1
         env:
           RUSTFLAGS: "-C debug-assertions -D warnings"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 env:
-  FRAME_OMNI_BENCHER_RELEASE_VERSION: polkadot-v1.11.0
+  FRAME_OMNI_BENCHER_RELEASE_VERSION: polkadot-v1.13.0
 
 # cancel previous runs
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,30 @@ jobs:
           RUSTFLAGS: "-C debug-assertions -D warnings"
           SKIP_WASM_BUILD: 1
 
+      - name: Test benchmarks ${{ matrix.runtime.name }}
+        run: |
+          PACKAGE_NAME=${{ matrix.runtime.package }}
+          RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
+          RUNTIME_BLOB_PATH=./target/production/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
+          # TODO: remove
+          echo "Running benchmarking for RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
+          # build wasm
+          cargo build --profile production -p ${{ matrix.runtime.package }} --features=runtime-benchmarks -q --locked
+          # TODO: remove
+          ls -lrt $RUNTIME_BLOB_PATH
+          # TODO: get `frame-omni-bencher` somehow - GHA? or download released binary? or whatever?
+          # TODO: we just try to build in-place
+          time git clone https://github.com/paritytech/polkadot-sdk --branch master --depth 1
+          git branch
+          cd ./polkadot-sdk
+          time cargo build --locked --release -p frame-omni-bencher
+          cd ..
+          # run benchmarking
+          echo "Running benchmarking for RUNTIME_BLOB_PATH=$RUNTIME_BLOB_PATH"
+          ./polkadot-sdk/target/release/frame-omni-bencher v1 benchmark pallet --runtime $RUNTIME_BLOB_PATH --all --steps 2 --repeat 1
+        env:
+          RUSTFLAGS: "-C debug-assertions -D warnings"
+
   # Job required by "confirmTestPassed"
   integration-test:
     needs: [integration-test-matrix]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ dependencies = [
  "polkadot-runtime-constants",
  "scale-info",
  "serde",
+ "serde_json",
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "snowbridge-outbound-queue-runtime-api",
@@ -14525,7 +14526,10 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-runtime-constants",
  "smallvec",
+ "sp-core 34.0.0",
  "sp-runtime 38.0.0",
+ "sp-std",
+ "staging-xcm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ sc-chain-spec = { version = "34.0.0" }
 scale-info = { version = "2.10.0", default-features = false }
 separator = { version = "0.4.1" }
 serde = { version = "1.0.196" }
-serde_json = { version = "1.0.113" }
+serde_json = { version = "1.0.113", default-features = false }
 smallvec = { version = "1.13.1" }
 snowbridge-beacon-primitives = { version = "0.7.0", default-features = false }
 snowbridge-core = { version = "0.7.0", default-features = false }

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -17,6 +17,7 @@ hex-literal = { workspace = true }
 log = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { optional = true, features = ["derive"], workspace = true }
+serde_json = { features = ["alloc"], workspace = true }
 tuplex = { workspace = true }
 
 # Local
@@ -191,6 +192,7 @@ std = [
 	"polkadot-runtime-constants/std",
 	"scale-info/std",
 	"serde",
+	"serde_json/std",
 	"snowbridge-beacon-primitives/std",
 	"snowbridge-core/std",
 	"snowbridge-outbound-queue-runtime-api/std",

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/genesis_config_presets.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/genesis_config_presets.rs
@@ -1,0 +1,92 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Genesis configs presets for the BridgeHubKusama runtime
+
+use crate::*;
+use sp_std::vec::Vec;
+use system_parachains_constants::genesis_presets::*;
+
+const BRIDGE_HUB_KUSAMA_ED: Balance = crate::ExistentialDeposit::get();
+
+fn bridge_hub_kusama_genesis(
+	invulnerables: Vec<(AccountId, AuraId)>,
+	endowed_accounts: Vec<AccountId>,
+	id: ParaId,
+) -> serde_json::Value {
+	serde_json::json!({
+		"balances": BalancesConfig {
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, BRIDGE_HUB_KUSAMA_ED * 4096 * 4096))
+				.collect(),
+		},
+		"parachainInfo": ParachainInfoConfig {
+			parachain_id: id,
+			..Default::default()
+		},
+		"collatorSelection": CollatorSelectionConfig {
+			invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
+			candidacy_bond: BRIDGE_HUB_KUSAMA_ED * 16,
+			..Default::default()
+		},
+		"session": SessionConfig {
+			keys: invulnerables
+				.into_iter()
+				.map(|(acc, aura)| {
+					(
+						acc.clone(),                          // account id
+						acc,                                  // validator id
+						SessionKeys { aura }, 				  // session keys
+					)
+				})
+				.collect(),
+		},
+		"polkadotXcm": {
+			"safeXcmVersion": Some(SAFE_XCM_VERSION),
+		},
+		"ethereumSystem": EthereumSystemConfig {
+			para_id: id,
+			asset_hub_para_id: kusama_runtime_constants::system_parachain::ASSET_HUB_ID.into(),
+			..Default::default()
+		},
+		// no need to pass anything to aura, in fact it will panic if we do. Session will take care
+		// of this. `aura: Default::default()`
+	})
+}
+
+fn bridge_hub_kusama_local_testnet_genesis(para_id: ParaId) -> serde_json::Value {
+	bridge_hub_kusama_genesis(invulnerables(), testnet_accounts(), para_id)
+}
+
+fn bridge_hub_kusama_development_genesis(para_id: ParaId) -> serde_json::Value {
+	bridge_hub_kusama_local_testnet_genesis(para_id)
+}
+
+/// Provides the JSON representation of predefined genesis config for given `id`.
+pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<sp_std::vec::Vec<u8>> {
+	let patch = match id.try_into() {
+		Ok("development") => bridge_hub_kusama_development_genesis(1002.into()),
+		Ok("local_testnet") => bridge_hub_kusama_local_testnet_genesis(1002.into()),
+		_ => return None,
+	};
+	Some(
+		serde_json::to_string(&patch)
+			.expect("serialization to json is expected to work. qed.")
+			.into_bytes(),
+	)
+}

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -24,6 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 pub mod bridge_to_ethereum_config;
 pub mod bridge_to_polkadot_config;
+mod genesis_config_presets;
 mod weights;
 pub mod xcm_config;
 
@@ -750,11 +751,14 @@ impl_runtime_apis! {
 		}
 
 		fn get_preset(id: &Option<sp_genesis_builder::PresetId>) -> Option<Vec<u8>> {
-			get_preset::<RuntimeGenesisConfig>(id, |_| None)
+			get_preset::<RuntimeGenesisConfig>(id, &genesis_config_presets::get_preset)
 		}
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
-			vec![]
+			vec![
+				sp_genesis_builder::PresetId::from("local_testnet"),
+				sp_genesis_builder::PresetId::from("development"),
+			]
 		}
 	}
 

--- a/system-parachains/constants/Cargo.toml
+++ b/system-parachains/constants/Cargo.toml
@@ -16,7 +16,10 @@ parachains-common = { workspace = true }
 polkadot-core-primitives = { workspace = true }
 polkadot-primitives = { workspace = true }
 polkadot-runtime-constants = { workspace = true }
+sp-core = { workspace = true }
 sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+xcm = { workspace = true }
 
 [features]
 default = ["std"]
@@ -27,5 +30,8 @@ std = [
 	"polkadot-core-primitives/std",
 	"polkadot-primitives/std",
 	"polkadot-runtime-constants/std",
+	"sp-core/std",
 	"sp-runtime/std",
+	"sp-std/std",
+	"xcm/std",
 ]

--- a/system-parachains/constants/src/genesis_presets.rs
+++ b/system-parachains/constants/src/genesis_presets.rs
@@ -1,0 +1,68 @@
+// Copyright (C) Parity Technologies and the various Polkadot contributors, see Contributions.md
+// for a list of specific contributors.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use parachains_common::AuraId;
+use polkadot_primitives::{AccountId, AccountPublic};
+use sp_core::{sr25519, Pair, Public};
+use sp_runtime::traits::IdentifyAccount;
+#[cfg(not(feature = "std"))]
+use sp_std::alloc::format;
+use sp_std::vec::Vec;
+
+/// Invulnerable Collators
+pub fn invulnerables() -> Vec<(parachains_common::AccountId, AuraId)> {
+	Vec::from([
+		(get_account_id_from_seed::<sr25519::Public>("Alice"), get_from_seed::<AuraId>("Alice")),
+		(get_account_id_from_seed::<sr25519::Public>("Bob"), get_from_seed::<AuraId>("Bob")),
+	])
+}
+
+/// Test accounts
+pub fn testnet_accounts() -> Vec<AccountId> {
+	Vec::from([
+		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		get_account_id_from_seed::<sr25519::Public>("Bob"),
+		get_account_id_from_seed::<sr25519::Public>("Charlie"),
+		get_account_id_from_seed::<sr25519::Public>("Dave"),
+		get_account_id_from_seed::<sr25519::Public>("Eve"),
+		get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+		get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+	])
+}
+
+/// Helper function to generate a crypto pair from seed
+pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
+	TPublic::Pair::from_string(&format!("//{}", seed), None)
+		.expect("static values are valid; qed")
+		.public()
+}
+
+/// Helper function to generate an account ID from seed
+pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+where
+	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+{
+	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
+}
+
+/// The default XCM version to set in genesis config.
+pub const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;

--- a/system-parachains/constants/src/lib.rs
+++ b/system-parachains/constants/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod genesis_presets;
 pub mod kusama;
 pub mod polkadot;
 


### PR DESCRIPTION
Relates to: https://github.com/polkadot-fellows/runtimes/pull/298

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [X] Does not require a CHANGELOG entry
- [ ] **fix runtimes to support benchmarking without chain-spec, just with runtime**
- [ ] fix benchmarks for frame-omni-bencher
- [ ] rewrite tutorial to use frame-omni-bencher instead of polkadot binary

optional:
- [ ] remove `chain-spec-builder` and fix `zombienet-sdk-tests`

Relates to: https://github.com/polkadot-fellows/runtimes/issues/128
Closes: https://github.com/polkadot-fellows/runtimes/issues/197