### PR TITLE
Add `uri` for `people` chains to the runtimes-matrix.json

### DIFF
--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -65,12 +65,14 @@
     "name": "people-kusama",
     "package": "people-kusama-runtime",
     "path": "system-parachains/people/people-kusama",
+    "uri": "wss://kusama-people-rpc.polkadot.io:443",
     "is_relay": false
   },
   {
     "name": "people-polkadot",
     "package": "people-polkadot-runtime",
     "path": "system-parachains/people/people-polkadot",
+    "uri": "wss://polkadot-people-rpc.polkadot.io:443",
     "is_relay": false
   },
   {


### PR DESCRIPTION
Relates to: https://github.com/polkadot-fellows/runtimes/issues/186

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [X] Does not require a CHANGELOG entry
