### PR TITLE
Test Relay<->AH migration through DMP messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ runtime/wasm/target/
 substrate.code-workspace
 target/
 **/__pycache__/
+*.snap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10013,6 +10013,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-integration-tests-ahm"
+version = "1.0.0"
+dependencies = [
+ "asset-hub-polkadot-runtime",
+ "cumulus-primitives-core",
+ "emulated-integration-tests-common",
+ "frame-remote-externalities",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-rc-migrator",
+ "parachains-common",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives 16.0.0",
+ "polkadot-runtime",
+ "polkadot-runtime-constants",
+ "polkadot-runtime-parachains",
+ "sc-consensus-grandpa",
+ "sp-authority-discovery",
+ "sp-consensus-babe",
+ "sp-consensus-beefy",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-storage 21.0.0",
+ "sp-tracing 17.0.1",
+ "tokio",
+]
+
+[[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,7 @@ resolver = "2"
 
 members = [
 	"chain-spec-generator",
+	"integration-tests/ahm",
 	"integration-tests/emulated/chains/parachains/assets/asset-hub-kusama",
 	"integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot",
 	"integration-tests/emulated/chains/parachains/bridges/bridge-hub-kusama",
@@ -316,6 +317,9 @@ members = [
 # Polkadot runtime requires unwinding.
 panic = "unwind"
 opt-level = 3
+# AHM: FAIL-CI
+debug-assertions = true
+overflow-checks = true
 
 [profile.production]
 inherits = "release"

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "polkadot-integration-tests-ahm"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+description = "Polkadot integration tests for the Asset Hub Migration"
+publish = false
+
+[dev-dependencies]
+asset-hub-polkadot-runtime = { workspace = true }
+authority-discovery-primitives = { workspace = true, default-features = true }
+babe-primitives = { workspace = true, default-features = true }
+beefy-primitives = { workspace = true, default-features = true }
+cumulus-primitives-core = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
+frame-support = { workspace = true, default-features = true }
+frame-system = { workspace = true, default-features = true }
+grandpa = { workspace = true }
+log = { workspace = true, default-features = true }
+pallet-rc-migrator = { workspace = true, default-features = true }
+parachains-common = { workspace = true, default-features = true }
+polkadot-parachain-primitives = { workspace = true, default-features = true }
+polkadot-primitives = { workspace = true, default-features = true }
+polkadot-runtime = { workspace = true }
+polkadot-runtime-constants = { workspace = true, default-features = true }
+remote-externalities = { workspace = true, default-features = true }
+runtime-parachains = { workspace = true, default-features = true }
+sp-core = { workspace = true, default-features = true }
+sp-io = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
+sp-storage = { workspace = true, default-features = true }
+sp-tracing = { workspace = true, default-features = true }
+tokio = { features = ["macros", "full"], workspace = true }

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -24,7 +24,7 @@ polkadot-parachain-primitives = { workspace = true, default-features = true }
 polkadot-primitives = { workspace = true, default-features = true }
 polkadot-runtime = { workspace = true }
 polkadot-runtime-constants = { workspace = true, default-features = true }
-remote-externalities = { workspace = true, default-features = true }
+remote-externalities = { workspace = true }
 runtime-parachains = { workspace = true, default-features = true }
 sp-core = { workspace = true, default-features = true }
 sp-io = { workspace = true, default-features = true }

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -31,4 +31,4 @@ sp-io = { workspace = true, default-features = true }
 sp-runtime = { workspace = true, default-features = true }
 sp-storage = { workspace = true, default-features = true }
 sp-tracing = { workspace = true, default-features = true }
-tokio = { features = ["macros", "full"], workspace = true }
+tokio = { features = ["full", "macros"], workspace = true }

--- a/integration-tests/ahm/src/lib.rs
+++ b/integration-tests/ahm/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
 #[cfg(test)]
 pub mod mock;
 #[cfg(test)]

--- a/integration-tests/ahm/src/lib.rs
+++ b/integration-tests/ahm/src/lib.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+pub mod mock;
+#[cfg(test)]
+pub mod tests;

--- a/integration-tests/ahm/src/mock.rs
+++ b/integration-tests/ahm/src/mock.rs
@@ -1,0 +1,57 @@
+use asset_hub_polkadot_runtime::Block as AssetHubBlock;
+use polkadot_runtime::Block as PolkadotBlock;
+use remote_externalities::{Builder, Mode, OfflineConfig, RemoteExternalities};
+
+const LOG_RC: &str = "runtime::relay";
+const LOG_AH: &str = "runtime::asset-hub";
+
+/// Load Relay and AH externalities in parallel.
+pub async fn load_externalities(
+) -> Option<(RemoteExternalities<PolkadotBlock>, RemoteExternalities<AssetHubBlock>)> {
+	let (rc, ah) = tokio::try_join!(
+		tokio::spawn(async { remote_ext_test_setup::<PolkadotBlock>("SNAP_RC").await }),
+		tokio::spawn(async { remote_ext_test_setup::<AssetHubBlock>("SNAP_AH").await })
+	)
+	.ok()?;
+	Some((rc?, ah?))
+}
+
+pub async fn remote_ext_test_setup<Block: sp_runtime::traits::Block>(
+	env: &str,
+) -> Option<RemoteExternalities<Block>> {
+	sp_tracing::try_init_simple();
+	let snap = std::env::var(env).ok()?;
+	let abs = std::path::absolute(snap.clone());
+
+	let ext = Builder::<Block>::default()
+		.mode(Mode::Offline(OfflineConfig { state_snapshot: snap.clone().into() }))
+		.build()
+		.await
+		.map_err(|e| {
+			eprintln!("Could not load from snapshot: {:?}: {:?}", abs, e);
+		})
+		.unwrap();
+
+	Some(ext)
+}
+
+pub fn next_block_rc() {
+	let now = frame_system::Pallet::<polkadot_runtime::Runtime>::block_number();
+	log::info!(target: LOG_RC, "Next block: {:?}", now + 1);
+	<polkadot_runtime::RcMigrator as frame_support::traits::OnFinalize<_>>::on_finalize(now);
+	frame_system::Pallet::<polkadot_runtime::Runtime>::set_block_number(now + 1);
+	<polkadot_runtime::RcMigrator as frame_support::traits::OnInitialize<_>>::on_initialize(
+		now + 1,
+	);
+}
+
+pub fn next_block_ah() {
+	let now = frame_system::Pallet::<asset_hub_polkadot_runtime::Runtime>::block_number();
+	log::info!(target: LOG_AH, "Next block: {:?}", now + 1);
+	<asset_hub_polkadot_runtime::AhMigrator as frame_support::traits::OnFinalize<_>>::on_finalize(
+		now,
+	);
+	frame_system::Pallet::<asset_hub_polkadot_runtime::Runtime>::set_block_number(now + 1);
+	<asset_hub_polkadot_runtime::MessageQueue as frame_support::traits::OnInitialize<_>>::on_initialize(now + 1);
+	<asset_hub_polkadot_runtime::AhMigrator as frame_support::traits::OnInitialize<_>>::on_initialize(now + 1);
+}

--- a/integration-tests/ahm/src/mock.rs
+++ b/integration-tests/ahm/src/mock.rs
@@ -1,3 +1,19 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
 use asset_hub_polkadot_runtime::Block as AssetHubBlock;
 use polkadot_runtime::Block as PolkadotBlock;
 use remote_externalities::{Builder, Mode, OfflineConfig, RemoteExternalities};

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -1,0 +1,81 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Rust integration for the Asset Hub Migration.
+//!
+//! This test calls `on_initialize` on the RC and on AH alternately and forwards DMP messages.
+//!
+//! Create snapshots in the root dir:
+//!
+//! ```
+//! try-runtime create-snapshot --uri wss://sys.ibp.network:443/statemint ah-polkadot.snap
+//! try-runtime create-snapshot --uri wss://try-runtime.polkadot.io:443 polkadot.snap
+//! ```
+//!
+//! Run with:
+//!
+//! ```
+//! SNAP_RC="../../polkadot.snap" SNAP_AH="../../ah-polkadot.snap" RUST_LOG="info" ct polkadot-integration-tests-ahm -r on_initialize_works -- --nocapture
+//! ```
+
+use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
+use frame_support::{pallet_prelude::*, traits::*, weights::WeightMeter};
+use pallet_rc_migrator::RcMigrationStage;
+use polkadot_runtime::RcMigrator;
+use sp_core::H256;
+use sp_io::TestExternalities;
+use sp_storage::StateVersion;
+use std::cell::OnceCell;
+
+use asset_hub_polkadot_runtime::{Block as AssetHubBlock, Runtime as AssetHub};
+use polkadot_runtime::{Block as PolkadotBlock, Runtime as Polkadot};
+
+use super::mock::*;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn account_migration_works() {
+	let Some((mut rc, mut ah)) = load_externalities().await else { return };
+
+	// Simulate 10 relay blocks and grab the DMP messages
+	let dmp_messages = rc.execute_with(|| {
+		for _ in 0..10 {
+			next_block_rc();
+		}
+
+		// DMP:
+		let para_id = ParaId::from(1000);
+		runtime_parachains::dmp::DownwardMessageQueues::<Polkadot>::take(para_id)
+	});
+	rc.commit_all().unwrap();
+	log::info!("Num of RC->AH DMP messages: {}", dmp_messages.len());
+
+	// Inject the DMP messages into the Asset Hub
+	ah.execute_with(|| {
+		// We bypass `set_validation_data` and `enqueue_inbound_downward_messages` by just directly
+		// enqueuing them.
+		for msg in dmp_messages {
+			let bounded_msg: BoundedVec<u8, _> = msg.msg.try_into().expect("DMP message too big");
+			asset_hub_polkadot_runtime::MessageQueue::enqueue_message(
+				bounded_msg.as_bounded_slice(),
+				AggregateMessageOrigin::Parent,
+			);
+		}
+
+		for _ in 0..10 {
+			next_block_ah();
+		}
+	});
+}

--- a/pallets/rc-migrator/src/accounts.rs
+++ b/pallets/rc-migrator/src/accounts.rs
@@ -156,6 +156,13 @@ pub type AccountFor<T> = Account<
 >;
 
 impl<T: Config> Pallet<T> {
+	/// Get the first account that the migration should begin with.
+	///
+	/// Returns `None` when there are no accounts present.
+	pub fn first_account(_weight: &mut WeightMeter) -> Result<Option<T::AccountId>, ()> {
+		();
+		Ok(SystemAccount::<T>::iter().next().map(|(who, _)| who))
+	}
 	// TODO: Currently, we use `debug_assert!` for basic test checks against a production snapshot.
 
 	/// Migrate accounts from RC to AH.
@@ -214,7 +221,7 @@ impl<T: Config> Pallet<T> {
 
 			log::debug!(
 				target: LOG_TARGET,
-				"Migrating account '{:?}'",
+				"Migrating account '{}'",
 				who.to_ss58check(),
 			);
 
@@ -367,7 +374,20 @@ impl<T: Config> Pallet<T> {
 	/// be calculated there.
 	pub fn get_consumer_count(_who: &T::AccountId, _info: &AccountInfoFor<T>) -> u8 {
 		// TODO: check the pallets for provider references on Relay Chain.
-		0
+
+		// The following pallets increase consumers and are deployed on (Polkadot, Kusama, Westend):
+		// - `balances`: (P/K/W)
+		// - `recovery`: (/K/W)
+		// - `assets`: (//)
+		// - `contracts`: (//)
+		// - `nfts`: (//)
+		// - `uniques`: (//)
+		// - `revive`: (//)
+		// Staking stuff:
+		// - `session`: (P/K/W)
+		// - `staking`: (P/K/W)
+
+		0 // TODO count them
 	}
 
 	/// Provider ref count of migrating to Asset Hub pallets except the reference for existential
@@ -377,7 +397,16 @@ impl<T: Config> Pallet<T> {
 	/// calculated there.
 	pub fn get_provider_count(_who: &T::AccountId, _info: &AccountInfoFor<T>) -> u8 {
 		// TODO: check the pallets for provider references on Relay Chain.
-		0
+
+		// The following pallets increase consumers and are deployed on (Polkadot, Kusama, Westend):
+		// - `crowdloan`: (P/K/W) https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/runtime/common/src/crowdloan/mod.rs#L416
+		// - `parachains_on_demand`: (P/K/W) https://github.com/paritytech/polkadot-sdk/blob/master/polkadot/runtime/parachains/src/on_demand/mod.rs#L407
+		// - `balances`: (P/K/W) https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/balances/src/lib.rs#L1026
+		// - `broker`: (_/_/_)
+		// - `delegate_staking`: (P/K/W)
+		// - `session`: (P/K/W) <- Don't count this one (see https://github.com/paritytech/polkadot-sdk/blob/8d4138f77106a6af49920ad84f3283f696f3f905/substrate/frame/session/src/lib.rs#L462-L465)
+
+		0 // TODO count the ones that we want to migrate
 	}
 
 	/// The part of the balance of the `who` that must stay on the Relay Chain.

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1551,8 +1551,8 @@ impl OnSwap for SwapLeases {
 }
 
 parameter_types! {
-	pub RcMigratorMaxWeight: Weight = Weight::from_all(1); // TODO set the actual max weight
-	pub AhMigratorMaxWeight: Weight = Weight::from_all(1); // TODO set the actual max weight
+	pub RcMigratorMaxWeight: Weight = Weight::from_parts(1_000_000_000, u64::MAX); // TODO set the actual max weight
+	pub AhMigratorMaxWeight: Weight = Weight::from_parts(1_000_000_000, 5*1024*1024); // TODO set the actual max weight
 }
 
 impl pallet_rc_migrator::Config for Runtime {

--- a/relay/polkadot/tests/ahm/accounts.rs
+++ b/relay/polkadot/tests/ahm/accounts.rs
@@ -14,18 +14,47 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use frame_support::weights::WeightMeter;
+use frame_support::{pallet_prelude::*, traits::*, weights::WeightMeter};
+use sp_core::H256;
+use sp_io::TestExternalities;
+use sp_storage::StateVersion;
+
+use std::cell::OnceCell;
 
 use super::*;
+use pallet_rc_migrator::RcMigrationStage;
 
 #[tokio::test]
 async fn account_test() {
-	let Some(mut ext) = remote_ext_test_setup().await else {
-		return;
-	};
-
-	ext.execute_with(|| {
-		let _ = RcMigrator::obtain_rc_accounts();
-		let _ = RcMigrator::migrate_accounts(None, &mut WeightMeter::new()).unwrap();
+	remote_ext_test_setup().await.map(|mut e| {
+		e.execute_with(|| {
+			let _ = RcMigrator::obtain_rc_accounts();
+			let _ = RcMigrator::migrate_accounts(None, &mut WeightMeter::new()).unwrap();
+		})
 	});
+}
+
+#[tokio::test]
+async fn on_initialize_works() {
+	remote_ext_test_setup().await.map(|mut e| {
+		e.execute_with(|| {
+			for _ in 0..10 {
+				log::debug!(target: LOG_TARGET, "Stage: {:?}", RcMigrationStage::<T>::get());
+				next_block();
+			}
+
+			// DMP:
+			let para_id = polkadot_parachain_primitives::primitives::Id::from(1000);
+			let msg_count = runtime_parachains::dmp::DownwardMessageQueues::<T>::get(para_id).len();
+			log::debug!(target: LOG_TARGET, "DMP message count for para 1000: {msg_count}");
+		})
+	});
+}
+
+fn next_block() {
+	let now = System::block_number();
+	log::debug!(target: LOG_TARGET, "Next block: {:?}", now + 1);
+	<RcMigrator as frame_support::traits::OnFinalize<_>>::on_finalize(now);
+	System::set_block_number(now + 1);
+	<RcMigrator as frame_support::traits::OnInitialize<_>>::on_initialize(now + 1);
 }

--- a/relay/polkadot/tests/ahm/mod.rs
+++ b/relay/polkadot/tests/ahm/mod.rs
@@ -35,6 +35,7 @@ use remote_externalities::{Builder, Mode, OfflineConfig, RemoteExternalities};
 async fn remote_ext_test_setup() -> Option<RemoteExternalities<Block>> {
 	sp_tracing::try_init_simple();
 	let snap = std::env::var("SNAP").ok()?;
+	//let snap = "/home/oliver/polkadot.snap".to_string(); // FIXME dont push
 	let abs = std::path::absolute(snap.clone());
 
 	let ext = Builder::<Block>::default()

--- a/relay/polkadot/tests/ahm/mod.rs
+++ b/relay/polkadot/tests/ahm/mod.rs
@@ -35,7 +35,6 @@ use remote_externalities::{Builder, Mode, OfflineConfig, RemoteExternalities};
 async fn remote_ext_test_setup() -> Option<RemoteExternalities<Block>> {
 	sp_tracing::try_init_simple();
 	let snap = std::env::var("SNAP").ok()?;
-	//let snap = "/home/oliver/polkadot.snap".to_string(); // FIXME dont push
 	let abs = std::path::absolute(snap.clone());
 
 	let ext = Builder::<Block>::default()


### PR DESCRIPTION
To be merged into the AHM dev branch.

Changes:
- Create `polkadot-integration-tests-ahm` crate that pulls in the Relay and AH runtimes
- Load snapshot for both chains and run trivial DMP testing
- Add stage to initialize the account migration
- TODO: Investigate failing debug assertion on the account migration

- [x] Does not require a CHANGELOG entry
