### PR TITLE
[AHM] Add Polkadot call filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10039,6 +10039,8 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-ah-migrator",
+ "pallet-indices",
+ "pallet-message-queue",
  "pallet-rc-migrator",
  "parachains-common",
  "polkadot-parachain-primitives",

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -20,6 +20,8 @@ grandpa = { workspace = true }
 log = { workspace = true, default-features = true }
 pallet-rc-migrator = { workspace = true, default-features = true }
 pallet-ah-migrator = { workspace = true, default-features = true }
+pallet-indices = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
 parachains-common = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true, default-features = true }
 polkadot-primitives = { workspace = true, default-features = true }

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -31,11 +31,12 @@
 //! SNAP_RC="../../polkadot.snap" SNAP_AH="../../ah-polkadot.snap" RUST_LOG="info" ct polkadot-integration-tests-ahm -r on_initialize_works -- --nocapture
 //! ```
 
-use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
+use cumulus_primitives_core::ParaId;
 use frame_support::{pallet_prelude::*, traits::*, weights::WeightMeter};
 use pallet_rc_migrator::{types::PalletMigrationChecks, MigrationStage, RcMigrationStage};
 use polkadot_primitives::InboundDownwardMessage;
 use remote_externalities::RemoteExternalities;
+use runtime_parachains::inclusion::AggregateMessageOrigin;
 
 use asset_hub_polkadot_runtime::Runtime as AssetHub;
 use polkadot_runtime::Runtime as Polkadot;
