### PR TITLE
[AHM] Referenda metadata

### DIFF
--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -111,6 +111,7 @@ pub enum PalletEventName {
 	BagsList,
 	Vesting,
 	Bounties,
+	ReferendaMetadata,
 }
 
 /// The migration stage on the Asset Hub.
@@ -772,6 +773,20 @@ pub mod pallet {
 			ensure_root(origin)?;
 
 			let res = Self::do_receive_crowdloan_messages(messages);
+
+			Self::increment_msg_received_count(res.is_err());
+
+			res.map_err(Into::into)
+		}
+
+		#[pallet::call_index(20)]
+		pub fn receive_referenda_metadata(
+			origin: OriginFor<T>,
+			metadata: Vec<(u32, <T as frame_system::Config>::Hash)>,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+
+			let res = Self::do_receive_referenda_metadata(metadata);
 
 			Self::increment_msg_received_count(res.is_err());
 

--- a/pallets/ah-migrator/src/referenda.rs
+++ b/pallets/ah-migrator/src/referenda.rs
@@ -175,12 +175,38 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	pub fn do_receive_referenda_metadata(
+		metadata: Vec<(u32, <T as frame_system::Config>::Hash)>,
+	) -> Result<(), Error<T>> {
+		log::info!(target: LOG_TARGET, "Integrating {} metadata", metadata.len());
+		let count = metadata.len() as u32;
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::ReferendaMetadata,
+			count,
+		});
+
+		for (id, hash) in metadata {
+			log::debug!(target: LOG_TARGET, "Integrating referendum {} metadata", id);
+			pallet_referenda::MetadataOf::<T, ()>::insert(id, hash);
+			log::debug!(target: LOG_TARGET, "Referendum {} integrated", id);
+		}
+
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::ReferendaMetadata,
+			count_good: count,
+			count_bad: 0,
+		});
+		log::info!(target: LOG_TARGET, "Processed {} metadata", count);
+
+		Ok(())
+	}
+
 	pub fn do_receive_referenda_values(
 		referendum_count: u32,
 		deciding_count: Vec<(TrackIdOf<T, ()>, u32)>,
 		track_queue: Vec<(TrackIdOf<T, ()>, Vec<(u32, u128)>)>,
 	) -> Result<(), Error<T>> {
-		log::info!(target: LOG_TARGET, "Integrating referenda pallet");
+		log::info!(target: LOG_TARGET, "Integrating referenda pallet values");
 
 		ReferendumCount::<T, ()>::put(referendum_count);
 		deciding_count.iter().for_each(|(track_id, count)| {
@@ -192,7 +218,7 @@ impl<T: Config> Pallet<T> {
 		});
 
 		Self::deposit_event(Event::ReferendaProcessed);
-		log::info!(target: LOG_TARGET, "Referenda pallet integrated");
+		log::info!(target: LOG_TARGET, "Referenda pallet values integrated");
 		Ok(())
 	}
 }

