### PR TITLE
Polkadot: Constant yearly emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+Change Polkadot inflation to 120M DOT per year ([polkadot-fellows/runtimes#471](https://github.com/polkadot-fellows/runtimes/pull/471))
+
 ## [1.3.3] 01.10.2024
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7421,6 +7421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15088,12 +15094,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -15108,10 +15115,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10069,6 +10069,7 @@ dependencies = [
 name = "polkadot-runtime"
 version = "1.0.0"
 dependencies = [
+ "approx",
  "binary-merkle-tree",
  "frame-benchmarking",
  "frame-election-provider-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0-only"                                        # TODO <https://
 
 [workspace.dependencies]
 assert_matches = { version = "1.5.0" }
+approx = { version = "0.5.1" }
 asset-hub-kusama-emulated-chain = { path = "integration-tests/emulated/chains/parachains/assets/asset-hub-kusama" }
 asset-hub-kusama-runtime = { path = "system-parachains/asset-hubs/asset-hub-kusama" }
 asset-hub-polkadot-emulated-chain = { path = "integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot" }

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -110,6 +110,7 @@ sp-debug-derive = { workspace = true }
 polkadot-parachain-primitives = { workspace = true }
 
 [dev-dependencies]
+approx = { workspace = true }
 sp-keyring = { workspace = true }
 sp-trie = { workspace = true }
 separator = { workspace = true }

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -3459,6 +3459,27 @@ mod multiplier_tests {
 		assert_eq!(projected_total_issuance, 26_725_065_621_398_235_666);
 	}
 
+	// Print percent per year, just as convenience.
+	#[test]
+	fn staking_inflation_correct_print_percent() {
+		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+			123, // ignored
+			456, // ignored
+			(35625 * MILLISECONDS_PER_DAY) / 100, // 1 year
+		);
+		let yearly_emission = to_stakers + to_treasury;
+		let mut ti: i128 = 15_011_657_390_566_252_333;
+
+		for y in 0..10 {
+			let new_ti = ti + yearly_emission as i128;
+			let inflation = 100.0 * (new_ti - ti) as f64 / ti as f64;
+			println!("Year {y} inflation: {inflation}%");
+			ti = new_ti;
+
+			assert!(inflation <= 8.0 && inflation > 2.0, "sanity check");
+		}
+	}
+
 	#[test]
 	fn fast_unstake_estimate() {
 		use pallet_fast_unstake::WeightInfo;

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -3432,8 +3432,8 @@ mod multiplier_tests {
 	#[test]
 	fn staking_inflation_correct_whole_year() {
 		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123, // ignored
-			456, // ignored
+			123,                                  // ignored
+			456,                                  // ignored
 			(35625 * MILLISECONDS_PER_DAY) / 100, // 1 year
 		);
 
@@ -3448,8 +3448,8 @@ mod multiplier_tests {
 	#[test]
 	fn staking_inflation_correct_not_overflow() {
 		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123, // ignored
-			456, // ignored
+			123,                                 // ignored
+			456,                                 // ignored
 			(35625 * MILLISECONDS_PER_DAY) / 10, // 10 years
 		);
 		let initial_ti: i128 = 15_011_657_390_566_252_333;
@@ -3463,8 +3463,8 @@ mod multiplier_tests {
 	#[test]
 	fn staking_inflation_correct_print_percent() {
 		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123, // ignored
-			456, // ignored
+			123,                                  // ignored
+			456,                                  // ignored
 			(35625 * MILLISECONDS_PER_DAY) / 100, // 1 year
 		);
 		let yearly_emission = to_stakers + to_treasury;

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -716,8 +716,8 @@ impl pallet_staking::EraPayout<Balance> for EraPayout {
 
 		// TI at the time of execution of [Referendum 1139](https://polkadot.subsquare.io/referenda/1139), block hash: `0x39422610299a75ef69860417f4d0e1d94e77699f45005645ffc5e8e619950f9f`.
 		let fixed_total_issuance: i128 = 15_011_657_390_566_252_333;
-		let yearly_inflation_rate = FixedU128::from_rational(8, 100);
-		let yearly_emission = yearly_inflation_rate.saturating_mul_int(fixed_total_issuance);
+		let fixed_inflation_rate = FixedU128::from_rational(8, 100);
+		let yearly_emission = fixed_inflation_rate.saturating_mul_int(fixed_total_issuance);
 
 		let era_emission = relative_era_len.saturating_mul_int(yearly_emission);
 		// 15% to treasury, as per ref 1139.
@@ -3405,7 +3405,7 @@ mod multiplier_tests {
 	const MILLISECONDS_PER_DAY: u64 = 24 * 60 * 60 * 1000;
 
 	#[test]
-	fn staking_inflation_correct() {
+	fn staking_inflation_correct_single_era() {
 		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
 			123, // ignored
 			456, // ignored
@@ -3413,8 +3413,14 @@ mod multiplier_tests {
 		);
 
 		// Values are within 0.1%
-		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64, max_relative = 0.1);
-		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64, max_relative = 0.1);
+		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64, max_relative = 0.01);
+		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64, max_relative = 0.01);
+		// Total per day is ~328,797 DOT
+		assert_relative_eq!(
+			(to_stakers as f64 + to_treasury as f64),
+			(328_797 * UNITS) as f64,
+			max_relative = 0.01
+		);
 	}
 
 	#[test]
@@ -3425,8 +3431,9 @@ mod multiplier_tests {
 			456, // ignored
 			2 * MILLISECONDS_PER_DAY,
 		);
-		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64 * 2.0, max_relative = 0.1);
-		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64 * 2.0, max_relative = 0.1);
+
+		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64 * 2.0, max_relative = 0.01);
+		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64 * 2.0, max_relative = 0.01);
 	}
 
 	#[test]
@@ -3437,28 +3444,16 @@ mod multiplier_tests {
 			(36525 * MILLISECONDS_PER_DAY) / 100, // 1 year
 		);
 
-		// 8% of the fixed total issuance: 120M Dot per year
+		// Our yearly emissions is about 120M DOT:
 		let yearly_emission = 120_093_259 * UNITS;
-
-		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.1);
-		assert_relative_eq!(to_treasury as f64, yearly_emission as f64 * 0.15, max_relative = 0.1);
-	}
-
-	#[test]
-	fn staking_inflation_while_year_exact() {
-		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123,                                  // ignored
-			456,                                  // ignored
-			(365625 * MILLISECONDS_PER_DAY) / 100, // 1 year
+		assert_relative_eq!(
+			to_stakers as f64 + to_treasury as f64,
+			yearly_emission as f64,
+			max_relative = 0.01
 		);
 
-		// 8% of the fixed total issuance is about 120M Dot per year
-		let yearly_emission = 120_093_259 * UNITS;
-		// But also check it exactly:
-		assert_eq!(to_stakers + to_treasury, 1200932590000000000);
-
-		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.1);
-		assert_relative_eq!(to_treasury as f64, yearly_emission as f64 * 0.15, max_relative = 0.1);
+		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.01);
+		assert_relative_eq!(to_treasury as f64, yearly_emission as f64 * 0.15, max_relative = 0.01);
 	}
 
 	// 10 years into the future, our values do not overflow.
