### PR TITLE
Rename OnDemandAssignmentProvider to OnDemand on Kusama

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1839,7 +1839,7 @@ construct_runtime! {
 		ParaSessionInfo: parachains_session_info = 61,
 		ParasDisputes: parachains_disputes = 62,
 		ParasSlashing: parachains_slashing = 63,
-		OnDemandAssignmentProvider: parachains_on_demand = 64,
+		OnDemand: parachains_on_demand = 64,
 		CoretimeAssignmentProvider: parachains_assigner_coretime = 65,
 
 		// Parachain Onboarding Pallets. Start indices at 70 to leave room.


### PR DESCRIPTION
Not sure why we have two different pallet names for this on Kusama and Polkadot. This ensures that on-demand chain docs are the same for both. If we have to preserve different names on Kusama and Polkadot, will work on the docs side instead.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [ ] Does not require a CHANGELOG entry
