### PR TITLE
Add `CheckMetadataHash` extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
           RUSTFLAGS: "-C debug-assertions -D warnings"
 
       - name: Test all features ${{ matrix.runtime.name }}
-        run: cargo test -p ${{ matrix.runtime.package }} --release --locked -q --features=runtime-benchmarks,try-runtime
+        run: cargo test -p ${{ matrix.runtime.package }} --release --locked -q --all-features
         env:
           RUSTFLAGS: "-C debug-assertions -D warnings"
           SKIP_WASM_BUILD: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Staking runtime api to check if reward is pending for an era ([polkadot-fellows/runtimes#318](https://github.com/polkadot-fellows/runtimes/pull/318))
 - Allow any parachain to have bidirectional channel with any system parachains ([polkadot-fellows/runtimes#329](https://github.com/polkadot-fellows/runtimes/pull/329))
+- Enable support for new hardware signers like the generic ledger app ([polkadot-fellows/runtimes#337](https://github.com/polkadot-fellows/runtimes/pull/337))
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -754,6 +755,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -1753,6 +1755,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -1901,6 +1904,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -2462,6 +2466,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -2672,6 +2677,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -3466,6 +3472,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-syn-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,21 +3586,21 @@ dependencies = [
 
 [[package]]
 name = "docify"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc4fd38aaa9fb98ac70794c82a00360d1e165a87fbf96a8a91f9dfc602aaee2"
+checksum = "43a2f138ad521dc4a2ced1a4576148a6a610b4c5923933b062a263130a6802ce"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa215f3a0d40fb2a221b3aa90d8e1fbb8379785a990cb60d62ac71ebdc6460"
+checksum = "1a081e51fb188742f5a7a1164ad752121abcb22874b21e2c3b0dd040c515fdad"
 dependencies = [
  "common-path",
- "derive-syn-parse",
+ "derive-syn-parse 0.2.0",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -3847,6 +3864,7 @@ dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -4513,6 +4531,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata-hash-extension"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb1eec9eb46d3e016c95b2fa875118c04609f2150013c56a894cae00581e265"
+dependencies = [
+ "array-bytes 6.2.2",
+ "docify",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 32.0.0",
+]
+
+[[package]]
 name = "frame-remote-externalities"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4585,7 +4619,7 @@ checksum = "3bf1d648c4007d421b9677b3c893256913498fff159dc2d85022cdd9cc432f3c"
 dependencies = [
  "Inflector",
  "cfg-expr",
- "derive-syn-parse",
+ "derive-syn-parse 0.1.5",
  "expander 2.0.0",
  "frame-support-procedural-tools",
  "itertools 0.10.5",
@@ -6893,7 +6927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "468155613a44cfd825f1fb0ffa532b018253920d404e6fca1e8d43155198a46d"
 dependencies = [
  "const-random",
- "derive-syn-parse",
+ "derive-syn-parse 0.1.5",
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
@@ -7008,6 +7042,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
+]
+
+[[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes 6.2.2",
+ "blake3",
+ "frame-metadata 16.0.0",
+ "parity-scale-codec",
+ "scale-decode 0.13.0",
+ "scale-info",
 ]
 
 [[package]]
@@ -9798,6 +9846,7 @@ dependencies = [
  "enumflags2",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -10820,6 +10869,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-remote-externalities",
  "frame-support",
  "frame-system",
@@ -13558,8 +13608,18 @@ checksum = "662d10dcd57b1c2a3c41c9cf68f71fb09747ada1ea932ad961aca7e2ca28315f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "scale-type-resolver",
+ "scale-type-resolver 0.1.1",
  "serde",
+]
+
+[[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver 0.2.0",
 ]
 
 [[package]]
@@ -13571,9 +13631,22 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
+ "scale-bits 0.5.0",
  "scale-decode-derive",
- "scale-type-resolver",
+ "scale-type-resolver 0.1.1",
+ "smallvec",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12ebca36cec2a3f983c46295b282b35e5f8496346fb859a8776dad5389e5389"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits 0.6.0",
+ "scale-type-resolver 0.2.0",
  "smallvec",
 ]
 
@@ -13598,9 +13671,9 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
+ "scale-bits 0.5.0",
  "scale-encode-derive",
- "scale-type-resolver",
+ "scale-type-resolver 0.1.1",
  "smallvec",
 ]
 
@@ -13654,6 +13727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
+
+[[package]]
 name = "scale-typegen"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13678,11 +13757,11 @@ dependencies = [
  "either",
  "frame-metadata 15.1.0",
  "parity-scale-codec",
- "scale-bits",
- "scale-decode",
+ "scale-bits 0.5.0",
+ "scale-decode 0.11.1",
  "scale-encode",
  "scale-info",
- "scale-type-resolver",
+ "scale-type-resolver 0.1.1",
  "serde",
  "yap",
 ]
@@ -15876,6 +15955,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-remote-externalities",
  "frame-support",
  "frame-system",
@@ -16274,16 +16354,25 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "18.0.0"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511bbc2df035f5fe2556d855369a1bbb45df620360391a1f6e3fa1a1d64af79a"
+checksum = "4a39a20e17c24ede36b5bd5e7543a4cef8d8a0daf6e1a046dc31832b837a54a0"
 dependencies = [
+ "array-bytes 6.2.2",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata 16.0.0",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
+ "sc-executor",
+ "sp-core 29.0.0",
+ "sp-io 31.0.0",
  "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version",
  "strum 0.24.1",
  "tempfile",
  "toml 0.8.10",
@@ -16322,8 +16411,8 @@ dependencies = [
  "jsonrpsee 0.22.5",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
- "scale-decode",
+ "scale-bits 0.5.0",
+ "scale-decode 0.11.1",
  "scale-encode",
  "scale-info",
  "scale-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14827,9 +14827,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "27.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef42aa652381ade883c14ffbbb5c0fec36d382d2217b5bace01b8a0e8634778"
+checksum = "2e4f8702afd77f14a32733e2b589c02694bf79d0b3a641963c508016208724d0"
 dependencies = [
  "hash-db",
  "log",
@@ -14849,9 +14849,9 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "15.0.0"
+version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0694be2891593450916d6b53a274d234bccbc86bcbada36ba23fc356989070c7"
+checksum = "0301e2f77afb450fbf2b093f8b324c7ad88cc82e5e69bd5dc8658a1f068b2a96"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ snowbridge-router-primitives = { version = "0.1.0", default-features = false }
 snowbridge-runtime-common = { version = "0.1.0", default-features = false }
 snowbridge-runtime-test-common = { version = "0.1.0" }
 snowbridge-system-runtime-api = { version = "0.1.0", default-features = false }
-sp-api = { version = "27.0.0", default-features = false }
+sp-api = { version = "27.0.1", default-features = false }
 sp-application-crypto = { version = "31.0.0", default-features = false }
 sp-arithmetic = { version = "24.0.0", default-features = false }
 sp-block-builder = { version = "27.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ enumflags2 = { version = "0.7.7" }
 frame-benchmarking = { version = "29.0.0", default-features = false }
 frame-election-provider-support = { version = "29.0.0", default-features = false }
 frame-executive = { version = "29.0.0", default-features = false }
+frame-metadata-hash-extension = { version = "0.1.0", default-features = false }
 frame-support = { version = "29.0.2", default-features = false }
 frame-system = { version = "29.0.0", default-features = false }
 frame-system-benchmarking = { version = "29.0.0", default-features = false }
@@ -222,7 +223,7 @@ sp-trie = { version = "30.0.0" }
 sp-version = { version = "30.0.0", default-features = false }
 sp-weights = { version = "28.0.0", default-features = false }
 static_assertions = { version = "1.1.0" }
-substrate-wasm-builder = { version = "18.0.0" }
+substrate-wasm-builder = { version = "18.0.1" }
 system-parachains-constants = { path = "system-parachains/constants", default-features = false }
 tokio = { version = "1.36.0" }
 xcm = { version = "8.0.1", default-features = false, package = "staging-xcm" }

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -115,6 +115,9 @@ sp-tracing = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -53,6 +53,7 @@ pallet-conviction-voting = { workspace = true }
 pallet-election-provider-multi-phase = { workspace = true }
 pallet-fast-unstake = { workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 pallet-grandpa = { workspace = true }
 pallet-nis = { workspace = true }
 pallet-identity = { workspace = true }
@@ -113,7 +114,7 @@ tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true }
+substrate-wasm-builder = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
@@ -128,6 +129,7 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-election-provider-support/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -185,6 +187,7 @@ std = [
 	"polkadot-runtime-common/std",
 	"runtime-parachains/std",
 	"scale-info/std",
+	"substrate-wasm-builder",
 	"sp-api/std",
 	"sp-application-crypto/std",
 	"sp-arithmetic/std",
@@ -309,10 +312,13 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = []

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -115,9 +115,6 @@ sp-tracing = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/relay/kusama/build.rs
+++ b/relay/kusama/build.rs
@@ -14,12 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.import_memory()
-		.export_heap_base()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("KSM", 12)
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -931,6 +931,7 @@ where
 			frame_system::CheckNonce::<Runtime>::from(nonce),
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
+			frame_metadata_hash_extension::CheckMetadataHash::new(false),
 		);
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|e| {

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1793,6 +1793,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 pub struct NominationPoolsMigrationV4OldPallet;

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -21,7 +21,7 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-arithmetic = { workspace = true }
-sp-api = { workspace = true }
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 sp-genesis-builder = { workspace = true }
 sp-std = { workspace = true }
 sp-application-crypto = { workspace = true }
@@ -112,6 +112,9 @@ sp-tracing = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -50,6 +50,7 @@ pallet-conviction-voting = { workspace = true }
 pallet-election-provider-multi-phase = { workspace = true }
 pallet-fast-unstake = { workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 pallet-grandpa = { workspace = true }
 pallet-identity = { workspace = true }
 pallet-indices = { workspace = true }
@@ -110,7 +111,7 @@ tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true }
+substrate-wasm-builder = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
@@ -125,6 +126,7 @@ std = [
 	"frame-benchmarking?/std",
 	"frame-election-provider-support/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -180,6 +182,7 @@ std = [
 	"polkadot-runtime-constants/std",
 	"runtime-parachains/std",
 	"scale-info/std",
+	"substrate-wasm-builder",
 	"sp-api/std",
 	"sp-application-crypto/std",
 	"sp-arithmetic/std",
@@ -298,10 +301,13 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]
 
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = []

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -21,7 +21,7 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-arithmetic = { workspace = true }
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
+sp-api = { workspace = true }
 sp-genesis-builder = { workspace = true }
 sp-std = { workspace = true }
 sp-application-crypto = { workspace = true }
@@ -112,9 +112,6 @@ sp-tracing = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/relay/polkadot/build.rs
+++ b/relay/polkadot/build.rs
@@ -6,7 +6,7 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// Polkadot is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
@@ -14,12 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	WasmBuilder::new()
-		.with_current_project()
-		.import_memory()
-		.export_heap_base()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("DOT", 10)
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1011,6 +1011,7 @@ where
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
 			claims::PrevalidateAttests::<Runtime>::new(),
+			frame_metadata_hash_extension::CheckMetadataHash::new(false),
 		);
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|e| {
@@ -2803,6 +2804,7 @@ mod test_fees {
 			frame_system::CheckWeight::<Runtime>::new(),
 			pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),
 			claims::PrevalidateAttests::<Runtime>::new(),
+			frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(false),
 		);
 		let uxt = UncheckedExtrinsic {
 			function: call,

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1774,6 +1774,7 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	claims::PrevalidateAttests<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 pub struct NominationPoolsMigrationV4OldPallet;

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -25,6 +25,7 @@ polkadot-runtime-constants = { workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -211,6 +212,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -272,7 +274,10 @@ std = [
 	"xcm/std",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -111,6 +111,9 @@ sp-io = { workspace = true, default-features = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -111,9 +111,6 @@ sp-io = { workspace = true, default-features = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/asset-hubs/asset-hub-kusama/build.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/build.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("KSM", 12)
 		.build()
 }
 

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -1011,6 +1011,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_asset_conversion_tx_payment::ChargeAssetTxPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -26,6 +26,7 @@ polkadot-runtime-constants = { workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -196,6 +197,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -256,7 +258,10 @@ std = [
 	"xcm/std",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -110,9 +110,6 @@ parachains-runtimes-test-utils = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -110,6 +110,9 @@ parachains-runtimes-test-utils = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/asset-hubs/asset-hub-polkadot/build.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/build.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("DOT", 10)
 		.build()
 }
 

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -993,6 +993,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_asset_conversion_tx_payment::ChargeAssetTxPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -10,6 +10,9 @@ version.workspace = true
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -29,6 +29,7 @@ polkadot-runtime-constants = { workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -154,6 +155,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -295,7 +297,10 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -10,9 +10,6 @@ version.workspace = true
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/build.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/build.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("KSM", 12)
 		.build()
 }
 

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/primitives/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/primitives/src/lib.rs
@@ -102,11 +102,11 @@ frame_support::parameter_types! {
 
 	/// Transaction fee that is paid at the Kusama BridgeHub for delivering single inbound message.
 	/// (initially was calculated by test `BridgeHubKusama::can_calculate_fee_for_complex_message_delivery_transaction` + `33%`)
-	pub const BridgeHubKusamaBaseDeliveryFeeInKsms: u128 = 56_374_989_788;
+	pub const BridgeHubKusamaBaseDeliveryFeeInKsms: u128 = 56_375_433_121;
 
 	/// Transaction fee that is paid at the Kusama BridgeHub for delivering single outbound message confirmation.
 	/// (initially was calculated by test `BridgeHubKusama::can_calculate_fee_for_complex_message_confirmation_transaction` + `33%`)
-	pub const BridgeHubKusamaBaseConfirmationFeeInKsms: u128 = 53_808_755_240;
+	pub const BridgeHubKusamaBaseConfirmationFeeInKsms: u128 = 53_809_198_573;
 }
 
 /// Compute the total estimated fee that needs to be paid in KSMs by the sender when sending

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -115,6 +115,7 @@ pub type SignedExtra = (
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	BridgeRejectObsoleteHeadersAndMessages,
 	bridge_to_polkadot_config::RefundBridgeHubPolkadotMessages,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 bridge_runtime_common::generate_bridge_reject_obsolete_headers_and_messages! {

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/tests/snowbridge.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/tests/snowbridge.rs
@@ -328,6 +328,7 @@ fn construct_extrinsic(
 		pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),
 		BridgeRejectObsoleteHeadersAndMessages,
 		(RefundBridgeHubPolkadotMessages::default()),
+		frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(false),
 	);
 	let payload = SignedPayload::new(call.clone(), extra.clone()).unwrap();
 	let signature = payload.using_encoded(|e| sender.sign(e));

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/tests/tests.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/tests/tests.rs
@@ -82,6 +82,7 @@ fn construct_extrinsic(
 		pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),
 		BridgeRejectObsoleteHeadersAndMessages,
 		(RefundBridgeHubPolkadotMessages::default()),
+		frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(false),
 	);
 	let payload = SignedPayload::new(call.clone(), extra.clone()).unwrap();
 	let signature = payload.using_encoded(|e| sender.sign(e));

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -10,6 +10,9 @@ version.workspace = true
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -10,9 +10,6 @@ version.workspace = true
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -29,6 +29,7 @@ polkadot-runtime-constants = { workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -152,6 +153,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -291,7 +293,10 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/build.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/build.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("DOT", 10)
 		.build()
 }
 

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/src/lib.rs
@@ -93,11 +93,11 @@ frame_support::parameter_types! {
 
 	/// Transaction fee that is paid at the Polkadot BridgeHub for delivering single inbound message.
 	/// (initially was calculated by test `BridgeHubPolkadot::can_calculate_fee_for_complex_message_delivery_transaction` + `33%`)
-	pub const BridgeHubPolkadotBaseDeliveryFeeInDots: Balance = 16_912_512_364;
+	pub const BridgeHubPolkadotBaseDeliveryFeeInDots: Balance = 16_912_645_364;
 
 	/// Transaction fee that is paid at the Polkadot BridgeHub for delivering single outbound message confirmation.
 	/// (initially was calculated by test `BridgeHubPolkadot::can_calculate_fee_for_complex_message_confirmation_transaction` + `33%`)
-	pub const BridgeHubPolkadotBaseConfirmationFeeInDots: Balance = 16_142_641_864;
+	pub const BridgeHubPolkadotBaseConfirmationFeeInDots: Balance = 16_142_774_864;
 }
 
 /// Compute the total estimated fee that needs to be paid in DOTs by the sender when sending

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -119,6 +119,7 @@ pub type SignedExtra = (
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	BridgeRejectObsoleteHeadersAndMessages,
 	bridge_to_kusama_config::RefundBridgeHubKusamaMessages,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 bridge_runtime_common::generate_bridge_reject_obsolete_headers_and_messages! {

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/snowbridge.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/snowbridge.rs
@@ -328,6 +328,7 @@ fn construct_extrinsic(
 		pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),
 		BridgeRejectObsoleteHeadersAndMessages,
 		(RefundBridgeHubKusamaMessages::default()),
+		frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(false),
 	);
 	let payload = SignedPayload::new(call.clone(), extra.clone()).unwrap();
 	let signature = payload.using_encoded(|e| sender.sign(e));

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/tests.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/tests.rs
@@ -83,6 +83,7 @@ fn construct_extrinsic(
 		pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(0),
 		BridgeRejectObsoleteHeadersAndMessages,
 		(RefundBridgeHubKusamaMessages::default()),
+		frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(false),
 	);
 	let payload = SignedPayload::new(call.clone(), extra.clone()).unwrap();
 	let signature = payload.using_encoded(|e| sender.sign(e));

--- a/system-parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/system-parachains/collectives/collectives-polkadot/Cargo.toml
@@ -90,9 +90,6 @@ collectives-polkadot-runtime-constants = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/system-parachains/collectives/collectives-polkadot/Cargo.toml
@@ -17,6 +17,7 @@ scale-info = { features = ["derive"], workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -174,6 +175,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -231,7 +233,10 @@ std = [
 	"xcm/std",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/system-parachains/collectives/collectives-polkadot/Cargo.toml
@@ -90,6 +90,9 @@ collectives-polkadot-runtime-constants = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/collectives/collectives-polkadot/build.rs
+++ b/system-parachains/collectives/collectives-polkadot/build.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("DOT", 10)
 		.build()
 }
 

--- a/system-parachains/collectives/collectives-polkadot/src/lib.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/lib.rs
@@ -721,6 +721,7 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/system-parachains/coretime/coretime-kusama/Cargo.toml
+++ b/system-parachains/coretime/coretime-kusama/Cargo.toml
@@ -22,6 +22,7 @@ system-parachains-constants = { workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -98,6 +99,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -206,7 +208,10 @@ experimental = ["pallet-aura/experimental"]
 
 fast-runtime = []
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/coretime/coretime-kusama/Cargo.toml
+++ b/system-parachains/coretime/coretime-kusama/Cargo.toml
@@ -84,9 +84,6 @@ parachains-runtimes-test-utils = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/coretime/coretime-kusama/Cargo.toml
+++ b/system-parachains/coretime/coretime-kusama/Cargo.toml
@@ -84,6 +84,9 @@ parachains-runtimes-test-utils = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/coretime/coretime-kusama/build.rs
+++ b/system-parachains/coretime/coretime-kusama/build.rs
@@ -14,13 +14,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
-		.build();
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("KSM", 12)
+		.build()
 }
 
 #[cfg(not(feature = "std"))]

--- a/system-parachains/coretime/coretime-kusama/src/lib.rs
+++ b/system-parachains/coretime/coretime-kusama/src/lib.rs
@@ -100,6 +100,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -104,9 +104,6 @@ polkadot-primitives = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [dev-dependencies]
 # The Encointer pallets might not have compatible versions of `polkadot-sdk` with the rest of the system parachains,

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -43,6 +43,7 @@ pallet-encointer-scheduler = { workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -168,6 +169,7 @@ std = [
 	"encointer-primitives/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -266,7 +268,10 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -104,6 +104,9 @@ polkadot-primitives = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [dev-dependencies]
 # The Encointer pallets might not have compatible versions of `polkadot-sdk` with the rest of the system parachains,

--- a/system-parachains/encointer/build.rs
+++ b/system-parachains/encointer/build.rs
@@ -14,12 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("KSM", 12)
 		.build()
 }
 

--- a/system-parachains/encointer/src/lib.rs
+++ b/system-parachains/encointer/src/lib.rs
@@ -721,6 +721,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/system-parachains/people/people-kusama/Cargo.toml
+++ b/system-parachains/people/people-kusama/Cargo.toml
@@ -79,9 +79,6 @@ system-parachains-constants = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
-# Workaround for a bug in the compiler?
-# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
-sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/people/people-kusama/Cargo.toml
+++ b/system-parachains/people/people-kusama/Cargo.toml
@@ -79,6 +79,9 @@ system-parachains-constants = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true }
+# Workaround for a bug in the compiler?
+# The code is fixed in `polkadot-sdk` and this will come with the next upgrade.
+sp-api = { workspace = true, features = [ "frame-metadata" ] }
 
 [features]
 default = ["std"]

--- a/system-parachains/people/people-kusama/Cargo.toml
+++ b/system-parachains/people/people-kusama/Cargo.toml
@@ -19,6 +19,7 @@ scale-info = { features = ["derive"], workspace = true }
 # Substrate
 frame-benchmarking = { optional = true, workspace = true }
 frame-executive = { workspace = true }
+frame-metadata-hash-extension = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
@@ -94,6 +95,7 @@ std = [
 	"enumflags2/std",
 	"frame-benchmarking?/std",
 	"frame-executive/std",
+	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
@@ -197,7 +199,10 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]
+
 # A feature that should be enabled when the runtime should be built for on-chain
 # deployment. This will disable stuff that shouldn't be part of the on-chain wasm
 # to make it smaller, like logging for example.
-on-chain-release-build = ["sp-api/disable-logging"]
+on-chain-release-build = ["sp-api/disable-logging", "metadata-hash"]

--- a/system-parachains/people/people-kusama/src/lib.rs
+++ b/system-parachains/people/people-kusama/src/lib.rs
@@ -95,6 +95,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
This signed extension enables the new metadata hash verification feature that was approved as
[RFC78](https://polkadot-fellows.github.io/RFCs/approved/0078-merkleized-metadata.html). This will bring support for the new generic ledger hardware wallet app and further hardware wallets in the Polkadot ecosystem.