--- a/pallets/rc-migrator/src/referenda.rs
+++ b/pallets/rc-migrator/src/referenda.rs
@@ -22,6 +22,7 @@ use pallet_referenda::{DecidingCount, MetadataOf, ReferendumCount, ReferendumInf
 pub enum ReferendaStage {
 	#[default]
 	StorageValues,
+	Metadata(Option<u32>),
 	ReferendumInfo(Option<u32>),
 }
 
@@ -40,8 +41,13 @@ impl<T: Config> PalletMigration for ReferendaMigrator<T> {
 		let stage = match last_key {
 			None | Some(ReferendaStage::StorageValues) => {
 				Self::migrate_values(weight_counter)?;
-				Some(ReferendaStage::ReferendumInfo(None))
+				Some(ReferendaStage::Metadata(None))
 			},
+			Some(ReferendaStage::Metadata(last_key)) =>
+				Self::migrate_many_metadata(last_key, weight_counter)?
+					.map_or(Some(ReferendaStage::ReferendumInfo(None)), |last_key| {
+						Some(ReferendaStage::Metadata(Some(last_key)))
+					}),
 			Some(ReferendaStage::ReferendumInfo(last_key)) =>
 				Self::migrate_many_referendum_info(last_key, weight_counter)?
 					.map(|last_key| ReferendaStage::ReferendumInfo(Some(last_key))),
@@ -52,13 +58,9 @@ impl<T: Config> PalletMigration for ReferendaMigrator<T> {
 
 impl<T: Config> ReferendaMigrator<T> {
 	fn migrate_values(_weight_counter: &mut WeightMeter) -> Result<(), Error<T>> {
-		defensive_assert!(
-			MetadataOf::<T, ()>::iter_keys().next().is_none(),
-			"Referenda metadata is not empty"
-		);
+		log::debug!(target: LOG_TARGET, "Migrating referenda values");
 
 		let referendum_count = ReferendumCount::<T, ()>::take();
-
 		const TRACKS_COUNT: usize = 16;
 
 		// track_id, count
@@ -87,10 +89,79 @@ impl<T: Config> ReferendaMigrator<T> {
 		Ok(())
 	}
 
+	fn migrate_many_metadata(
+		mut last_key: Option<u32>,
+		weight_counter: &mut WeightMeter,
+	) -> Result<Option<u32>, Error<T>> {
+		log::debug!(target: LOG_TARGET, "Migrating referenda metadata");
+
+		// we should not send more than AH can handle within the block.
+		let mut ah_weight_counter = WeightMeter::with_limit(T::MaxAhWeight::get());
+		let mut batch = Vec::new();
+
+		let last_key = loop {
+			if weight_counter.try_consume(T::DbWeight::get().reads_writes(1, 1)).is_err() {
+				if batch.is_empty() {
+					defensive!("Out of weight too early");
+					return Err(Error::OutOfWeight);
+				} else {
+					break last_key;
+				}
+			}
+
+			// TODO: replace by the actual weight.
+			if ah_weight_counter.try_consume(Weight::from_all(1)).is_err() {
+				if batch.is_empty() {
+					defensive!("Out of weight too early");
+					return Err(Error::OutOfWeight);
+				} else {
+					break last_key;
+				}
+			}
+
+			let next_key = match last_key {
+				Some(last_key) => {
+					let Some(next_key) = MetadataOf::<T, ()>::iter_keys_from_key(last_key).next()
+					else {
+						break None;
+					};
+					next_key
+				},
+				None => {
+					let Some(next_key) = MetadataOf::<T, ()>::iter_keys().next() else {
+						break None;
+					};
+					next_key
+				},
+			};
+
+			let Some(hash) = MetadataOf::<T, ()>::take(next_key) else {
+				defensive!("MetadataOf is empty");
+				last_key = MetadataOf::<T, ()>::iter_keys_from_key(next_key).next();
+				continue;
+			};
+
+			batch.push((next_key, hash));
+			last_key = Some(next_key);
+		};
+
+		if !batch.is_empty() {
+			Pallet::<T>::send_chunked_xcm_and_track(
+				batch,
+				|batch| types::AhMigratorCall::<T>::ReceiveReferendaMetadata { metadata: batch },
+				|_| Weight::from_all(1), // TODO
+			)?;
+		}
+
+		Ok(last_key)
+	}
+
 	fn migrate_many_referendum_info(
 		mut last_key: Option<u32>,
 		weight_counter: &mut WeightMeter,
 	) -> Result<Option<u32>, Error<T>> {
+		log::debug!(target: LOG_TARGET, "Migrating referenda info");
+
 		// we should not send more than AH can handle within the block.
 		let mut ah_weight_counter = WeightMeter::with_limit(T::MaxAhWeight::get());
 
@@ -135,7 +206,7 @@ impl<T: Config> ReferendaMigrator<T> {
 				},
 			};
 
-			let Some(info) = pallet_referenda::ReferendumInfoFor::<T, ()>::take(next_key) else {
+			let Some(info) = ReferendumInfoFor::<T, ()>::take(next_key) else {
 				defensive!("ReferendumInfoFor is empty");
 				last_key = ReferendumInfoFor::<T, ()>::iter_keys_from_key(next_key).next();
 				continue;

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -91,6 +91,8 @@ pub enum AhMigratorCall<T: Config> {
 	ReceiveAssetRates { asset_rates: Vec<(<T as pallet_asset_rate::Config>::AssetKind, FixedU128)> },
 	#[codec(index = 19)]
 	ReceiveCrowdloanMessages { messages: Vec<crowdloan::RcCrowdloanMessageOf<T>> },
+	#[codec(index = 20)]
+	ReceiveReferendaMetadata { metadata: Vec<(u32, <T as frame_system::Config>::Hash)> },
 	#[codec(index = 101)]
 	StartMigration,
 }


### PR DESCRIPTION
Migrates metadata storage for referenda pallet.

Previously the storage item was empty for Polkadot state and therefore skipped. The current state contains some data.