### PR TITLE
Lower Parachain and Data Deposits to Encourage Experimentation on Kusama

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1468,7 +1468,7 @@ impl parachains_slashing::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ParaDeposit: Balance = 40 * UNITS;
+	pub const ParaDeposit: Balance = 4 * UNITS;
 }
 
 impl paras_registrar::Config for Runtime {

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -830,7 +830,7 @@ parameter_types! {
 	pub const TipCountdown: BlockNumber = DAYS;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
 	pub const TipReportDepositBase: Balance = 100 * CENTS;
-	pub const DataDepositPerByte: Balance = CENTS;
+	pub const DataDepositPerByte: Balance = CENTS / 10;
 	pub const MaxApprovals: u32 = 100;
 	pub const MaxAuthorities: u32 = 100_000;
 	pub const MaxKeys: u32 = 10_000;


### PR DESCRIPTION
Chaos is a ladder, this PR proposes bringing the rungs a tad bit closer to make it easier to climb.

In other words, this PR aims to lower the barriers for experimentation and innovation within the Polkadot ecosystem. We're reducing both the `ParaDeposit` and `DataDepositPerByte` to encourage more developers and projects to deploy and test their ideas on Kusama.

The changes:

- Reduced ParaDeposit from 40 UNITS to 4 UNITS
- Lowered DataDepositPerByte from 1 CENT to 0.1 CENTS

These adjustments will make it more accessible for teams to register a blockchain and get started. I think that making things accessible starts with making them affordable, this aims to do just that. This aligns with Kusama's role as a canary network, where we can push the boundaries of what's possible.

While we're lowering the initial costs, it's worth noting that this change **doesn't implement an adaptive fee structure** that would increase costs if too much code is registered too quickly. Such a mechanism could be considered for future implementations, potentially as a Polkadot-ready solution. 

Kusama is the playground for radical innovation. With these lowered deposits, we're inviting chaos – controlled chaos that drives progress.

Expect the unexpected, and let's see what comes out the other end. :)