### PR TITLE
Add xcm recorder to all runtimes

### DIFF
--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -189,7 +189,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = XcmPallet;
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = LocalOriginConverter;
 	type IsReserve = ();

--- a/relay/polkadot/src/xcm_config.rs
+++ b/relay/polkadot/src/xcm_config.rs
@@ -207,7 +207,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = XcmPallet;
 	type AssetTransactor = LocalAssetTransactor;
 	type OriginConverter = LocalOriginConverter;
 	// Polkadot Relay recognises no chains which act as reserves.

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs
@@ -327,7 +327,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// Asset Hub trusts only particular, pre-configured bridged locations from a different consensus

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
@@ -388,7 +388,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// Asset Hub trusts only particular, pre-configured bridged locations from a different consensus

--- a/system-parachains/collectives/collectives-polkadot/src/xcm_config.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/xcm_config.rs
@@ -201,7 +201,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 	type AssetTransactor = FungibleTransactor;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// Collectives does not recognize a reserve location for any asset. Users must teleport DOT

--- a/system-parachains/coretime/coretime-kusama/src/xcm_config.rs
+++ b/system-parachains/coretime/coretime-kusama/src/xcm_config.rs
@@ -189,7 +189,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// Coretime chain does not recognize a reserve location for any asset. Users must teleport KSM

--- a/system-parachains/coretime/coretime-polkadot/src/xcm_config.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/xcm_config.rs
@@ -212,7 +212,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// Coretime chain does not recognize a reserve location for any asset. Users must teleport DOT

--- a/system-parachains/encointer/src/xcm_config.rs
+++ b/system-parachains/encointer/src/xcm_config.rs
@@ -162,7 +162,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 	type AssetTransactor = FungibleTransactor;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = ();

--- a/system-parachains/people/people-kusama/src/xcm_config.rs
+++ b/system-parachains/people/people-kusama/src/xcm_config.rs
@@ -192,7 +192,7 @@ pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 	type AssetTransactor = FungibleTransactor;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	// People chain does not recognize a reserve location for any asset. Users must teleport KSM

--- a/system-parachains/people/people-polkadot/src/xcm_config.rs
+++ b/system-parachains/people/people-polkadot/src/xcm_config.rs
@@ -257,7 +257,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
-	type XcmRecorder = ();
+	type XcmRecorder = PolkadotXcm;
 }
 
 /// Converts a local signed origin into an XCM `Location`. Forms the basis for local origins


### PR DESCRIPTION
The `XcmRecorder` config item is necessary for the `DryRunApi` to return the `local_xcm`.
`pallet-xcm` can be used as the implementation.
Added it to all runtimes.
