### PR TITLE
Improve test names

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -50,7 +50,7 @@ jobs:
   # If you add more jobs, remember to add them to the "needs" array.
   confirmChangelogChecksPassed:
     runs-on: ubuntu-latest
-    name: All tests passed
+    name: All changelog tests passed
     # If any new job gets added, be sure to add it to this list
     needs:
       - verify-changelog-updated

--- a/.github/workflows/check-features.yaml
+++ b/.github/workflows/check-features.yaml
@@ -1,5 +1,5 @@
 # Various checks to verify the cargo workspace and its crates are correctly configured.
-name: "Workspace"
+name: "Workspace features"
 
 on:
   push:
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  name: Check workspace features
   check:
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
The name of the "All changelog tests passing" was clashing with the name of the "All tests passing" test.

Give the check features test a name.

Both changes are required to mark these tests as required in github.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