@@ -3467,13 +3462,17 @@ mod multiplier_tests {
 		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
 			123,                                 // ignored
 			456,                                 // ignored
-			(365625 * MILLISECONDS_PER_DAY) / 10, // 10 years
+			(36525 * MILLISECONDS_PER_DAY) / 10, // 10 years
 		);
 		let initial_ti: i128 = 15_011_657_390_566_252_333;
 		let projected_total_issuance = (to_stakers as i128 + to_treasury as i128) + initial_ti;
 
 		// In 2034, there will be about 2.7 billion DOT in existence.
-		assert_relative_eq!(projected_total_issuance as f64, (2_700_000_0000 * UNITS) as f64, max_relative = 0.1);
+		assert_relative_eq!(
+			projected_total_issuance as f64,
+			(2_700_000_000 * UNITS) as f64,
+			max_relative = 0.01
+		);
 	}
 
 	// Print percent per year, just as convenience.
@@ -3482,7 +3481,7 @@ mod multiplier_tests {
 		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
 			123,                                  // ignored
 			456,                                  // ignored
-			(365625 * MILLISECONDS_PER_DAY) / 100, // 1 year
+			(36525 * MILLISECONDS_PER_DAY) / 100, // 1 year
 		);
 		let yearly_emission = to_stakers + to_treasury;
 		let mut ti: i128 = 15_011_657_390_566_252_333;

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -3432,8 +3432,16 @@ mod multiplier_tests {
 			2 * MILLISECONDS_PER_DAY,
 		);
 
-		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64 * 2.0, max_relative = 0.001);
-		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64 * 2.0, max_relative = 0.001);
+		assert_relative_eq!(
+			to_stakers as f64,
+			(279_477 * UNITS) as f64 * 2.0,
+			max_relative = 0.001
+		);
+		assert_relative_eq!(
+			to_treasury as f64,
+			(49_320 * UNITS) as f64 * 2.0,
+			max_relative = 0.001
+		);
 	}
 
 	#[test]
@@ -3453,7 +3461,11 @@ mod multiplier_tests {
 		);
 
 		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.001);
