### PR TITLE
Polkadot Relay fix corrupt ledger migration checks

### DIFF
--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -2043,7 +2043,8 @@ pub mod restore_corrupt_ledger_2 {
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-			let found_corrupted: bool = Decode::decode(&mut &state[..])?;
+			let found_corrupted: bool = Decode::decode(&mut &state[..])
+				.map_err(|_| sp_runtime::TryRuntimeError::Corruption)?;
 			if found_corrupted {
 				assert!(pallet_staking::Ledger::<Runtime>::get(CorruptStash::get()).is_none());
 			}

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -2036,13 +2036,17 @@ pub mod restore_corrupt_ledger_2 {
 
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
-			assert!(pallet_staking::Ledger::<Runtime>::get(CorruptStash::get()).is_some());
-			Ok(Default::default())
+			let found_corrupted =
+				pallet_staking::Ledger::<Runtime>::get(CorruptStash::get()).is_some();
+			Ok(found_corrupted.encode())
 		}
 
 		#[cfg(feature = "try-runtime")]
-		fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-			assert!(pallet_staking::Ledger::<Runtime>::get(CorruptStash::get()).is_none());
+		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+			let found_corrupted: bool = Decode::decode(&mut &state[..])?;
+			if found_corrupted {
+				assert!(pallet_staking::Ledger::<Runtime>::get(CorruptStash::get()).is_none());
+			}
 			Ok(())
 		}
 	}


### PR DESCRIPTION
This fixes `try-runtime`  migration validation for the `restore_corrupt_ledger_2` migration.

🚨 This fix is required to unblock CI for all other PRs, which are currently incorrectly failing migration CI checks.

- [x] Does not require a CHANGELOG entry