### PR TITLE
[AHM] pause scheduler during migration

### DIFF
--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -44,6 +44,7 @@ pub mod staking;
 pub mod types;
 
 pub use pallet::*;
+pub use pallet_rc_migrator::types::ZeroWeightOr;
 
 use frame_support::{
 	pallet_prelude::*,
@@ -524,6 +525,17 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_initialize(_: BlockNumberFor<T>) -> Weight {
 			Weight::zero()
+		}
+	}
+
+	impl<T: Config> pallet_rc_migrator::types::MigrationStatus for Pallet<T> {
+		fn is_ongoing() -> bool {
+			// TODO: implement
+			true
+		}
+		fn is_finished() -> bool {
+			// TODO: implement
+			false
 		}
 	}
 }

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -55,7 +55,7 @@ use frame_support::{
 		tokens::{Fortitude, Precision, Preservation},
 		Contains, Defensive, LockableCurrency, ReservableCurrency,
 	},
-	weights::WeightMeter,
+	weights::{Weight, WeightMeter},
 };
 use frame_system::{pallet_prelude::*, AccountInfo};
 use multisig::MultisigMigrator;
@@ -212,14 +212,14 @@ impl<AccountId, BlockNumber, BagsListScore, VotingClass>
 {
 	/// Whether the migration is finished.
 	///
-	/// This is **not** the same as `!self.is_ongoing()`.
+	/// This is **not** the same as `!self.is_ongoing()` since it may not have started.
 	pub fn is_finished(&self) -> bool {
 		matches!(self, MigrationStage::MigrationDone)
 	}
 
 	/// Whether the migration is ongoing.
 	///
-	/// This is **not** the same as `!self.is_finished()`.
+	/// This is **not** the same as `!self.is_finished()` since it may not have started.
 	pub fn is_ongoing(&self) -> bool {
 		!matches!(self, MigrationStage::Pending | MigrationStage::MigrationDone)
 	}
@@ -927,6 +927,15 @@ pub mod pallet {
 			};
 
 			Ok(())
+		}
+	}
+
+	impl<T: Config> types::MigrationStatus for Pallet<T> {
+		fn is_ongoing() -> bool {
+			RcMigrationStage::<T>::get().is_ongoing()
+		}
+		fn is_finished() -> bool {
+			RcMigrationStage::<T>::get().is_finished()
 		}
 	}
 }

--- a/pallets/rc-migrator/src/scheduler.md
+++ b/pallets/rc-migrator/src/scheduler.md
@@ -5,3 +5,5 @@ Based on the scheduler pallet's usage in the Polkadot/Kusama runtime, it primari
 2. Service tasks from the referendum pallet, specifically `nudge_referendum` and `refund_submission_deposit`
 
 We plan to map all calls that are used in the Governance by inspecting the production snapshots.
+
+During the migration process, we will disable the processing of scheduled tasks on both the Relay Chain and Asset Hub. This is achieved by setting the `MaximumWeight` parameter to zero for the scheduler using the `rc_pallet_migrator::types::ZeroWeightOr` helper type. Once the migration is complete, any tasks that are due for execution on Asset Hub will be processed, even if they are delayed. This behavior is appropriate for both types of tasks we handle.

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -253,7 +253,8 @@ impl pallet_scheduler::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
-	type MaximumWeight = MaximumSchedulerWeight;
+	type MaximumWeight =
+		pallet_rc_migrator::types::ZeroWeightOr<RcMigrator, MaximumSchedulerWeight>;
 	// The goal of having ScheduleOrigin include AuctionAdmin is to allow the auctions track of
 	// OpenGov to schedule periodic auctions.
 	// Also allow Treasurer to schedule recurring payments.

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1079,7 +1079,7 @@ impl pallet_scheduler::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
-	type MaximumWeight = MaximumSchedulerWeight;
+	type MaximumWeight = pallet_ah_migrator::ZeroWeightOr<AhMigrator, MaximumSchedulerWeight>;
 	// Also allow Treasurer to schedule recurring payments.
 	type ScheduleOrigin = EitherOf<EnsureRoot<AccountId>, Treasurer>;
 	type MaxScheduledPerBlock = MaxScheduledPerBlock;


### PR DESCRIPTION
meant to be merged into ahm dev branch

Pause the scheduler pallet during migration.

We can pause the scheduler by setting it's weight limit for task processing to zero. It will end early `on_initialize` without error:
https://github.com/paritytech/polkadot-sdk/blob/f373af0d1c1e296c1b07486dd74710b40089250e/substrate/frame/scheduler/src/lib.rs#L1156