### PR TITLE
Adds migrations to restore currupted staking ledgers in Polkadot and Kusama

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10008,6 +10008,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "hex-literal",
  "log",
  "pallet-asset-rate",
  "pallet-authority-discovery",

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1824,6 +1824,20 @@ pub mod migrations {
 	pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);
 }
 
+/// Migration to fix current corrupted staking ledgers in Kusama.
+///
+/// It consists of:
+/// * Call into `pallet_staking::Pallet::<T>::restore_ledger` with:
+///  * Root origin;
+///  * Default `None` paramters.
+/// * Forces unstake of recovered ledger if the final restored ledger has higher stake than the
+/// stash's free balance.
+///
+/// The stashes associated with corrupted ledgers that will be "migrated" are set in
+/// [`CorruptedStashes`].
+///
+/// For more details about the corrupt ledgers issue, recovery and which stashes to migrate, check
+/// <https://hackmd.io/m_h9DRutSZaUqCwM9tqZ3g?view>.
 pub(crate) mod restore_corrupted_ledgers {
 	use super::*;
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1864,9 +1864,11 @@ pub(crate) mod restore_corrupted_ledgers {
 				) {
 					Ok(_) => (), // proceed.
 					Err(err) => {
+						// note: after first migration run, restoring ledger will fail with
+						// `staking::pallet::Error::<T>CannotRestoreLedger`.
 						log::error!(
 							target: LOG_TARGET,
-							"migrations::corrupted_ledgers: error restoring ledger {:?}, unexpected.",
+							"migrations::corrupted_ledgers: error restoring ledger {:?}, unexpected (unless running try-state idempotency round).",
 							err
 						);
 						continue

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -92,6 +92,7 @@ pallet-election-provider-support-benchmarking = { optional = true, workspace = t
 pallet-offences-benchmarking = { optional = true, workspace = true }
 pallet-session-benchmarking = { optional = true, workspace = true }
 pallet-nomination-pools-benchmarking = { optional = true, workspace = true }
+hex-literal = { workspace = true }
 
 polkadot-runtime-common = { workspace = true }
 runtime-parachains = { workspace = true }

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -2039,6 +2039,20 @@ pub mod migrations {
 	pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);
 }
 
+/// Migration to fix current corrupted staking ledgers in Polkadot.
+///
+/// It consists of:
+/// * Call into `pallet_staking::Pallet::<T>::restore_ledger` with:
+///  * Root origin;
+///  * Default `None` paramters.
+/// * Forces unstake of recovered ledger if the final restored ledger has higher stake than the
+/// stash's free balance.
+///
+/// The stashes associated with corrupted ledgers that will be "migrated" are set in
+/// [`CorruptedStashes`].
+///
+/// For more details about the corrupt ledgers issue, recovery and which stashes to migrate, check
+/// <https://hackmd.io/m_h9DRutSZaUqCwM9tqZ3g?view>.
 pub(crate) mod restore_corrupted_ledgers {
 	use super::*;
 

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -2042,7 +2042,7 @@ pub mod migrations {
 pub(crate) mod restore_corrupted_ledgers {
 	use super::*;
 
-	use frame_support::traits::{Currency, OnRuntimeUpgrade};
+	use frame_support::traits::Currency;
 	use frame_system::RawOrigin;
 
 	use pallet_staking::WeightInfo;
@@ -2081,9 +2081,11 @@ pub(crate) mod restore_corrupted_ledgers {
 				) {
 					Ok(_) => (), // proceed.
 					Err(err) => {
+						// note: after first migration run, restoring ledger will fail with
+						// `staking::pallet::Error::<T>CannotRestoreLedger`.
 						log::error!(
 							target: LOG_TARGET,
-							"migrations::corrupted_ledgers: error restoring ledger {:?}, unexpected.",
+							"migrations::corrupted_ledgers: error restoring ledger {:?}, unexpected (unless running try-state idempotency round).",
 							err
 						);
 						continue


### PR DESCRIPTION
Note: for more details on the corrupted ledgers issue and recovery steps check https://hackmd.io/m_h9DRutSZaUqCwM9tqZ3g?view.

This PR adds a migration in Polkadot and Kusama runtimes to recover the current corrupted ledgers in Polkadot and Kusama. A migration consists of:

1. Call into `pallet_staking::Pallet::<T>::restore_ledger` for each of the "whitelisted" stashes as `Root` origin.
2. Performs a check that ensures the restored ledger's stake does not overflow the current stash's free balance. If that's the case, force unstake the ledger. This check is currently missing in polkadot-sdk/pallet-staking ([PR with patch here](https://github.com/paritytech/polkadot-sdk/pull/5066)).

The reason to restore the corrupted ledgers as migrations implemented in the fellowship runtimes is to speed up the whole process and avoid having to wait for 1. merge and releases of https://github.com/paritytech/polkadot-sdk/pull/5066 and 2. referenda to call into `Call::restore_ledger` for both Polkadot and Kusama.

Alternatively, we could add a new temporary pallet directly in the fellowship runtime which would expose an extrinsic to restore the ledgers and perform the extra missing check. See this [PR as an example](https://github.com/gpestana/fellowship-runtimes/pull/2).