### PR TITLE
change max_deciding of the FellowshipAdmin track to 30

### DIFF
--- a/relay/polkadot/src/governance/tracks.rs
+++ b/relay/polkadot/src/governance/tracks.rs
@@ -154,7 +154,7 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 16
 		13,
 		pallet_referenda::TrackInfo {
 			name: "fellowship_admin",
-			max_deciding: 10,
+			max_deciding: 30,
 			decision_deposit: 5 * GRAND,
 			prepare_period: 2 * HOURS,
 			decision_period: 28 * DAYS,


### PR DESCRIPTION
This PR changes the max number of refs that can be in the `deciding` state in the `FellowshipAdmin` track from 10 to 30.

This is a defensive measure to allow a potential submission of 21 rank retention refs for Head Ambassadors to go into simultaneous decision.

## Background and Rationale
The OpenGov community is currently discussing updates to the Ambassador Program social contract. One potential path is to begin to make use of the `demotionPeriod` parameter in the `ambassadorCore` to introduce a demotion period. This would then force the existing 20 collective members of rank 3 (the highest rank) to submit retention referenda to the OpenGon `FellowshipAdmin` track. If the track would fill up and not allow sufficient decisions within the demotionPeriod, it could lead to unwanted demotions that are not in the intention of the DAO.

To avoid this situation, this PR raises the limit to 30. This gives room for 21 retention referenda + additional room for any other potential collectives chain related refs.


- [ ] Does not require a CHANGELOG entry
