### PR TITLE
Bridges integration tests: added support for running with different releases

### DIFF
--- a/integration-tests/bridges/README.md
+++ b/integration-tests/bridges/README.md
@@ -25,9 +25,12 @@ To start a test, you need to:
 - build Substrate relay by running `cargo build -p substrate-relay --release` command in the
 [`parity-bridges-common`](https://github.com/paritytech/parity-bridges-common) repository clone. Copy the binary to `~/local_bridge_testing/bin/substrate-relay`. 
 - build chain spec generator:
+  - (you can use the current branch, or you can build generators from different branches, such as from specific tags or releases)
   - add the `sudo` pallet to the Polkadot and Kusama runtimes and give sudo rights to Alice, e.g. by running `git apply ./integration-tests/bridges/sudo-relay.patch` from the fellows root dir.
   - with this change build the chain spec generator by running `cargo build --release -p chain-spec-generator --features fast-runtime` 
-command. Copy the binary to `~/local_bridge_testing/bin/chain-spec-generator`.
+command.
+    - Copy the binary to `~/local_bridge_testing/bin/chain-spec-generator-kusama`.
+    - Copy the binary to `~/local_bridge_testing/bin/chain-spec-generator-polkadot`.
 - check/change the `POLKADOT_BINARY` and `POLKADOT_PARACHAIN_BINARY` paths (and ensure that the nearby variables
 have correct values) in the `./run-test.sh`.
 

--- a/integration-tests/bridges/environments/polkadot-kusama/bridge_hub_kusama_local_network.toml
+++ b/integration-tests/bridges/environments/polkadot-kusama/bridge_hub_kusama_local_network.toml
@@ -5,7 +5,7 @@ node_spawn_timeout = 240
 default_command = "{{POLKADOT_BINARY}}"
 default_args = ["-lparachain=debug,xcm=trace"]
 chain = "kusama-local"
-chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY}} {% raw %} {{chainName}} {% endraw %}"
+chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY_FOR_KUSAMA}} {% raw %} {{chainName}} {% endraw %}"
 
 [[relaychain.nodes]]
 name = "alice"
@@ -31,7 +31,7 @@ balance = 2000000000000
 [[parachains]]
 id = 1000
 chain = "asset-hub-kusama-local"
-chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY}} {% raw %} {{chainName}} {% endraw %}"
+chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY_FOR_KUSAMA}} {% raw %} {{chainName}} {% endraw %}"
 cumulus_based = true
 
 [[parachains.collators]]
@@ -49,7 +49,7 @@ args = ["-lparachain=debug,xcm=trace,runtime::bridge-transfer=trace"]
 [[parachains]]
 id = 1002
 chain = "bridge-hub-kusama-local"
-chain_spec_command = "{{ENV_PATH}}/generate_bh_spec.sh Polkadot {% raw %} {{chainName}} {% endraw %}"
+chain_spec_command = "{{ENV_PATH}}/generate_bhk_spec.sh Polkadot {% raw %} {{chainName}} {% endraw %}"
 cumulus_based = true
 
 # run alice as parachain collator

--- a/integration-tests/bridges/environments/polkadot-kusama/bridge_hub_polkadot_local_network.toml
+++ b/integration-tests/bridges/environments/polkadot-kusama/bridge_hub_polkadot_local_network.toml
@@ -5,7 +5,7 @@ node_spawn_timeout = 240
 default_command = "{{POLKADOT_BINARY}}"
 default_args = ["-lparachain=debug,xcm=trace"]
 chain = "polkadot-local"
-chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY}} {% raw %} {{chainName}} {% endraw %}"
+chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY_FOR_POLKADOT}} {% raw %} {{chainName}} {% endraw %}"
 
 [[relaychain.nodes]]
 name = "alice"
@@ -31,7 +31,7 @@ balance = 2000000000000
 [[parachains]]
 id = 1000
 chain = "asset-hub-polkadot-local"
-chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY}} {% raw %} {{chainName}} {% endraw %}"
+chain_spec_command = "{{CHAIN_SPEC_GEN_BINARY_FOR_POLKADOT}} {% raw %} {{chainName}} {% endraw %}"
 cumulus_based = true
 
 [[parachains.collators]]
@@ -49,7 +49,7 @@ args = ["-lparachain=debug,xcm=trace,runtime::bridge-transfer=trace"]
 [[parachains]]
 id = 1002
 chain = "bridge-hub-polkadot-local"
-chain_spec_command = "{{ENV_PATH}}/generate_bh_spec.sh Kusama {% raw %} {{chainName}} {% endraw %}"
+chain_spec_command = "{{ENV_PATH}}/generate_bhp_spec.sh Kusama {% raw %} {{chainName}} {% endraw %}"
 cumulus_based = true
 
 [[parachains.collators]]

--- a/integration-tests/bridges/environments/polkadot-kusama/generate_bhk_spec.sh
+++ b/integration-tests/bridges/environments/polkadot-kusama/generate_bhk_spec.sh
@@ -6,7 +6,7 @@ shift
 # Add Alice as bridge owner
 # We do this only if there is a `.genesis.runtimeGenesis.patch` object.
 # Otherwise we're working with the raw chain spec.
-$CHAIN_SPEC_GEN_BINARY "$@" \
+$CHAIN_SPEC_GEN_BINARY_FOR_KUSAMA "$@" \
   | jq 'if .genesis.runtimeGenesis.patch
     then .genesis.runtimeGenesis.patch.bridge'$bridged_chain'Grandpa.owner = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
     else .

--- a/integration-tests/bridges/environments/polkadot-kusama/generate_bhp_spec.sh
+++ b/integration-tests/bridges/environments/polkadot-kusama/generate_bhp_spec.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+bridged_chain=$1
+shift
+
+# Add Alice as bridge owner
+# We do this only if there is a `.genesis.runtimeGenesis.patch` object.
+# Otherwise we're working with the raw chain spec.
+$CHAIN_SPEC_GEN_BINARY_FOR_POLKADOT "$@" \
+  | jq 'if .genesis.runtimeGenesis.patch
+    then .genesis.runtimeGenesis.patch.bridge'$bridged_chain'Grandpa.owner = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    else .
+    end'

--- a/integration-tests/bridges/run-test.sh
+++ b/integration-tests/bridges/run-test.sh
@@ -34,7 +34,8 @@ echo
 export ZOMBIENET_BINARY=$LOCAL_BRIDGE_TESTING_PATH/bin/zombienet
 export POLKADOT_BINARY=$LOCAL_BRIDGE_TESTING_PATH/bin/polkadot
 export POLKADOT_PARACHAIN_BINARY=$LOCAL_BRIDGE_TESTING_PATH/bin/polkadot-parachain
-export CHAIN_SPEC_GEN_BINARY=$LOCAL_BRIDGE_TESTING_PATH/bin/chain-spec-generator
+export CHAIN_SPEC_GEN_BINARY_FOR_KUSAMA=$LOCAL_BRIDGE_TESTING_PATH/bin/chain-spec-generator-kusama
+export CHAIN_SPEC_GEN_BINARY_FOR_POLKADOT=$LOCAL_BRIDGE_TESTING_PATH/bin/chain-spec-generator-polkadot
 export SUBSTRATE_RELAY_BINARY=$LOCAL_BRIDGE_TESTING_PATH/bin/substrate-relay
 
 export TEST_DIR=`mktemp -d /tmp/bridges-tests-run-XXXXX`


### PR DESCRIPTION
This PR introduces a minor update to the bridges testing scripts, enabling the use of different `chain-spec-generator` versions for Polkadot and Kusama environments from various releases. Polkadot and Kusama runtimes are upgraded asynchronously, so this is useful when testing bridging between the Polkadot Bridge Hub (e.g., currently live as v1.2.8) and the Kusama Bridge Hub (upcoming upgrade to v1.3.0).

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [X] Does not require a CHANGELOG entry
