### PR TITLE
Enable elastic scaling node side feature on Polkadot 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Staking runtime api to check if reward is pending for an era ([polkadot-fellows/runtimes#318](https://github.com/polkadot-fellows/runtimes/pull/318))
 - Allow any parachain to have bidirectional channel with any system parachains ([polkadot-fellows/runtimes#329](https://github.com/polkadot-fellows/runtimes/pull/329))
 - Enable support for new hardware signers like the generic ledger app ([polkadot-fellows/runtimes#337](https://github.com/polkadot-fellows/runtimes/pull/337))
+- Enable Elastic Scaling node side feature for Polkadot ([polkadot-fellows/runtimes#340](https://github.com/polkadot-fellows/runtimes/pull/340))
 
 ### Changed
 

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1783,6 +1783,7 @@ pub type SignedExtra = (
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 	claims::PrevalidateAttests<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 pub struct NominationPoolsMigrationV4OldPallet;
@@ -1807,6 +1808,7 @@ pub mod migrations {
 	use runtime_parachains::configuration::WeightInfo;
 	#[cfg(feature = "try-runtime")]
 	use sp_core::crypto::ByteArray;
+
 	parameter_types! {
 		pub const ImOnlinePalletName: &'static str = "ImOnline";
 	}


### PR DESCRIPTION
This feature is needed on Polkadot to ensure parachains can still make progress if they have multiple cores assigned. Relay chain support for elastic scaling is implemented but requires bumping `polkadot-runtime-parachains` crate version to at least `11.0.0` which will happen later.

- [ ] Does not require a CHANGELOG entry
