### PR TITLE
Reduce Bounty Payout Delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Bounties: Remove payout delay ([polkadot-fellows/runtimes#386](https://github.com/polkadot-fellows/runtimes/pull/386))
+
 ## [1.2.8] 03.07.2024
 
 ### Added

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -775,7 +775,7 @@ impl pallet_treasury::Config for Runtime {
 
 parameter_types! {
 	pub const BountyDepositBase: Balance = 100 * CENTS;
-	pub const BountyDepositPayoutDelay: BlockNumber = 4 * DAYS;
+	pub const BountyDepositPayoutDelay: BlockNumber = 0;
 	pub const BountyUpdatePeriod: BlockNumber = 90 * DAYS;
 	pub const MaximumReasonLength: u32 = 16384;
 	pub const CuratorDepositMultiplier: Permill = Permill::from_percent(50);

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -889,7 +889,7 @@ impl pallet_treasury::Config for Runtime {
 
 parameter_types! {
 	pub const BountyDepositBase: Balance = DOLLARS;
-	pub const BountyDepositPayoutDelay: BlockNumber = 8 * DAYS;
+	pub const BountyDepositPayoutDelay: BlockNumber = 0;
 	pub const BountyUpdatePeriod: BlockNumber = 90 * DAYS;
 	pub const MaximumReasonLength: u32 = 16384;
 	pub const CuratorDepositMultiplier: Permill = Permill::from_percent(50);


### PR DESCRIPTION
The bounty payout delay originally existed to provide time for the Council to remove curators of a bounty if they were not acting in accordance with its existence. The Council motion time was 7 days, and thus the bounty delay was 8 days to give the Council time to remove curators and void payouts prior to a bounty being claimable.

With OpenGov tracks being 28 days, I don't see this as anything more than a PITA for curators/awardees. Does anyone have motivation for this delay to be in effect in the current setup? (cc @muharem , @shawntabrizi )