### PR TITLE
change try-runtime endpoints to the new ones

### DIFF
--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -3,14 +3,14 @@
     "name": "polkadot",
     "package": "polkadot-runtime",
     "path": "relay/polkadot",
-    "uri": "wss://polkadot-try-runtime-node.parity-chains.parity.io:443",
+    "uri": "wss://try-runtime.polkadot.io:443",
     "is_relay": true
   },
   {
     "name": "kusama",
     "package": "staging-kusama-runtime",
     "path": "relay/kusama",
-    "uri": "wss://kusama-try-runtime-node.parity-chains.parity.io:443",
+    "uri": "wss://try-runtime-kusama.polkadot.io:443",
     "is_relay": true
   },
   {


### PR DESCRIPTION
as part of https://github.com/paritytech/devops/issues/3502, try-runtime nodes were migrated to a new provider with a new domain address. The PR fixes all the references to try-runtime nodes on rococo, westend, kusama and polkadot networks.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
