### PR TITLE
review-bot and get-fellows-action upgrades

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/merge') }}
     steps:
       - name: Get the GitHub handle of the fellows
-        uses: paritytech/get-fellows-action@v1.1.4
+        uses: paritytech/get-fellows-action@v1.2.0
         id: fellows
       - name: Generate a token
         id: merge_token

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -26,7 +26,7 @@ jobs:
           app-id: ${{ secrets.REVIEW_APP_ID }}
           private-key: ${{ secrets.REVIEW_APP_KEY }}
       - name: "Evaluates PR reviews and assigns reviewers"
-        uses: paritytech/review-bot@v2.5.0
+        uses: paritytech/review-bot@v2.6.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           team-token: ${{ steps.team_token.outputs.token }}

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Get the GitHub handle of the fellows
-        uses: paritytech/get-fellows-action@v1.1.4
+        uses: paritytech/get-fellows-action@v1.2.0
         id: fellows
         # Require new reviews when the author is pushing and he is not a fellow
       - name: Fail when author pushes new code


### PR DESCRIPTION
Both use PAPI and People parachain now

**note:** review-bot is obviously set to be run as configured in master, meaning that it won't run the updated version for this PR

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
