### PR TITLE
Switch clippy from +nightly to $RUST_STABLE_VERSION

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Set rust version via common env file
         run: cat .github/env >> $GITHUB_ENV
 
-      - name: Install nightly toolchain
-        run: rustup toolchain install "nightly-$RUST_NIGHTLY_VERSION" --profile minimal --component clippy
+      - name: Install stable toolchain
+        run: |
+          rustup toolchain install $RUST_STABLE_VERSION --profile minimal --component clippy
+          cargo --version
+          cargo clippy --version
 
       - name: Fetch cache
         uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43 # v2.7.0
@@ -34,7 +37,7 @@ jobs:
           shared-key: "fellowship-cache-clippy"
 
       - name: Clippy
-        run: cargo +nightly-$RUST_NIGHTLY_VERSION clippy --all-targets --locked -q
+        run: cargo clippy --all-targets --locked -q
         env:
           RUSTFLAGS: "-D warnings"
           SKIP_WASM_BUILD: 1

--- a/relay/kusama/src/governance/origins.rs
+++ b/relay/kusama/src/governance/origins.rs
@@ -18,7 +18,6 @@
 
 pub use pallet_custom_origins::*;
 
-#[allow(unreachable_patterns)]
 #[frame_support::pallet]
 pub mod pallet_custom_origins {
 	use crate::{Balance, GRAND, QUID};

--- a/relay/polkadot/src/governance/origins.rs
+++ b/relay/polkadot/src/governance/origins.rs
@@ -18,7 +18,6 @@
 
 pub use pallet_custom_origins::*;
 
-#[allow(unreachable_patterns)]
 #[frame_support::pallet]
 pub mod pallet_custom_origins {
 	use crate::{Balance, DOLLARS, GRAND};

--- a/system-parachains/collectives/collectives-polkadot/src/ambassador/origins.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/ambassador/origins.rs
@@ -15,7 +15,6 @@
 
 //! The Ambassador Program's origins.
 
-#[allow(unreachable_patterns)]
 #[frame_support::pallet]
 pub mod pallet_origins {
 	use crate::ambassador::ranks;

--- a/system-parachains/collectives/collectives-polkadot/src/fellowship/origins.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/fellowship/origins.rs
@@ -19,7 +19,6 @@
 use super::ranks;
 pub use pallet_origins::*;
 
-#[allow(unreachable_patterns)]
 #[frame_support::pallet]
 pub mod pallet_origins {
 	use super::ranks;


### PR DESCRIPTION
Relates to: https://github.com/paritytech/polkadot-sdk/issues/6127

- [X] Does not require a CHANGELOG entry
