### PR TITLE
CI: updated all deprecated actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -40,7 +40,7 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Verify
         run: .github/changelog-processor.py CHANGELOG.md --validate-changelog

--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  name: Check workspace features
   check:
+    name: Check workspace features
     runs-on: ubuntu-22.04
 
     steps:
@@ -28,7 +28,7 @@ jobs:
         run: cargo install --locked -q zepter && zepter --version
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Dont clone historic commits.
 

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -26,7 +26,7 @@ jobs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     name: Extract tasks from matrix
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: runtime
         run: |
           # Filter out runtimes that don't have a URI
@@ -51,7 +51,7 @@ jobs:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build EXTRA_ARGS
         run: |

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt update && sudo apt install --assume-yes cmake protobuf-compiler
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set rust version via common env file
         run: cat .github/env >> $GITHUB_ENV

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set rust version via common env file
         run: cat .github/env >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,7 @@ jobs:
 
       - name: Create release
         id: create-release
+        # TODO: Replace as it has been deprecated
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -183,6 +184,7 @@ jobs:
           >>$GITHUB_ENV echo SPEC=$(<${JSON} jq -r .runtimes.compact.subwasm.core_version.specVersion)
 
       - name: Upload compressed ${{ matrix.runtime.name }} v${{ env.SPEC }} wasm
+        # TODO: Replace as it has been deprecated
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       should-release: ${{ steps.run.outputs.should-release }}
       version: ${{ steps.run.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: run
         run: |
           echo "should-release=$(.github/changelog-processor.py CHANGELOG.md --should-release)" >> $GITHUB_OUTPUT
@@ -26,7 +26,7 @@ jobs:
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: runtime
         run: |
           TASKS=$(echo $(cat .github/workflows/runtimes-matrix.json) | sed 's/ //g' )
@@ -41,10 +41,10 @@ jobs:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache target dir
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "${{ github.workspace }}/${{ matrix.runtime.path }}/target"
           key: srtool-target-${{ matrix.runtime.path }}-${{ matrix.runtime.name }}-${{ github.sha }}
@@ -68,13 +68,13 @@ jobs:
           echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.runtime.name }}_srtool_output.json
 
       - name: Upload ${{ matrix.runtime.name }} srtool json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime.name }}-srtool-json
           path: ${{ matrix.runtime.name }}_srtool_output.json
 
       - name: Upload  ${{ matrix.runtime.name }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime.name }}
           path: |
@@ -88,13 +88,13 @@ jobs:
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download srtool json output
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Archive context output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-notes-context
           path: |
@@ -170,10 +170,10 @@ jobs:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Get runtime info
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     name: Extract runtimes from matrix
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: runtime
         run: |
           TASKS=$(echo $(cat .github/workflows/runtimes-matrix.json) | sed 's/ //g' )
@@ -35,7 +35,7 @@ jobs:
       itest: ${{ steps.itest.outputs.itest }}
     name: Extract integration tests from matrix
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: itest
         run: |
           TASKS=$(echo $(cat .github/workflows/integration-tests-matrix.json) | sed 's/ //g' )
@@ -65,7 +65,7 @@ jobs:
           df -h
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set rust version via common env file
         run: cat .github/env >> $GITHUB_ENV
@@ -121,7 +121,7 @@ jobs:
           df -h
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set rust version via common env file
         run: cat .github/env >> $GITHUB_ENV
@@ -167,7 +167,7 @@ jobs:
           df -h
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set rust version via common env file
         run: cat .github/env >> $GITHUB_ENV
@@ -215,7 +215,7 @@ jobs:
           df -h
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set rust version via common env file
         run: cat .github/env >> $GITHUB_ENV


### PR DESCRIPTION
I have noticed there are a lot of outdated actions with deprecated warnings:
<img width="956" alt="image" src="https://github.com/user-attachments/assets/bebf97c0-4a3c-41ba-87db-ab9b6789eb4c">

This PR updates all of GitHub actions to latest version to remove such warnings.

I have also added some`TODO` to actions that have been archived by GitHub and that require an alternative action/solution. We can do that in a different PR once we identify the correct solution.

- [x] Does not require a CHANGELOG entry