-		assert_relative_eq!(to_treasury as f64, yearly_emission as f64 * 0.15, max_relative = 0.001);
+		assert_relative_eq!(
+			to_treasury as f64,
+			yearly_emission as f64 * 0.15,
+			max_relative = 0.001
+		);
 	}
 
 	// 10 years into the future, our values do not overflow.

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -3413,13 +3413,13 @@ mod multiplier_tests {
 		);
 
 		// Values are within 0.1%
-		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64, max_relative = 0.01);
-		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64, max_relative = 0.01);
+		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64, max_relative = 0.001);
+		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64, max_relative = 0.001);
 		// Total per day is ~328,797 DOT
 		assert_relative_eq!(
 			(to_stakers as f64 + to_treasury as f64),
 			(328_797 * UNITS) as f64,
-			max_relative = 0.01
+			max_relative = 0.001
 		);
 	}
 
@@ -3432,8 +3432,8 @@ mod multiplier_tests {
 			2 * MILLISECONDS_PER_DAY,
 		);
 
-		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64 * 2.0, max_relative = 0.01);
-		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64 * 2.0, max_relative = 0.01);
+		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64 * 2.0, max_relative = 0.001);
+		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64 * 2.0, max_relative = 0.001);
 	}
 
 	#[test]
@@ -3449,11 +3449,11 @@ mod multiplier_tests {
 		assert_relative_eq!(
 			to_stakers as f64 + to_treasury as f64,
 			yearly_emission as f64,
-			max_relative = 0.01
+			max_relative = 0.001
 		);
 
-		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.01);
-		assert_relative_eq!(to_treasury as f64, yearly_emission as f64 * 0.15, max_relative = 0.01);
+		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.001);
+		assert_relative_eq!(to_treasury as f64, yearly_emission as f64 * 0.15, max_relative = 0.001);
 	}
 
 	// 10 years into the future, our values do not overflow.
@@ -3471,7 +3471,7 @@ mod multiplier_tests {
 		assert_relative_eq!(
 			projected_total_issuance as f64,
 			(2_700_000_000 * UNITS) as f64,
-			max_relative = 0.01
+			max_relative = 0.001
 		);
 	}
 


### PR DESCRIPTION
Sets the inflation to ~120M DOT per year as specified in [Ref 1139](https://polkadot.subsquare.io/referenda/1139). 15% of that goes to the treasury and the rest to stakers.

## Details

This MR sets the Polkadot inflation to a fixed amount per year. The yearly increase is ~120,063,259 DOT. The amount was set to 8% of the Total Issuance at block [22810263](https://polkadot.statescan.io/#/blocks/22810263) in which referendum [1139](https://polkadot.subsquare.io/referenda/1139) was executed. You can check this for yourself:

<img width="1414" alt="Screenshot 2024-10-08 at 16 51 07" src="https://github.com/user-attachments/assets/3254f706-c53f-44c2-8ab7-75f08b9ce3f8">

Multiplying this by 8% and converting to DOT is about **`120,093,259` DOT per year**.  
This results in an emissions of `120,093,259 / 365.25` about **`328,797` DOT per day**.

The Total Issuance and yearly inflation look like this over the next 25 years:
![inflation](https://github.com/user-attachments/assets/32572833-0a62-4823-9b7e-00350fcf1b9d)

<details><summary>Concrete numbers</summary>
<p>

```pre
Initial 1.501 BDOT
Year 1: 1.621 BDOT +7.407%
Year 2: 1.741 BDOT +6.897%
Year 3: 1.861 BDOT +6.452%
Year 4: 1.982 BDOT +6.061%
Year 5: 2.102 BDOT +5.714%
Year 6: 2.222 BDOT +5.405%
Year 7: 2.342 BDOT +5.128%
Year 8: 2.462 BDOT +4.878%
Year 9: 2.582 BDOT +4.651%
Year 10: 2.702 BDOT +4.444%
Year 11: 2.822 BDOT +4.255%
Year 12: 2.942 BDOT +4.082%
Year 13: 3.062 BDOT +3.922%
Year 14: 3.182 BDOT +3.774%
Year 15: 3.303 BDOT +3.636%
Year 16: 3.423 BDOT +3.509%
Year 17: 3.543 BDOT +3.390%
Year 18: 3.663 BDOT +3.279%
Year 19: 3.783 BDOT +3.175%
Year 20: 3.903 BDOT +3.077%
Year 21: 4.023 BDOT +2.985%
Year 22: 4.143 BDOT +2.899%
Year 23: 4.263 BDOT +2.817%
Year 24: 4.383 BDOT +2.740%
Year 25: 4.503 BDOT +2.667%
```

</p>
</details> 

## Implications

15% of the inflation goes to the treasury which results in a yearly treasury inflow of ~18M DOT (1.5M DOT per month).  
Stakers will receive ~102M DOT per year (~8.5M DOT per month).