@@ -78,14 +79,16 @@ async fn account_migration_works() {
 	ah.execute_with(|| {
 		let ah_pre_check_payload =
 			pallet_ah_migrator::preimage::PreimageMigrationCheck::<AssetHub>::pre_check();
-		let mut fp =
-			asset_hub_polkadot_runtime::MessageQueue::footprint(AggregateMessageOrigin::Parent);
+		let mut fp = asset_hub_polkadot_runtime::MessageQueue::footprint(
+			cumulus_primitives_core::AggregateMessageOrigin::Parent,
+		);
 		enqueue_dmp(dmp_messages);
 
 		// Loop until no more DMPs are queued
 		loop {
-			let new_fp =
-				asset_hub_polkadot_runtime::MessageQueue::footprint(AggregateMessageOrigin::Parent);
+			let new_fp = asset_hub_polkadot_runtime::MessageQueue::footprint(
+				cumulus_primitives_core::AggregateMessageOrigin::Parent,
+			);
 			if fp == new_fp {
 				log::info!("AH DMP messages left: {}", fp.storage.count);
 				break;

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -36,7 +36,6 @@ use frame_support::{pallet_prelude::*, traits::*, weights::WeightMeter};
 use pallet_rc_migrator::{types::PalletMigrationChecks, MigrationStage, RcMigrationStage};
 use polkadot_primitives::InboundDownwardMessage;
 use remote_externalities::RemoteExternalities;
-use runtime_parachains::inclusion::AggregateMessageOrigin;
 
 use asset_hub_polkadot_runtime::Runtime as AssetHub;
 use polkadot_runtime::Runtime as Polkadot;

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -31,7 +31,7 @@
 //! SNAP_RC="../../polkadot.snap" SNAP_AH="../../ah-polkadot.snap" RUST_LOG="info" ct polkadot-integration-tests-ahm -r on_initialize_works -- --nocapture
 //! ```
 
-use cumulus_primitives_core::ParaId;
+use cumulus_primitives_core::{AggregateMessageOrigin, ParaId};
 use frame_support::{pallet_prelude::*, traits::*, weights::WeightMeter};
 use pallet_rc_migrator::{types::PalletMigrationChecks, MigrationStage, RcMigrationStage};
 use polkadot_primitives::InboundDownwardMessage;
@@ -79,16 +79,14 @@ async fn account_migration_works() {
 	ah.execute_with(|| {
 		let ah_pre_check_payload =
 			pallet_ah_migrator::preimage::PreimageMigrationCheck::<AssetHub>::pre_check();
-		let mut fp = asset_hub_polkadot_runtime::MessageQueue::footprint(
-			cumulus_primitives_core::AggregateMessageOrigin::Parent,
-		);
+		let mut fp =
+			asset_hub_polkadot_runtime::MessageQueue::footprint(AggregateMessageOrigin::Parent);
 		enqueue_dmp(dmp_messages);
 
 		// Loop until no more DMPs are queued
 		loop {
-			let new_fp = asset_hub_polkadot_runtime::MessageQueue::footprint(
-				cumulus_primitives_core::AggregateMessageOrigin::Parent,
-			);
+			let new_fp =
+				asset_hub_polkadot_runtime::MessageQueue::footprint(AggregateMessageOrigin::Parent);
 			if fp == new_fp {
 				log::info!("AH DMP messages left: {}", fp.storage.count);
 				break;

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -208,15 +208,12 @@ pub mod pallet {
 		type AhWeightInfo: AhWeightInfo;
 		/// The existential deposit on the Asset Hub.
 		type AhExistentialDeposit: Get<<Self as pallet_balances::Config>::Balance>;
-		/// Whether this call is permanently disabled on the Relay Chain.
-		///
-		/// This includes all pallets that will be moved to the Asset Hub and we dont want anyone to
-		/// keep using them.
-		type RcCallEnabledAfterMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
-		/// Whether this Relay Chain call is disabled temporarily during the migration.
+		/// Contains all calls that are allowed during the migration.
 		///
 		/// The calls in here will be available again after the migration.
 		type RcCallEnabledDuringMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
+		/// Contains all calls that are allowed after the migration finished.
+		type RcCallEnabledAfterMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
 	}
 
 	#[pallet::error]

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -211,9 +211,9 @@ pub mod pallet {
 		/// Contains all calls that are allowed during the migration.
 		///
 		/// The calls in here will be available again after the migration.
-		type RcCallEnabledDuringMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
+		type RcCallsEnabledDuringMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
 		/// Contains all calls that are allowed after the migration finished.
-		type RcCallEnabledAfterMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
+		type RcCallsEnabledAfterMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
 	}
 
 	#[pallet::error]

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -211,9 +211,9 @@ pub mod pallet {
 		/// Contains all calls that are allowed during the migration.
 		///
 		/// The calls in here will be available again after the migration.
-		type RcCallsEnabledDuringMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
+		type RcIntraMigrationCalls: Contains<<Self as frame_system::Config>::RuntimeCall>;
 		/// Contains all calls that are allowed after the migration finished.
-		type RcCallsEnabledAfterMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
+		type RcPostMigrationCalls: Contains<<Self as frame_system::Config>::RuntimeCall>;
 	}
 
 	#[pallet::error]
@@ -612,11 +612,11 @@ impl<T: Config> Contains<<T as frame_system::Config>::RuntimeCall> for Pallet<T>
 		const ALLOWED: bool = true;
 		const FORBIDDEN: bool = false;
 
-		if is_finished && !T::RcCallEnabledAfterMigration::contains(call) {
+		if is_finished && !T::RcIntraMigrationCalls::contains(call) {
 			return FORBIDDEN;
 		}
 
-		if is_ongoing && !T::RcCallEnabledDuringMigration::contains(call) {
+		if is_ongoing && !T::RcPostMigrationCalls::contains(call) {
 			return FORBIDDEN;
 		}
 

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -46,7 +46,7 @@ use frame_support::{
 	traits::{
 		fungible::{Inspect, InspectFreeze, Mutate, MutateFreeze, MutateHold},
 		tokens::{Fortitude, Precision, Preservation},
-		Defensive, LockableCurrency, ReservableCurrency,
+		Contains, Defensive, LockableCurrency, ReservableCurrency,
 	},
 	weights::WeightMeter,
 };
@@ -96,7 +96,19 @@ impl<T: Config> From<OutOfWeightError> for Error<T> {
 	}
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[derive(
+	Encode,
+	Decode,
+	Clone,
+	PartialEq,
+	Eq,
+	Default,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
+	PartialOrd,
+	Ord,
+)]
 pub enum MigrationStage<AccountId> {
 	/// The migration has not yet started but will start in the next block.
 	#[default]
@@ -196,6 +208,15 @@ pub mod pallet {
 		type AhWeightInfo: AhWeightInfo;
 		/// The existential deposit on the Asset Hub.
 		type AhExistentialDeposit: Get<<Self as pallet_balances::Config>::Balance>;
+		/// Whether this call is permanently disabled on the Relay Chain.
+		///
+		/// This includes all pallets that will be moved to the Asset Hub and we dont want anyone to
+		/// keep using them.
+		type RcCallEnabledAfterMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
+		/// Whether this Relay Chain call is disabled temporarily during the migration.
+		///
+		/// The calls in here will be available again after the migration.
+		type RcCallEnabledDuringMigration: Contains<<Self as frame_system::Config>::RuntimeCall>;
 	}
 
 	#[pallet::error]
@@ -249,16 +270,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
-
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {
-		/// TODO
-		#[pallet::call_index(0)]
-		#[pallet::weight({1})]
-		pub fn do_something(_origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			Ok(().into())
-		}
-	}
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
@@ -591,5 +602,27 @@ pub mod pallet {
 
 			Ok(())
 		}
+	}
+}
+
+impl<T: Config> Contains<<T as frame_system::Config>::RuntimeCall> for Pallet<T> {
+	fn contains(call: &<T as frame_system::Config>::RuntimeCall) -> bool {
+		let stage = RcMigrationStage::<T>::get();
+		let is_finished = stage >= MigrationStage::MigrationDone;
+		let is_ongoing = stage > MigrationStage::Pending && !is_finished;
+
+		// We have to return whether the call is allowed:
+		const ALLOWED: bool = true;
+		const FORBIDDEN: bool = false;
+
+		if is_finished && !T::RcCallEnabledAfterMigration::contains(call) {
+			return FORBIDDEN;
+		}
+
+		if is_ongoing && !T::RcCallEnabledDuringMigration::contains(call) {
+			return FORBIDDEN;
+		}
+
+		ALLOWED
 	}
 }

--- a/relay/polkadot/src/ah_migration/mod.rs
+++ b/relay/polkadot/src/ah_migration/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Asset Hub Migration.
+
+pub mod phase1;

--- a/relay/polkadot/src/ah_migration/phase1.rs
+++ b/relay/polkadot/src/ah_migration/phase1.rs
@@ -1,0 +1,131 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! First phase of the Asset Hub Migration.
+
+use crate::*;
+
+/// Contains all calls that are enabled during the migration.
+pub struct CallsEnabledDuringMigration;
+impl Contains<<Runtime as frame_system::Config>::RuntimeCall> for CallsEnabledDuringMigration {
+	fn contains(call: &<Runtime as frame_system::Config>::RuntimeCall) -> bool {
+		let (during, _after) = call_allowed_status(call);
+		during
+	}
+}
+
+/// Contains all calls that are enabled after the migration.
+pub struct CallsEnabledAfterMigration;
+impl Contains<<Runtime as frame_system::Config>::RuntimeCall> for CallsEnabledAfterMigration {
+	fn contains(call: &<Runtime as frame_system::Config>::RuntimeCall) -> bool {
+		let (_during, after) = call_allowed_status(call);
+		after
+	}
+}
+
+/// Return whether a call should be enabled during and/or after the migration.
+///
+/// Time line of the migration looks like this:
+///
+/// --------|-----------|--------->
+///       Start        End
+///
+/// We now define 2 periods:
+///
+/// 1. During the migration: [Start, End]
+/// 2. After the migration: (End, ∞)
+///
+/// Visually:
+///
+///         |-----1-----|
+///                      |---2---->
+/// --------|-----------|--------->
+///       Start        End
+///
+/// This call returns a 2-tuple to indicate whether a call is enabled during these periods.
+pub fn call_allowed_status(call: &<Runtime as frame_system::Config>::RuntimeCall) -> (bool, bool) {
+	use RuntimeCall::*;
+	const ON: bool = true;
+	const OFF: bool = false;
+
+	match call {
+		System(..) => (ON, ON),
+		Scheduler(..) => (OFF, OFF),
+		Preimage(..) => (OFF, OFF),
+		Babe(..) => (ON, ON), // TODO double check
+		Timestamp(..) => (OFF, OFF),
+		Indices(..) => (OFF, OFF),
+		Balances(..) => (OFF, ON),
+		// TransactionPayment has no calls
+		// Authorship has no calls
+		Staking(..) => (OFF, OFF),
+		// Offences has no calls
+		// Historical has no calls
+		Session(..) => (OFF, OFF),
+		Grandpa(..) => (ON, ON), // TODO double check
+		// AuthorityDiscovery has no calls
+		Treasury(..) => (OFF, OFF),
+		ConvictionVoting(..) => (OFF, OFF),
+		Referenda(..) => (OFF, OFF),
+		// Origins has no calls
+		Whitelist(..) => (OFF, OFF),
+		Claims(..) => (OFF, OFF),
+		Vesting(..) => (OFF, OFF),
+		Utility(..) => (OFF, ON), // batching etc
+		Proxy(..) => (OFF, ON),
+		Multisig(..) => (OFF, ON),
+		Bounties(..) => (OFF, OFF),
+		ChildBounties(..) => (OFF, OFF),
+		ElectionProviderMultiPhase(..) => (OFF, OFF),
+		VoterList(..) => (OFF, OFF),
+		NominationPools(..) => (OFF, OFF),
+		FastUnstake(..) => (OFF, OFF),
+		// DelegatedStaking has on calls
+		// ParachainsOrigin has no calls
+		Configuration(..) => (ON, ON), /* TODO allow this to be called by fellow origin during the migration https://github.com/polkadot-fellows/runtimes/pull/559#discussion_r1928794490 */
+		ParasShared(..) => (OFF, OFF), /* Has no calls but a call enum https://github.com/paritytech/polkadot-sdk/blob/ee803b74056fac5101c06ec5998586fa6eaac470/polkadot/runtime/parachains/src/shared.rs#L185-L186 */
+		ParaInclusion(..) => (OFF, OFF), /* Has no calls but a call enum https://github.com/paritytech/polkadot-sdk/blob/74ec1ee226ace087748f38dfeffc869cd5534ac8/polkadot/runtime/parachains/src/inclusion/mod.rs#L352-L353 */
+		ParaInherent(..) => (ON, ON),    // only inherents
+		// ParaScheduler has no calls
+		Paras(..) => (ON, ON),
+		Initializer(..) => (ON, ON),
+		// Dmp has no calls and deprecated
+		Hrmp(..) => (OFF, OFF),
+		// ParaSessionInfo has no calls
+		ParasDisputes(..) => (OFF, ON), // TODO check with security
+		ParasSlashing(..) => (OFF, ON), // TODO check with security
+		OnDemand(..) => (OFF, ON),
+		// CoretimeAssignmentProvider has no calls
+		Registrar(..) => (OFF, ON),
+		Slots(..) => (OFF, OFF),
+		Auctions(..) => (OFF, OFF),
+		Crowdloan(
+			crowdloan::Call::<Runtime>::dissolve { .. } |
+			crowdloan::Call::<Runtime>::refund { .. } |
+			crowdloan::Call::<Runtime>::dissolve { .. },
+		) => (OFF, ON),
+		Crowdloan(..) => (OFF, OFF),
+		Coretime(coretime::Call::<Runtime>::request_revenue_at { .. }) => (OFF, ON),
+		Coretime(..) => (ON, ON),
+		StateTrieMigration(..) => (OFF, OFF), // Deprecated
+		XcmPallet(..) => (OFF, ON), /* TODO allow para origins and root to call this during the migration, see https://github.com/polkadot-fellows/runtimes/pull/559#discussion_r1928789463 */
+		MessageQueue(..) => (ON, ON), // TODO think about this
+		AssetRate(..) => (OFF, OFF),
+		Beefy(..) => (OFF, ON), /* TODO @claravanstaden @bkontur
+		                         * RcMigrator has no calls currently
+		                         * Exhaustive match. Compiler ensures that we did not miss any. */
+	}
+}

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1662,8 +1662,8 @@ pub fn call_disable_status(call: &<Runtime as frame_system::Config>::RuntimeCall
 		ParaInclusion(..) => (OFF, OFF), /* Has no calls but a call enum https://github.com/paritytech/polkadot-sdk/blob/74ec1ee226ace087748f38dfeffc869cd5534ac8/polkadot/runtime/parachains/src/inclusion/mod.rs#L352-L353 */
 		ParaInherent(..) => (ON, ON),    // only inherents
 		// ParaScheduler has no calls
-		Paras(..) => (OFF, ON), // TODO only root so could think about keeping it on
-		Initializer(..) => (OFF, ON), // only root so could think about keeping it on
+		Paras(..) => (ON, ON),
+		Initializer(..) => (ON, ON),
 		// Dmp // has no calls and deprecated
 		Hrmp(..) => (OFF, OFF),
 		// ParaSessionInfo has no calls
@@ -1672,7 +1672,7 @@ pub fn call_disable_status(call: &<Runtime as frame_system::Config>::RuntimeCall
 		OnDemand(..) => (OFF, ON),
 		// CoretimeAssignmentProvider has no calls
 		Registrar(..) => (OFF, ON),
-		Slots(..) => (OFF, ON), // TODO not sure
+		Slots(..) => (OFF, OFF),
 		Auctions(..) => (OFF, OFF),
 		Crowdloan(..) => (OFF, ON), // TODO maybe only payouts
 		Coretime(..) => (OFF, ON),

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1627,7 +1627,7 @@ pub fn call_disable_status(call: &<Runtime as frame_system::Config>::RuntimeCall
 		System(..) => (OFF, ON),
 		Scheduler(..) => (OFF, OFF),
 		Preimage(..) => (OFF, OFF),
-		Babe(..) => todo!(),
+		Babe(..) => todo!("FAIL-CI"),
 		Timestamp(..) => (OFF, OFF),
 		Indices(..) => (OFF, OFF),
 		Balances(..) => (OFF, ON),
@@ -1637,7 +1637,7 @@ pub fn call_disable_status(call: &<Runtime as frame_system::Config>::RuntimeCall
 		// Offences has no calls
 		// Historical has no calls
 		Session(..) => (OFF, OFF),
-		Grandpa(..) => todo!(),
+		Grandpa(..) => todo!("FAIL-CI"),
 		// AuthorityDiscovery has no calls
 		Treasury(..) => (OFF, OFF),
 		ConvictionVoting(..) => (OFF, OFF),

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -50,6 +50,7 @@ use runtime_parachains::{
 	shared as parachains_shared,
 };
 
+use ah_migration::phase1 as ahm_phase1;
 use authority_discovery_primitives::AuthorityId as AuthorityDiscoveryId;
 use beefy_primitives::{
 	ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature},
@@ -138,6 +139,7 @@ mod bag_thresholds;
 // Genesis preset configurations.
 pub mod genesis_config_presets;
 // Governance configurations.
+pub mod ah_migration;
 pub mod governance;
 use governance::{
 	pallet_custom_origins, AuctionAdmin, FellowshipAdmin, GeneralAdmin, LeaseAdmin, StakingAdmin,
@@ -1576,120 +1578,8 @@ impl pallet_rc_migrator::Config for Runtime {
 	type AhExistentialDeposit = AhExistentialDeposit;
 	type RcWeightInfo = ();
 	type AhWeightInfo = ();
-	type RcPostMigrationCalls = CallsEnabledDuringMigration;
-	type RcIntraMigrationCalls = CallsEnabledAfterMigration;
-}
-
-/// Contains all calls that are enabled during the migration.
-pub struct CallsEnabledDuringMigration;
-impl Contains<<Runtime as frame_system::Config>::RuntimeCall> for CallsEnabledDuringMigration {
-	fn contains(call: &<Runtime as frame_system::Config>::RuntimeCall) -> bool {
-		let (during, _after) = call_allowed_status(call);
-		during
-	}
-}
-
-/// Contains all calls that are enabled after the migration.
-pub struct CallsEnabledAfterMigration;
-impl Contains<<Runtime as frame_system::Config>::RuntimeCall> for CallsEnabledAfterMigration {
-	fn contains(call: &<Runtime as frame_system::Config>::RuntimeCall) -> bool {
-		let (_during, after) = call_allowed_status(call);
-		after
-	}
-}
-
-/// Return whether a call should be enabled during and/or after the migration.
-///
-/// Time line of the migration looks like this:
-///
-/// --------|-----------|--------->
-///       Start        End
-///
-/// We now define 2 periods:
-///
-/// 1. During the migration: [Start, End]
-/// 2. After the migration: (End, ∞)
-///
-/// Visually:
-///
-///         |-----1-----|
-///                      |---2---->
-/// --------|-----------|--------->
-///       Start        End
-///
-/// This call returns a 2-tuple to indicate whether a call is enabled during these periods.
-pub fn call_allowed_status(call: &<Runtime as frame_system::Config>::RuntimeCall) -> (bool, bool) {
-	use RuntimeCall::*;
-	const ON: bool = true;
-	const OFF: bool = false;
-
-	match call {
-		System(..) => (ON, ON),
-		Scheduler(..) => (OFF, OFF),
-		Preimage(..) => (OFF, OFF),
-		Babe(..) => (ON, ON), // TODO double check
-		Timestamp(..) => (OFF, OFF),
-		Indices(..) => (OFF, OFF),
-		Balances(..) => (OFF, ON),
-		// TransactionPayment has no calls
-		// Authorship has no calls
-		Staking(..) => (OFF, OFF),
-		// Offences has no calls
-		// Historical has no calls
-		Session(..) => (OFF, OFF),
-		Grandpa(..) => (ON, ON), // TODO double check
-		// AuthorityDiscovery has no calls
-		Treasury(..) => (OFF, OFF),
-		ConvictionVoting(..) => (OFF, OFF),
-		Referenda(..) => (OFF, OFF),
-		// Origins has no calls
-		Whitelist(..) => (OFF, OFF),
-		Claims(..) => (OFF, OFF),
-		Vesting(..) => (OFF, OFF),
-		Utility(..) => (OFF, ON), // batching etc
-		Proxy(..) => (OFF, ON),
-		Multisig(..) => (OFF, ON),
-		Bounties(..) => (OFF, OFF),
-		ChildBounties(..) => (OFF, OFF),
-		ElectionProviderMultiPhase(..) => (OFF, OFF),
-		VoterList(..) => (OFF, OFF),
-		NominationPools(..) => (OFF, OFF),
-		FastUnstake(..) => (OFF, OFF),
-		// DelegatedStaking has on calls
-		// ParachainsOrigin has no calls
-		Configuration(..) => (ON, ON), /* TODO allow this to be called by fellow origin during the migration https://github.com/polkadot-fellows/runtimes/pull/559#discussion_r1928794490 */
-		ParasShared(..) => (OFF, OFF), /* Has no calls but a call enum https://github.com/paritytech/polkadot-sdk/blob/ee803b74056fac5101c06ec5998586fa6eaac470/polkadot/runtime/parachains/src/shared.rs#L185-L186 */
-		ParaInclusion(..) => (OFF, OFF), /* Has no calls but a call enum https://github.com/paritytech/polkadot-sdk/blob/74ec1ee226ace087748f38dfeffc869cd5534ac8/polkadot/runtime/parachains/src/inclusion/mod.rs#L352-L353 */
-		ParaInherent(..) => (ON, ON),    // only inherents
-		// ParaScheduler has no calls
-		Paras(..) => (ON, ON),
-		Initializer(..) => (ON, ON),
-		// Dmp has no calls and deprecated
-		Hrmp(..) => (OFF, OFF),
-		// ParaSessionInfo has no calls
-		ParasDisputes(..) => (OFF, ON), // TODO check with security
-		ParasSlashing(..) => (OFF, ON), // TODO check with security
-		OnDemand(..) => (OFF, ON),
-		// CoretimeAssignmentProvider has no calls
-		Registrar(..) => (OFF, ON),
-		Slots(..) => (OFF, OFF),
-		Auctions(..) => (OFF, OFF),
-		Crowdloan(
-			crowdloan::Call::<Runtime>::dissolve { .. } |
-			crowdloan::Call::<Runtime>::refund { .. } |
-			crowdloan::Call::<Runtime>::dissolve { .. },
-		) => (OFF, ON),
-		Crowdloan(..) => (OFF, OFF),
-		Coretime(coretime::Call::<Runtime>::request_revenue_at { .. }) => (OFF, ON),
-		Coretime(..) => (ON, ON),
-		StateTrieMigration(..) => (OFF, OFF), // Deprecated
-		XcmPallet(..) => (OFF, ON), /* TODO allow para origins and root to call this during the migration, see https://github.com/polkadot-fellows/runtimes/pull/559#discussion_r1928789463 */
-		MessageQueue(..) => (ON, ON), // TODO think about this
-		AssetRate(..) => (OFF, OFF),
-		Beefy(..) => (OFF, ON), /* TODO @claravanstaden @bkontur
-		                         * RcMigrator has no calls currently
-		                         * Exhaustive match. Compiler ensures that we did not miss any. */
-	}
+	type RcPostMigrationCalls = ahm_phase1::CallsEnabledDuringMigration;
+	type RcIntraMigrationCalls = ahm_phase1::CallsEnabledAfterMigration;
 }
 
 construct_runtime! {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1612,7 +1612,7 @@ impl Contains<<Runtime as frame_system::Config>::RuntimeCall> for CallsEnabledAf
 ///
 /// Visually:
 ///
-/// 		|-----1-----|
+///         |-----1-----|
 ///                      |---2---->
 /// --------|-----------|--------->
 ///       Start        End

--- a/relay/polkadot/tests/ahm/mod.rs
+++ b/relay/polkadot/tests/ahm/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Asset Hub Migrator tests.
+//! Asset Hub Migration tests.
 
 mod accounts;
 
@@ -50,6 +50,7 @@ async fn remote_ext_test_setup() -> Option<RemoteExternalities<Block>> {
 	Some(ext)
 }
 
+/// Check that the call filtering mechanism works.
 #[test]
 fn call_filter_works() {
 	let mut t: sp_io::TestExternalities =
@@ -104,9 +105,8 @@ fn call_filter_works() {
 
 	// Try to actually dispatch the calls
 	t.execute_with(|| {
-		let alice = AccountId32::from([0; 32]);
 		<pallet_balances::Pallet<T> as frame_support::traits::Currency<_>>::deposit_creating(
-			&alice,
+			&AccountId32::from([0; 32]),
 			u64::MAX.into(),
 		);
 
@@ -139,11 +139,12 @@ fn call_filter_works() {
 	});
 }
 
+/// Whether a call is forbidden by the call filter.
 fn is_forbidden(call: &polkadot_runtime::RuntimeCall) -> bool {
 	let Err(err) = call.clone().dispatch(RuntimeOrigin::signed(AccountId32::from([0; 32]))) else {
 		return false;
 	};
 
-	let runtime_err: sp_runtime::DispatchError = frame_system::Error::<T>::CallFiltered.into();
-	err.error == runtime_err
+	let filtered_err: sp_runtime::DispatchError = frame_system::Error::<T>::CallFiltered.into();
+	err.error == filtered_err
 }

--- a/relay/polkadot/tests/ahm/mod.rs
+++ b/relay/polkadot/tests/ahm/mod.rs
@@ -64,9 +64,12 @@ fn call_filter_works() {
 			),
 			page_index: 0,
 		});
-	// System calls are filtered during the migration:
-	let system_call =
-		polkadot_runtime::RuntimeCall::System(frame_system::Call::<T>::remark { remark: vec![] });
+	// Balances calls are filtered during the migration:
+	let balances_call =
+		polkadot_runtime::RuntimeCall::Balances(pallet_balances::Call::<T>::transfer_all {
+			dest: AccountId32::from([0; 32]).into(),
+			keep_alive: false,
+		});
 	// Indices calls are filtered during and after the migration:
 	let indices_call =
 		polkadot_runtime::RuntimeCall::Indices(pallet_indices::Call::<T>::claim { index: 0 });
@@ -80,7 +83,7 @@ fn call_filter_works() {
 			RcMigrationStage::<T>::put(MigrationStage::Pending);
 
 			assert!(is_allowed(&mq_call));
-			assert!(is_allowed(&system_call));
+			assert!(is_allowed(&balances_call));
 			assert!(is_allowed(&indices_call));
 		}
 
@@ -89,7 +92,7 @@ fn call_filter_works() {
 			RcMigrationStage::<T>::put(MigrationStage::ProxyMigrationInit);
 
 			assert!(is_allowed(&mq_call));
-			assert!(!is_allowed(&system_call));
+			assert!(!is_allowed(&balances_call));
 			assert!(!is_allowed(&indices_call));
 		}
 
@@ -98,7 +101,7 @@ fn call_filter_works() {
 			RcMigrationStage::<T>::put(MigrationStage::MigrationDone);
 
 			assert!(is_allowed(&mq_call));
-			assert!(is_allowed(&system_call));
+			assert!(is_allowed(&balances_call));
 			assert!(!is_allowed(&indices_call));
 		}
 	});
@@ -115,7 +118,7 @@ fn call_filter_works() {
 			RcMigrationStage::<T>::put(MigrationStage::Pending);
 
 			assert!(!is_forbidden(&mq_call));
-			assert!(!is_forbidden(&system_call));
+			assert!(!is_forbidden(&balances_call));
 			assert!(!is_forbidden(&indices_call));
 		}
 
@@ -124,7 +127,7 @@ fn call_filter_works() {
 			RcMigrationStage::<T>::put(MigrationStage::ProxyMigrationInit);
 
 			assert!(!is_forbidden(&mq_call));
-			assert!(is_forbidden(&system_call));
+			assert!(is_forbidden(&balances_call));
 			assert!(is_forbidden(&indices_call));
 		}
 
@@ -133,7 +136,7 @@ fn call_filter_works() {
 			RcMigrationStage::<T>::put(MigrationStage::MigrationDone);
 
 			assert!(!is_forbidden(&mq_call));
-			assert!(!is_forbidden(&system_call));
+			assert!(!is_forbidden(&balances_call));
 			assert!(is_forbidden(&indices_call));
 		}
 	});


### PR DESCRIPTION
To be merged into the AHM working branch.

Changes:
- Configure the RC Migrator pallet as call filter for the Polkadot Relay chain
- Test

- [x] Does not require a CHANGELOG entry
