### PR TITLE
[AHM] Fix accounts migration failures

### DIFF
--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -45,9 +45,10 @@ use polkadot_runtime::{Block as PolkadotBlock, Runtime as Polkadot};
 use polkadot_runtime_common::{paras_registrar, slots as pallet_slots};
 use remote_externalities::RemoteExternalities;
 use runtime_parachains::dmp::DownwardMessageQueues;
+use sp_core::crypto::Ss58Codec;
 use sp_runtime::AccountId32;
 use std::{collections::BTreeMap, str::FromStr};
-use xcm_emulator::ConvertLocation;
+use xcm_emulator::{ConvertLocation, WeightMeter};
 
 type RcChecks = (
 	pallet_rc_migrator::preimage::PreimageChunkMigrator<Polkadot>,
@@ -343,4 +344,63 @@ async fn migration_works() {
 	run_check(|| AhChecks::post_check(rc_pre.unwrap(), ah_pre.unwrap()), &mut ah);
 
 	println!("Migration done in {} RC blocks", rc_block_count);
+}
+
+#[tokio::test]
+async fn some_account_migration_works() {
+	use frame_system::Account as SystemAccount;
+	use pallet_rc_migrator::accounts::AccountsMigrator;
+
+	let Some((mut rc, mut ah)) = load_externalities().await else { return };
+
+	let accounts: Vec<AccountId32> = vec![
+		// 18.03.2025 - account with reserve above ED, but no free balance
+		"5HB5nWBF2JfqogQYTcVkP1BfrgfadBizGmLBhmoAbGm5C7ir".parse().unwrap(),
+		// 18.03.2025 - account with zero free balance, and reserve below ED
+		"5GTtcseuBoAVLbxQ32XRnqkBmxxDaHqdpPs8ktUnH1zE4Cg3".parse().unwrap(),
+		// 18.03.2025 - account with free balance below ED, and reserve above ED
+		"5HMehBKuxRq7AqdxwQcaM7ff5e8Snchse9cNNGT9wsr4CqBK".parse().unwrap(),
+	];
+
+	for account_id in accounts {
+		let maybe_withdrawn_account = rc.execute_with(|| {
+			let rc_account = SystemAccount::<Polkadot>::get(&account_id);
+			log::info!("Migrating account id: {:?}", account_id.to_ss58check());
+			log::info!("RC account info: {:?}", rc_account);
+
+			let maybe_withdrawn_account = AccountsMigrator::<Polkadot>::withdraw_account(
+				account_id,
+				rc_account,
+				&mut WeightMeter::new(),
+				&mut WeightMeter::new(),
+				0,
+			)
+			.unwrap_or_else(|err| {
+				log::error!("Account withdrawal failed: {:?}", err);
+				None
+			});
+
+			maybe_withdrawn_account
+		});
+
+		let withdrawn_account = match maybe_withdrawn_account {
+			Some(withdrawn_account) => withdrawn_account,
+			None => {
+				log::warn!("Account is not withdrawable");
+				continue;
+			},
+		};
+
+		log::info!("Withdrawn account: {:?}", withdrawn_account);
+
+		ah.execute_with(|| {
+			use asset_hub_polkadot_runtime::AhMigrator;
+			use codec::{Decode, Encode};
+
+			let encoded_account = withdrawn_account.encode();
+			let account = Decode::decode(&mut &encoded_account[..]).unwrap();
+			let res = AhMigrator::do_receive_account(account);
+			log::info!("Account integration result: {:?}", res);
+		});
+	}
 }

--- a/pallets/ah-migrator/src/account.rs
+++ b/pallets/ah-migrator/src/account.rs
@@ -56,12 +56,21 @@ impl<T: Config> Pallet<T> {
 	pub fn do_receive_account(
 		account: RcAccount<T::AccountId, T::Balance, T::RcHoldReason, T::RcFreezeReason>,
 	) -> Result<(), Error<T>> {
+		if !Self::has_existential_deposit(&account) {
+			frame_system::Pallet::<T>::inc_providers(&account.who);
+		}
+
 		let who = account.who;
 		let total_balance = account.free + account.reserved;
 		let minted = match <T as pallet::Config>::Currency::mint_into(&who, total_balance) {
 			Ok(minted) => minted,
 			Err(e) => {
-				log::error!(target: LOG_TARGET, "Failed to mint into account {}: {:?}", who.to_ss58check(), e);
+				log::error!(
+					target: LOG_TARGET,
+					"Failed to mint into account {}: {:?}",
+					who.to_ss58check(),
+					e
+				);
 				return Err(Error::<T>::FailedToProcessAccount);
 			},
 		};
@@ -73,13 +82,23 @@ impl<T: Config> Pallet<T> {
 				&who,
 				hold.amount,
 			) {
-				log::error!(target: LOG_TARGET, "Failed to hold into account {}: {:?}", who.to_ss58check(), e);
+				log::error!(
+					target: LOG_TARGET,
+					"Failed to hold into account {}: {:?}",
+					who.to_ss58check(),
+					e
+				);
 				return Err(Error::<T>::FailedToProcessAccount);
 			}
 		}
 
 		if let Err(e) = <T as pallet::Config>::Currency::reserve(&who, account.unnamed_reserve) {
-			log::error!(target: LOG_TARGET, "Failed to reserve into account {}: {:?}", who.to_ss58check(), e);
+			log::error!(
+				target: LOG_TARGET,
+				"Failed to reserve into account {}: {:?}",
+				who.to_ss58check(),
+				e
+			);
 			return Err(Error::<T>::FailedToProcessAccount);
 		}
 
@@ -89,7 +108,12 @@ impl<T: Config> Pallet<T> {
 				&who,
 				freeze.amount,
 			) {
-				log::error!(target: LOG_TARGET, "Failed to freeze into account {}: {:?}", who.to_ss58check(), e);
+				log::error!(
+					target: LOG_TARGET,
+					"Failed to freeze into account {}: {:?}",
+					who.to_ss58check(),
+					e
+				);
 				return Err(Error::<T>::FailedToProcessAccount);
 			}
 		}
@@ -122,5 +146,15 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Ok(())
+	}
+
+	/// Returns true if the account has an existential deposit and it does not need an extra
+	/// provider reference to exist.
+	pub fn has_existential_deposit(
+		account: &RcAccount<T::AccountId, T::Balance, T::RcHoldReason, T::RcFreezeReason>,
+	) -> bool {
+		frame_system::Pallet::<T>::providers(&account.who) > 0 ||
+			<T as pallet::Config>::Currency::balance(&account.who).saturating_add(account.free) >=
+				<T as pallet::Config>::Currency::minimum_balance()
 	}
 }

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -57,7 +57,7 @@ use frame_support::{
 	pallet_prelude::*,
 	storage::{transactional::with_transaction_opaque_err, TransactionOutcome},
 	traits::{
-		fungible::{InspectFreeze, Mutate, MutateFreeze, MutateHold, Unbalanced},
+		fungible::{Inspect, InspectFreeze, Mutate, MutateFreeze, MutateHold, Unbalanced},
 		Defensive, DefensiveTruncateFrom, LockableCurrency, OriginTrait, QueryPreimage,
 		ReservableCurrency, StorePreimage, WithdrawReasons as LockWithdrawReasons,
 	},
@@ -835,7 +835,7 @@ pub mod pallet {
 			DmpDataMessageCounts::<T>::put((processed, processed_with_error));
 			log::debug!(
 				target: LOG_TARGET,
-				"Increment XCM message processed, processed: {}, processed with error: {}",
+				"Increment XCM message processed, total processed: {}, failed: {}",
 				processed,
 				processed_with_error
 			);

--- a/pallets/rc-migrator/src/accounts.rs
+++ b/pallets/rc-migrator/src/accounts.rs
@@ -294,7 +294,7 @@ impl<T: Config> AccountsMigrator<T> {
 	/// Migrate a single account out of the Relay chain and return it.
 	///
 	/// The account on the relay chain is modified as part of this operation.
-	fn withdraw_account(
+	pub fn withdraw_account(
 		who: T::AccountId,
 		account_info: AccountInfoFor<T>,
 		rc_weight: &mut WeightMeter,
@@ -347,22 +347,8 @@ impl<T: Config> AccountsMigrator<T> {
 
 		let account_data: AccountData<T::Balance> = account_info.data.clone();
 
-		if account_data.free.is_zero() &&
-			account_data.reserved.is_zero() &&
-			account_data.frozen.is_zero()
-		{
-			if account_info.nonce.is_zero() {
-				log::warn!(
-					target: LOG_TARGET,
-					"Possible system account detected. \
-					Consumer ref: {}, Provider ref: {}, Account: '{}'",
-					account_info.consumers,
-					account_info.providers,
-					who.to_ss58check()
-				);
-			} else {
-				log::warn!(target: LOG_TARGET, "Weird account detected '{}'", who.to_ss58check());
-			}
+		if !Self::can_migrate_account(&who, &account_info) {
+			log::info!(target: LOG_TARGET, "Account '{}' is not migrated", who.to_ss58check());
 			return Ok(None);
 		}
 
@@ -388,19 +374,56 @@ impl<T: Config> AccountsMigrator<T> {
 			}
 		}
 
+		let ed = <T as Config>::Currency::minimum_balance();
 		let holds: Vec<IdAmount<T::RuntimeHoldReason, T::Balance>> =
 			pallet_balances::Holds::<T>::get(&who).into();
 
 		for hold in &holds {
-			if let Err(e) =
-				<T as Config>::Currency::release(&hold.id, &who, hold.amount, Precision::Exact)
-			{
+			let IdAmount { id, amount } = hold.clone();
+			let free = <T as Config>::Currency::balance(&who);
+
+			// When the free balance is below the minimum balance and we attempt to release a hold,
+			// the `fungible` implementation would burn the entire free balance while zeroing the
+			// hold. To prevent this, we partially release the hold just enough to raise the free
+			// balance to the minimum balance, while maintaining some balance on hold. This approach
+			// prevents the free balance from being burned.
+			// This scenario causes a panic in the test environment - see:
+			// https://github.com/paritytech/polkadot-sdk/blob/35e6befc5dd61deb154ff0eb7c180a038e626d66/substrate/frame/balances/src/impl_fungible.rs#L285
+			let amount = if free < ed && amount.saturating_sub(ed - free) > 0 {
+				log::debug!(
+					target: LOG_TARGET,
+					"Partially releasing hold to prevent the free balance from being burned"
+				);
+				let partial_amount = ed - free;
+				if let Err(e) =
+					<T as Config>::Currency::release(&id, &who, partial_amount, Precision::Exact)
+				{
+					log::error!(target: LOG_TARGET,
+						"Failed to partially release hold: {:?} \
+						for account: {:?}, \
+						partial amount: {:?}, \
+						with error: {:?}",
+						id,
+						who.to_ss58check(),
+						partial_amount,
+						e
+					);
+					return Err(Error::FailedToWithdrawAccount);
+				}
+				amount - partial_amount
+			} else {
+				amount
+			};
+
+			if let Err(e) = <T as Config>::Currency::release(&id, &who, amount, Precision::Exact) {
 				log::error!(target: LOG_TARGET,
-					"Failed to release hold: {:?} \
-					for account: {:?} \
+					"Failed to release the hold: {:?} \
+					for account: {:?}, \
+					amount: {:?}, \
 					with error: {:?}",
-					hold.id,
+					id,
 					who.to_ss58check(),
+					amount,
 					e
 				);
 				return Err(Error::FailedToWithdrawAccount);
@@ -519,6 +542,42 @@ impl<T: Config> AccountsMigrator<T> {
 		}
 
 		Ok(Some(withdrawn_account))
+	}
+
+	/// Check if the account can be withdrawn and migrated to AH.
+	pub fn can_migrate_account(who: &T::AccountId, account: &AccountInfoFor<T>) -> bool {
+		let ed = <T as Config>::Currency::minimum_balance();
+		let total_balance = <T as Config>::Currency::total_balance(who);
+		if total_balance < ed {
+			if account.nonce.is_zero() {
+				log::warn!(
+					target: LOG_TARGET,
+					"Possible system non-migratable account detected. \
+					Account: '{}', info: {:?}",
+					who.to_ss58check(),
+					account
+				);
+			} else {
+				log::warn!(
+					target: LOG_TARGET,
+					"Non-migratable account detected. \
+					Account: '{}', info: {:?}",
+					who.to_ss58check(),
+					account
+				);
+			}
+			if !total_balance.is_zero() || !account.data.frozen.is_zero() {
+				log::warn!(
+					target: LOG_TARGET,
+					"Non-migratable account has non-zero balance. \
+					Account: '{}', info: {:?}",
+					who.to_ss58check(),
+					account
+				);
+			}
+			return false;
+		}
+		true
 	}
 
 	/// Get the weight for importing a single account on Asset Hub.

--- a/pallets/rc-migrator/src/accounts.rs
+++ b/pallets/rc-migrator/src/accounts.rs
@@ -550,7 +550,7 @@ impl<T: Config> AccountsMigrator<T> {
 		let total_balance = <T as Config>::Currency::total_balance(who);
 		if total_balance < ed {
 			if account.nonce.is_zero() {
-				log::warn!(
+				log::info!(
 					target: LOG_TARGET,
 					"Possible system non-migratable account detected. \
 					Account: '{}', info: {:?}",
@@ -558,7 +558,7 @@ impl<T: Config> AccountsMigrator<T> {
 					account
 				);
 			} else {
-				log::warn!(
+				log::info!(
 					target: LOG_TARGET,
 					"Non-migratable account detected. \
 					Account: '{}', info: {:?}",


### PR DESCRIPTION
The PR addresses the following issues in account migrations:

Problem 1:
An account has a free balance below the existential deposit (ED) but a reserved balance above ED. This causes the free balance to be burned when releasing the hold, additionally leading to a panic in the test environment due to an existing debug_assert.

Solution:
The hold is partially released first to meet the ED requirement before releasing the remaining hold.

Example: https://polkadot.subscan.io/account/16HwqWaypD6acNeUu3faVGVowG86UvG1ieLrXZSWVxsaNyLS

Problem 2:
An account has no free balance but a held balance above ED. This results in an error when attempting to recover the hold on Asset Hub (AH).

Solution:
A provider reference is added on AH if the account lacks a free balance to meet the ED requirement.

Example: https://polkadot.subscan.io/account/167NvqSJt5wKFDR4RFYkXA1piJfEKVH8MG4fs4nX9MnbNPQa

Problem 3:
An account’s total balance (free + reserved) is below ED, causing most fungible implementation operations to fail.

Solution:
Such accounts are ignored and not migrated.

Example (currently only one account): https://polkadot.subscan.io/account/15QBmCuy3aRxn8xuzfaRvzaLdawsGbPmttbcvBU8q71kEb7a