### PR TITLE
updated review-bot dependencies to latest (`2.5.0`)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,11 +14,11 @@ jobs:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
     steps:
       - name: Get the GitHub handle of the fellows
-        uses: paritytech/get-fellows-action@v1.1.3
+        uses: paritytech/get-fellows-action@v1.1.4
         id: fellows
       - name: Generate a token
         id: merge_token
-        uses: actions/create-github-app-token@v1.8.1
+        uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.MERGE_APP_ID }}
           private-key: ${{ secrets.MERGE_APP_KEY }}

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -16,17 +16,17 @@ jobs:
     steps:
       - name: Extract content of artifact
         id: number
-        uses: Bullrich/extract-text-from-artifact@v1.0.0
+        uses: Bullrich/extract-text-from-artifact@v1.0.1
         with:
           artifact-name: pr_number
       - name: Generate token
         id: team_token
-        uses: actions/create-github-app-token@v1.9.3
+        uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.REVIEW_APP_ID }}
           private-key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v2.4.1
+        uses: paritytech/review-bot@v2.5.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           team-token: ${{ steps.team_token.outputs.token }}

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Get the GitHub handle of the fellows
-        uses: paritytech/get-fellows-action@v1.1.3
+        uses: paritytech/get-fellows-action@v1.1.4
         id: fellows
         # Require new reviews when the author is pushing and he is not a fellow
       - name: Fail when author pushes new code


### PR DESCRIPTION
This commit updates get-fellows-action to v1.1.4 where `papi` was updated to latest (`0.9.0`) which contains a fix for polkadot-api/polkadot-api#327. This will accelerate the process of the triggering of review-bot.

Review-bot has also been updated to latest. It has the pull request number being injected, so it will always fetch the latest status when it runs.

With the fix provided in #369 this should make the whole process work as intended.

- [x] Does not require a CHANGELOG entry
