### PR TITLE
Trigger Release v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ Note: This release only affects the following runtimes and is not a full system 
 - Polkadot Asset Hub
 - Polkadot Bridge Hub
 - Polkadot Collectives
-- Kusama Relay Chain
-- Kusama Asset Hub
 - Kusama Bridge Hub
 
 ## [1.2.7] 14.06.2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.2.8] 03.07.2024
 
 ### Changed
 
 - Polkadot chains: allow arbitrary XCM execution ([polkadot-fellows/runtimes#345](https://github.com/polkadot-fellows/runtimes/pull/345))
 - Snowbridge: Sync headers on demand ([polkadot-fellows/runtimes#345](https://github.com/polkadot-fellows/runtimes/pull/365))
+
+Note: This release only affects the following runtimes and is not a full system release:
+
+- Polkadot Relay Chain
+- Polkadot Asset Hub
+- Polkadot Bridge Hub
+- Polkadot Collectives
+- Kusama Relay Chain
+- Kusama Asset Hub
+- Kusama Bridge Hub
 
 ## [1.2.7] 14.06.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Note: This release only affects the following runtimes and is not a full system 
 - Polkadot Asset Hub
 - Polkadot Bridge Hub
 - Polkadot Collectives
+- Kusama Relay Chain
 - Kusama Bridge Hub
 
 ## [1.2.7] 14.06.2024

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1_002_006,
+	spec_version: 1_002_008,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 26,

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kusama"),
 	impl_name: create_runtime_str!("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1_002_008,
+	spec_version: 1_002_006,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 26,

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("statemine"),
 	impl_name: create_runtime_str!("statemine"),
 	authoring_version: 1,
-	spec_version: 1_002_008,
+	spec_version: 1_002_006,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 15,

--- a/system-parachains/collectives/collectives-polkadot/src/lib.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("collectives"),
 	impl_name: create_runtime_str!("collectives"),
 	authoring_version: 1,
-	spec_version: 1_002_006,
+	spec_version: 1_002_008,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 7,


### PR DESCRIPTION
Triggers the release of https://github.com/polkadot-fellows/runtimes/issues/358 to reduce costs to run the Ethereum client.