### PR TITLE
CI: Use `matrix.runtime.uri` for `try-runtime` tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,7 @@ jobs:
           RUSTFLAGS: "-C debug-assertions -D warnings"
           SKIP_WASM_BUILD: 1
           WS: ${{ matrix.runtime.uri }}
+          RUST_LOG: "remote-ext=info"
 
       - name: Test benchmarks ${{ matrix.runtime.name }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,7 @@ jobs:
         env:
           RUSTFLAGS: "-C debug-assertions -D warnings"
           SKIP_WASM_BUILD: 1
+          WS: ${{ matrix.runtime.uri }}
 
       - name: Test benchmarks ${{ matrix.runtime.name }}
         run: |


### PR DESCRIPTION
Some tests gated with the `try-runtime` feature have the ability to configure the node URI using some hard-coded defaults, e.g.:
```
let transport: Transport =
			var("WS").unwrap_or("wss://rpc.dotters.network/kusama".to_string()).into();
...
let transport: Transport =
			var("WS").unwrap_or("wss://kusama-rpc.polkadot.io:443".to_string()).into();
...
let transport: Transport =
			var("WS").unwrap_or("wss://rpc.polkadot.io:443".to_string()).into();
...
let transport: Transport =
			var("WS").unwrap_or("wss://rpc.dotters.network/polkadot".to_string()).into();
```

Additionally, we have a dedicated runtime `uri` specified in the `runtimes-matrix.json`, e.g.,
```
{
    "name": "polkadot",
    "uri": "wss://try-runtime.polkadot.io:443",
  },
  {
    "name": "kusama",
    "uri": "wss://try-runtime-kusama.polkadot.io:443",
  },
```

so, let's use those dedicated `uri`s instead of the hard-coded ones.

---

I came across this issue by accident when Kusama's `remote_tests::next_inflation` failed with `Error while getting storage data` here: https://github.com/polkadot-fellows/runtimes/actions/runs/12526255825/job/34938624858?pr=519.  
I wasn't sure if it is flaky, missing some keys in the actual block, or just a connection problem, so I also enabled `remote-ext=info` logs (if the logs are too much, we can switch to `remote-ext=warn/error`).
```
remote_tests::next_inflation --- FAILED

failures:

---- remote_tests::next_inflation stdout ----
thread 'remote_tests::next_inflation' panicked at relay/kusama/src/lib.rs:3230:14:
called `Result::unwrap()` on an `Err` value: "Error while getting storage data"
```

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
