### PR TITLE
Let the entire job fail when one strategy fails

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -44,9 +44,10 @@ jobs:
   # if they all pass, that job will pass too.
   check-migrations:
     needs: [runtime-matrix]
-    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
+      # Ensure the other jobs are continue
+      fail-fast: false
       matrix:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
     steps:

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -46,7 +46,7 @@ jobs:
     needs: [runtime-matrix]
     runs-on: ubuntu-latest
     strategy:
-      # Ensure the other jobs are continue
+      # Ensure the other jobs continue
       fail-fast: false
       matrix:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}


### PR DESCRIPTION
Before the entire job counted as success, even with individual strategies failing.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
