### PR TITLE
Fix auto-renew benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-kusama-runtime",
  "staging-xcm",
  "staging-xcm-executor",
@@ -689,7 +689,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -745,7 +745,7 @@ dependencies = [
  "polkadot-runtime",
  "polkadot-runtime-common",
  "polkadot-system-emulated-network",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
@@ -823,7 +823,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -861,7 +861,7 @@ dependencies = [
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-builder",
@@ -886,7 +886,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -1431,7 +1431,7 @@ dependencies = [
  "kusama-runtime-constants",
  "polkadot-runtime-constants",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "system-parachains-constants",
 ]
@@ -1449,7 +1449,7 @@ dependencies = [
  "polkadot-runtime-constants",
  "snowbridge-core",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
  "system-parachains-constants",
@@ -1469,7 +1469,7 @@ dependencies = [
  "serde",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -1518,7 +1518,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -1551,7 +1551,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -1570,7 +1570,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -1589,7 +1589,7 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -1610,7 +1610,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-std",
  "sp-trie 37.0.0",
@@ -1633,7 +1633,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "sp-trie 37.0.0",
 ]
@@ -1665,7 +1665,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
 ]
 
@@ -1682,7 +1682,7 @@ dependencies = [
  "scale-info",
  "snowbridge-core",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
 ]
@@ -1732,7 +1732,7 @@ dependencies = [
  "snowbridge-pallet-system",
  "snowbridge-router-primitives",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
@@ -1816,7 +1816,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -1878,7 +1878,7 @@ dependencies = [
  "snowbridge-pallet-system",
  "snowbridge-router-primitives",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
@@ -1974,7 +1974,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -2028,7 +2028,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "staging-xcm",
  "staging-xcm-builder",
@@ -2060,7 +2060,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "sp-trie 37.0.0",
  "staging-xcm",
@@ -2411,7 +2411,7 @@ dependencies = [
  "polkadot-runtime-constants",
  "polkadot-system-emulated-network",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
@@ -2481,7 +2481,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -2665,7 +2665,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-kusama-runtime",
  "staging-xcm",
  "staging-xcm-executor",
@@ -2726,7 +2726,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -2774,7 +2774,7 @@ dependencies = [
  "polkadot-runtime-constants",
  "polkadot-runtime-parachains",
  "polkadot-system-emulated-network",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-executor",
  "xcm-runtime-apis",
@@ -2835,7 +2835,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -3097,7 +3097,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -3127,7 +3127,7 @@ dependencies = [
  "sp-externalities 0.29.0",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-std",
  "sp-trie 37.0.0",
@@ -3160,7 +3160,7 @@ dependencies = [
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -3175,7 +3175,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
 ]
 
@@ -3199,7 +3199,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -3216,7 +3216,7 @@ dependencies = [
  "polkadot-primitives 15.0.0",
  "sp-api",
  "sp-consensus-aura",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -3231,7 +3231,7 @@ dependencies = [
  "polkadot-primitives 16.0.0",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
  "staging-xcm",
 ]
@@ -3274,7 +3274,7 @@ dependencies = [
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -3289,7 +3289,7 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives 16.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
 ]
@@ -3828,7 +3828,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "xcm-emulator",
 ]
@@ -3862,7 +3862,7 @@ dependencies = [
  "pallet-encointer-balances",
  "pallet-encointer-ceremonies",
  "pallet-transaction-payment",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -3886,7 +3886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d3890b05d20d81cd72e461b4e4a40e574f357bd8bd93095d60196bf85f0ca2b"
 dependencies = [
  "encointer-primitives",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -3963,7 +3963,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-transaction-pool",
@@ -3987,7 +3987,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -4007,7 +4007,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "substrate-geohash",
 ]
@@ -4099,7 +4099,7 @@ dependencies = [
  "serde",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "substrate-fixed",
 ]
@@ -4406,7 +4406,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-storage 21.0.0",
  "static_assertions",
@@ -4438,7 +4438,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -4456,7 +4456,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
 ]
 
@@ -4496,7 +4496,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -4514,7 +4514,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "spinners",
  "substrate-rpc-client",
@@ -4524,9 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "38.0.0"
+version = "38.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e44af69fa61bc5005ffe0339e198957e77f0f255704a9bee720da18a733e3dc"
+checksum = "f7dd8b9f161a8289e3b9fe6c1068519358dbff2270d38097a923d3d1b4459dca"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4554,7 +4554,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-metadata-ir",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
  "sp-state-machine 0.43.0",
  "sp-std",
@@ -4623,7 +4623,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "sp-version",
  "sp-weights 31.0.0",
@@ -4641,7 +4641,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -4664,7 +4664,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -4919,7 +4919,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -6121,7 +6121,7 @@ dependencies = [
  "polkadot-runtime-common",
  "smallvec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm-builder",
 ]
@@ -7639,7 +7639,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7658,7 +7658,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7673,7 +7673,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7688,7 +7688,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7706,7 +7706,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7723,7 +7723,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7740,7 +7740,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-consensus-aura",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7756,7 +7756,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-authority-discovery",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7770,7 +7770,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7792,7 +7792,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
 ]
@@ -7815,7 +7815,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
 ]
 
@@ -7832,7 +7832,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7850,7 +7850,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
 ]
@@ -7877,7 +7877,7 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
 
@@ -7896,7 +7896,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -7915,7 +7915,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-consensus-grandpa",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -7934,7 +7934,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "sp-trie 37.0.0",
 ]
@@ -7956,7 +7956,7 @@ dependencies = [
  "pallet-bridge-grandpa",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -7981,15 +7981,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic 26.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-broker"
-version = "0.17.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3043c90106d88cb93fcf0d9b6d19418f11f44cc2b11873414aec3b46044a24ea"
+checksum = "018b477d7d464c451b1d09a4ce9e792c3c65b15fd764b23da38ff9980e786065"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8001,7 +8001,7 @@ dependencies = [
  "sp-api",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8020,7 +8020,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8039,7 +8039,7 @@ dependencies = [
  "parity-scale-codec",
  "rand",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -8057,7 +8057,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8074,7 +8074,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8093,7 +8093,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8108,7 +8108,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -8131,7 +8131,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
 ]
 
@@ -8146,7 +8146,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "sp-npos-elections",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8165,7 +8165,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8222,7 +8222,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8255,7 +8255,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8293,7 +8293,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8314,7 +8314,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8337,7 +8337,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8356,7 +8356,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8377,7 +8377,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -8410,7 +8410,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -8430,7 +8430,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8451,7 +8451,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
 ]
@@ -8470,7 +8470,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8489,7 +8489,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -8507,7 +8507,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8521,7 +8521,7 @@ dependencies = [
  "parity-scale-codec",
  "safe-mix",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8538,7 +8538,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8557,7 +8557,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -8576,7 +8576,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8592,7 +8592,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8609,7 +8609,7 @@ dependencies = [
  "pallet-nfts",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8627,7 +8627,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8654,7 +8654,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8671,7 +8671,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
  "sp-tracing 17.0.1",
 ]
@@ -8692,7 +8692,7 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-staking 36.0.0",
 ]
@@ -8721,7 +8721,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -8745,7 +8745,7 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -8764,7 +8764,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8781,7 +8781,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8796,7 +8796,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8815,7 +8815,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8830,7 +8830,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8849,7 +8849,7 @@ dependencies = [
  "serde",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8868,7 +8868,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8885,7 +8885,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -8904,7 +8904,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
  "sp-state-machine 0.43.0",
@@ -8924,7 +8924,7 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "rand",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
 ]
 
@@ -8943,7 +8943,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -8965,7 +8965,7 @@ dependencies = [
  "serde",
  "sp-application-crypto 38.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -9016,7 +9016,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9032,7 +9032,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9050,7 +9050,7 @@ dependencies = [
  "scale-info",
  "sp-inherents",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-storage 21.0.0",
  "sp-timestamp",
 ]
@@ -9068,7 +9068,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9080,7 +9080,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -9100,7 +9100,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9115,7 +9115,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9131,7 +9131,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9146,7 +9146,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9161,7 +9161,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9181,7 +9181,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9201,7 +9201,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9223,7 +9223,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9244,7 +9244,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -9274,7 +9274,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -9304,7 +9304,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-tracing 17.0.1",
  "staging-parachain-info",
  "staging-xcm",
@@ -9565,7 +9565,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-storage 21.0.0",
  "sp-transaction-pool",
@@ -9611,7 +9611,7 @@ dependencies = [
  "parity-scale-codec",
  "people-kusama-runtime",
  "polkadot-runtime-common",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-kusama-runtime",
  "staging-xcm",
  "staging-xcm-executor",
@@ -9672,7 +9672,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -9721,7 +9721,7 @@ dependencies = [
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
  "polkadot-system-emulated-network",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-xcm",
  "staging-xcm-executor",
  "xcm-runtime-apis",
@@ -9780,7 +9780,7 @@ dependencies = [
  "sp-genesis-builder",
  "sp-inherents",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-std",
  "sp-storage 21.0.0",
@@ -9940,7 +9940,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9958,7 +9958,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -9974,7 +9974,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
 ]
 
@@ -10001,7 +10001,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 34.0.0",
 ]
 
@@ -10028,7 +10028,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -10121,7 +10121,7 @@ dependencies = [
  "sp-keyring",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
  "sp-std",
@@ -10181,7 +10181,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-npos-elections",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
  "staging-xcm",
@@ -10199,7 +10199,7 @@ dependencies = [
  "polkadot-runtime-common",
  "smallvec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm-builder",
 ]
@@ -10258,7 +10258,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
  "sp-std",
@@ -11150,7 +11150,7 @@ dependencies = [
  "polkadot-primitives 16.0.0",
  "scale-info",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -11631,7 +11631,7 @@ dependencies = [
  "sp-blockchain",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
 ]
 
@@ -11658,7 +11658,7 @@ dependencies = [
  "sp-crypto-hashing",
  "sp-genesis-builder",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-tracing 17.0.1",
 ]
@@ -11695,7 +11695,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-database",
  "sp-externalities 0.29.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-statement-store",
  "sp-storage 21.0.0",
@@ -11722,7 +11722,7 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "substrate-prometheus-endpoint",
  "thiserror",
@@ -11768,7 +11768,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -11868,7 +11868,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
  "sp-mixnet",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "thiserror",
 ]
 
@@ -11913,7 +11913,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -11940,7 +11940,7 @@ dependencies = [
  "sc-network-types",
  "sp-consensus",
  "sp-consensus-grandpa",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -11958,7 +11958,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -11994,7 +11994,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
@@ -12035,7 +12035,7 @@ dependencies = [
  "serde_json",
  "sp-core 34.0.0",
  "sp-rpc",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-version",
  "thiserror",
 ]
@@ -12074,7 +12074,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "thiserror",
 ]
 
@@ -12735,7 +12735,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -12896,7 +12896,7 @@ dependencies = [
  "snowbridge-milagro-bls",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "ssz_rs",
  "ssz_rs_derive",
@@ -12920,7 +12920,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
  "staging-xcm-builder",
@@ -12943,7 +12943,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -12971,7 +12971,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -13009,7 +13009,7 @@ dependencies = [
  "snowbridge-pallet-ethereum-client-fixtures",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "static_assertions",
 ]
@@ -13050,7 +13050,7 @@ dependencies = [
  "snowbridge-router-primitives",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -13088,7 +13088,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
 ]
 
@@ -13107,7 +13107,7 @@ dependencies = [
  "snowbridge-core",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -13127,7 +13127,7 @@ dependencies = [
  "snowbridge-core",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
  "staging-xcm-executor",
@@ -13176,7 +13176,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-keyring",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "staging-parachain-info",
  "staging-xcm",
  "staging-xcm-executor",
@@ -13260,7 +13260,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-metadata-ir",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-state-machine 0.43.0",
  "sp-trie 37.0.0",
@@ -13351,7 +13351,7 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-application-crypto 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -13362,7 +13362,7 @@ checksum = "74738809461e3d4bd707b5b94e0e0c064a623a74a6a8fe5c98514417a02858dd"
 dependencies = [
  "sp-api",
  "sp-inherents",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -13379,7 +13379,7 @@ dependencies = [
  "sp-consensus",
  "sp-core 34.0.0",
  "sp-database",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror",
  "tracing",
@@ -13396,7 +13396,7 @@ dependencies = [
  "log",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "thiserror",
 ]
@@ -13414,7 +13414,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-slots",
  "sp-inherents",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-timestamp",
 ]
 
@@ -13433,7 +13433,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core 34.0.0",
  "sp-inherents",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-timestamp",
 ]
 
@@ -13454,7 +13454,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
  "sp-mmr-primitives",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "strum 0.26.3",
 ]
@@ -13474,7 +13474,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -13662,7 +13662,7 @@ dependencies = [
  "scale-info",
  "serde_json",
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -13675,7 +13675,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "thiserror",
 ]
 
@@ -13740,7 +13740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c0e20624277f578b27f44ecfbe2ebc2e908488511ee2c900c5281599f700ab3"
 dependencies = [
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "strum 0.26.3",
 ]
 
@@ -13815,7 +13815,7 @@ dependencies = [
  "sp-api",
  "sp-core 34.0.0",
  "sp-debug-derive",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "thiserror",
 ]
 
@@ -13830,7 +13830,7 @@ dependencies = [
  "serde",
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -13841,7 +13841,7 @@ checksum = "2d9de237d72ecffd07f90826eef18360208b16d8de939d54e61591fac0fcbf99"
 dependencies = [
  "sp-api",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -13893,9 +13893,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.2"
+version = "39.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658f23be7c79a85581029676a73265c107c5469157e3444c8c640fdbaa8bfed0"
+checksum = "b1e00503b83cf48fffe48746b91b9b832d6785d4e2eeb0941558371eac6baac6"
 dependencies = [
  "docify",
  "either",
@@ -13983,7 +13983,7 @@ dependencies = [
  "sp-api",
  "sp-core 34.0.0",
  "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
@@ -13998,7 +13998,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -14012,7 +14012,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -14077,7 +14077,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-externalities 0.29.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "thiserror",
  "x25519-dalek",
@@ -14125,7 +14125,7 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "sp-inherents",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "thiserror",
 ]
 
@@ -14161,7 +14161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4bf251059485a7dd38fe4afeda8792983511cc47f342ff4695e2dcae6b5247"
 dependencies = [
  "sp-api",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -14225,7 +14225,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror",
@@ -14466,7 +14466,7 @@ dependencies = [
  "sp-keyring",
  "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
  "sp-std",
@@ -14495,7 +14495,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -14513,7 +14513,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "xcm-procedural",
 ]
@@ -14535,7 +14535,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm",
  "staging-xcm-executor",
@@ -14556,7 +14556,7 @@ dependencies = [
  "sp-arithmetic 26.0.0",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-weights 31.0.0",
  "staging-xcm",
  "tracing",
@@ -14717,7 +14717,7 @@ dependencies = [
  "log",
  "sc-rpc-api",
  "serde",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
 ]
 
 [[package]]
@@ -14996,7 +14996,7 @@ dependencies = [
  "polkadot-runtime-constants",
  "smallvec",
  "sp-core 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "staging-xcm",
 ]
@@ -16714,7 +16714,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-crypto-hashing",
  "sp-io 38.0.0",
- "sp-runtime 39.0.2",
+ "sp-runtime 39.0.5",
  "sp-std",
  "sp-tracing 17.0.1",
  "staging-xcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ pallet-bridge-grandpa = { version = "0.18.0", default-features = false }
 pallet-bridge-messages = { version = "0.18.0", default-features = false }
 pallet-bridge-parachains = { version = "0.18.0", default-features = false }
 pallet-bridge-relayers = { version = "0.18.0", default-features = false }
-pallet-broker = { version = "0.17.0", default-features = false }
+pallet-broker = { version = "0.17.2", default-features = false }
 pallet-child-bounties = { version = "37.0.0", default-features = false }
 pallet-collator-selection = { version = "19.0.0", default-features = false }
 pallet-collective = { version = "38.0.0", default-features = false }

--- a/system-parachains/coretime/coretime-kusama/src/coretime.rs
+++ b/system-parachains/coretime/coretime-kusama/src/coretime.rs
@@ -345,6 +345,6 @@ impl pallet_broker::Config for Runtime {
 	type PalletId = BrokerPalletId;
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountOf = SovereignAccountOf;
-	type MaxAutoRenewals = ConstU32<0>;
+	type MaxAutoRenewals = ConstU32<100>;
 	type PriceAdapter = pallet_broker::CenterTargetPrice<Balance>;
 }

--- a/system-parachains/coretime/coretime-kusama/src/lib.rs
+++ b/system-parachains/coretime/coretime-kusama/src/lib.rs
@@ -186,16 +186,10 @@ parameter_types! {
 /// Filter:
 /// - Credit purchase calls until the credit system is implemented. Otherwise, users may have chance
 ///   of locking their funds forever on purchased credits they cannot use.
-/// - Auto-renew functionality until resolution of polkadot-sdk issue [#6474](https://github.com/paritytech/polkadot-sdk/issues/6474)
 pub struct IsFilteredBrokerCall;
 impl Contains<RuntimeCall> for IsFilteredBrokerCall {
 	fn contains(c: &RuntimeCall) -> bool {
-		matches!(
-			c,
-			RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. }) |
-				RuntimeCall::Broker(pallet_broker::Call::enable_auto_renew { .. }) |
-				RuntimeCall::Broker(pallet_broker::Call::disable_auto_renew { .. })
-		)
+		matches!(c, RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. }))
 	}
 }
 

--- a/system-parachains/coretime/coretime-polkadot/src/coretime.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/coretime.rs
@@ -348,6 +348,6 @@ impl pallet_broker::Config for Runtime {
 	type PalletId = BrokerPalletId;
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountOf = SovereignAccountOf;
-	type MaxAutoRenewals = ConstU32<0>;
+	type MaxAutoRenewals = ConstU32<100>;
 	type PriceAdapter = pallet_broker::CenterTargetPrice<Balance>;
 }

--- a/system-parachains/coretime/coretime-polkadot/src/lib.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/lib.rs
@@ -184,16 +184,13 @@ parameter_types! {
 /// - Credit purchase calls until the credit system is implemented. Otherwise, users may have chance
 ///   of locking their funds forever on purchased credits they cannot use.
 /// - The interlace call until the relay can support this fully
-/// - Auto-renew functionality until resolution of polkadot-sdk issue [#6474](https://github.com/paritytech/polkadot-sdk/issues/6474)
 pub struct IsFilteredBrokerCall;
 impl Contains<RuntimeCall> for IsFilteredBrokerCall {
 	fn contains(c: &RuntimeCall) -> bool {
 		matches!(
 			c,
 			RuntimeCall::Broker(pallet_broker::Call::purchase_credit { .. }) |
-				RuntimeCall::Broker(pallet_broker::Call::interlace { .. }) |
-				RuntimeCall::Broker(pallet_broker::Call::enable_auto_renew { .. }) |
-				RuntimeCall::Broker(pallet_broker::Call::disable_auto_renew { .. })
+				RuntimeCall::Broker(pallet_broker::Call::interlace { .. })
 		)
 	}
 }


### PR DESCRIPTION
Bump broker pallet to fix auto-renew benchmarks. Also remove previous mitigations. Fixes #510 

- [X] Does not require a CHANGELOG entry

There has been no release with this broken benchmark, therefore the changelog already reflects the changes introduced by this release.

Benchmarks will be run before release