### PR TITLE
[AHM] refactor events and enable scheduled migration start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10116,6 +10116,7 @@ dependencies = [
  "pallet-rc-migrator",
  "pallet-timestamp",
  "pallet-whitelist",
+ "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
  "polkadot-parachain-primitives",

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -49,3 +49,4 @@ hex = { workspace = true }
 pallet-whitelist = { workspace = true, default-features = true }
 pallet-bounties = { workspace = true, default-features = true }
 cumulus-pallet-parachain-system = { workspace = true }
+pallet-xcm = { workspace = true, default-features = true }

--- a/integration-tests/ahm/src/mock.rs
+++ b/integration-tests/ahm/src/mock.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
-use asset_hub_polkadot_runtime::{Block as AssetHubBlock, Runtime as AssetHub};
+use asset_hub_polkadot_runtime::{AhMigrator, Block as AssetHubBlock, Runtime as AssetHub};
 use codec::Decode;
 use cumulus_primitives_core::{
 	AggregateMessageOrigin as ParachainMessageOrigin, InboundDownwardMessage, ParaId,
@@ -25,7 +25,7 @@ use pallet_rc_migrator::{
 	MigrationStageOf as RcMigrationStageOf, RcMigrationStage as RcMigrationStageStorage,
 };
 use polkadot_primitives::UpwardMessage;
-use polkadot_runtime::{Block as PolkadotBlock, Runtime as Polkadot};
+use polkadot_runtime::{Block as PolkadotBlock, RcMigrator, Runtime as Polkadot};
 use remote_externalities::{Builder, Mode, OfflineConfig, RemoteExternalities};
 use runtime_parachains::{
 	dmp::DownwardMessageQueues,
@@ -75,10 +75,9 @@ pub fn next_block_rc() {
 	frame_system::Pallet::<Polkadot>::set_block_number(now);
 	frame_system::Pallet::<Polkadot>::reset_events();
 	let weight = <polkadot_runtime::MessageQueue as OnInitialize<_>>::on_initialize(now);
-	let weight = <polkadot_runtime::RcMigrator as OnInitialize<_>>::on_initialize(now)
-		.saturating_add(weight);
+	let weight = <RcMigrator as OnInitialize<_>>::on_initialize(now).saturating_add(weight);
 	<polkadot_runtime::MessageQueue as OnFinalize<_>>::on_finalize(now);
-	<polkadot_runtime::RcMigrator as OnFinalize<_>>::on_finalize(now);
+	<RcMigrator as OnFinalize<_>>::on_finalize(now);
 
 	let limit = <Polkadot as frame_system::Config>::BlockWeights::get().max_block;
 	assert!(
@@ -96,10 +95,9 @@ pub fn next_block_ah() {
 	frame_system::Pallet::<AssetHub>::set_block_number(now);
 	frame_system::Pallet::<Polkadot>::reset_events();
 	let weight = <asset_hub_polkadot_runtime::MessageQueue as OnInitialize<_>>::on_initialize(now);
-	let weight = <asset_hub_polkadot_runtime::AhMigrator as OnInitialize<_>>::on_initialize(now)
-		.saturating_add(weight);
+	let weight = <AhMigrator as OnInitialize<_>>::on_initialize(now).saturating_add(weight);
 	<asset_hub_polkadot_runtime::MessageQueue as OnFinalize<_>>::on_finalize(now);
-	<asset_hub_polkadot_runtime::AhMigrator as OnFinalize<_>>::on_finalize(now);
+	<AhMigrator as OnFinalize<_>>::on_finalize(now);
 
 	let limit = <AssetHub as frame_system::Config>::BlockWeights::get().max_block;
 	assert!(
@@ -155,14 +153,14 @@ pub fn set_initial_migration_stage(
 	relay_chain: &mut RemoteExternalities<PolkadotBlock>,
 ) -> RcMigrationStageOf<Polkadot> {
 	let stage = relay_chain.execute_with(|| {
-		if let Ok(stage) = std::env::var("START_STAGE") {
+		let stage = if let Ok(stage) = std::env::var("START_STAGE") {
 			log::info!("Setting start stage: {:?}", &stage);
-			let stage = RcMigrationStage::from_str(&stage).expect("Invalid start stage");
-			RcMigrationStageStorage::<Polkadot>::put(stage.clone());
-			stage
+			RcMigrationStage::from_str(&stage).expect("Invalid start stage")
 		} else {
-			RcMigrationStageStorage::<Polkadot>::get()
-		}
+			RcMigrationStage::AccountsMigrationInit
+		};
+		RcMigrationStageStorage::<Polkadot>::put(stage.clone());
+		stage
 	});
 	relay_chain.commit_all().unwrap();
 	stage

--- a/integration-tests/ahm/src/mock.rs
+++ b/integration-tests/ahm/src/mock.rs
@@ -148,7 +148,8 @@ pub fn enqueue_ump(msgs: Vec<UpwardMessage>) {
 // Sets the initial migration stage on the Relay Chain.
 //
 // If the `START_STAGE` environment variable is set, it will be used to set the initial migration
-// stage. Otherwise, the current migration stage will be returned.
+// stage. Otherwise, the `AccountsMigrationInit` stage will be set bypassing the `Scheduled` stage.
+// The `Scheduled` stage is tested separately by the `scheduled_migration_works` test.
 pub fn set_initial_migration_stage(
 	relay_chain: &mut RemoteExternalities<PolkadotBlock>,
 ) -> RcMigrationStageOf<Polkadot> {

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -51,6 +51,7 @@ use remote_externalities::RemoteExternalities;
 use runtime_parachains::dmp::DownwardMessageQueues;
 use sp_runtime::AccountId32;
 use std::{collections::BTreeMap, str::FromStr};
+use xcm::latest::*;
 use xcm_emulator::{assert_ok, ConvertLocation};
 
 type RcChecks = (
@@ -385,10 +386,15 @@ async fn scheduled_migration_works() {
 		let now = frame_system::Pallet::<Polkadot>::block_number();
 		let scheduled_at = now + 2;
 
-		assert_ok!(RcMigrator::schedule_migration(
-			RawOrigin::Root.into(),
-			DispatchTime::At(scheduled_at)
+		// Fellowship Origin
+		let origin = pallet_xcm::Origin::Xcm(Location::new(
+			0,
+			[
+				Junction::Parachain(1001),
+				Junction::Plurality { id: BodyId::Technical, part: BodyPart::Voice },
+			],
 		));
+		assert_ok!(RcMigrator::schedule_migration(origin.into(), DispatchTime::At(scheduled_at)));
 		assert_eq!(
 			RcMigrationStageStorage::<Polkadot>::get(),
 			RcMigrationStage::Scheduled { block_number: scheduled_at }

--- a/pallets/ah-migrator/src/account.rs
+++ b/pallets/ah-migrator/src/account.rs
@@ -25,7 +25,10 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(), Error<T>> {
 		log::info!(target: LOG_TARGET, "Integrating {} accounts", accounts.len());
 
-		Self::deposit_event(Event::<T>::AccountBatchReceived { count: accounts.len() as u32 });
+		Self::deposit_event(Event::<T>::BatchReceived {
+			pallet: PalletEventName::Balances,
+			count: accounts.len() as u32,
+		});
 		let (mut count_good, mut count_bad) = (0, 0);
 
 		for account in accounts {
@@ -48,7 +51,11 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		Self::deposit_event(Event::<T>::AccountBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::<T>::BatchProcessed {
+			pallet: PalletEventName::Balances,
+			count_good,
+			count_bad,
+		});
 		Ok(())
 	}
 

--- a/pallets/ah-migrator/src/asset_rate.rs
+++ b/pallets/ah-migrator/src/asset_rate.rs
@@ -24,14 +24,18 @@ impl<T: Config> Pallet<T> {
 		log::info!(target: LOG_TARGET, "Processing {} asset rates", rates.len());
 
 		let count = rates.len() as u32;
-		Self::deposit_event(Event::AssetRatesReceived { count });
+		Self::deposit_event(Event::BatchReceived { pallet: PalletEventName::AssetRates, count });
 
 		for rate in rates {
 			Self::do_receive_asset_rate(rate)?;
 		}
 
 		log::info!(target: LOG_TARGET, "Processed {} asset rates", count);
-		Self::deposit_event(Event::AssetRatesProcessed { count_good: count, count_bad: 0 });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::AssetRates,
+			count_good: count,
+			count_bad: 0,
+		});
 
 		Ok(())
 	}

--- a/pallets/ah-migrator/src/claims.rs
+++ b/pallets/ah-migrator/src/claims.rs
@@ -21,7 +21,10 @@ use pallet_rc_migrator::claims::{alias, RcClaimsMessage, RcClaimsMessageOf};
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_claims(messages: Vec<RcClaimsMessageOf<T>>) -> Result<(), Error<T>> {
 		log::info!(target: LOG_TARGET, "Integrating {} claims", messages.len());
-		Self::deposit_event(Event::ClaimsBatchReceived { count: messages.len() as u32 });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::Claims,
+			count: messages.len() as u32,
+		});
 		let (mut count_good, mut count_bad) = (0, 0);
 
 		for message in messages {
@@ -33,7 +36,11 @@ impl<T: Config> Pallet<T> {
 				},
 			}
 		}
-		Self::deposit_event(Event::ClaimsBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::Claims,
+			count_good,
+			count_bad,
+		});
 
 		Ok(())
 	}

--- a/pallets/ah-migrator/src/conviction_voting.rs
+++ b/pallets/ah-migrator/src/conviction_voting.rs
@@ -27,13 +27,20 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(), Error<T>> {
 		log::info!(target: LOG_TARGET, "Processing {} conviction voting messages", messages.len());
 		let count = messages.len() as u32;
-		Self::deposit_event(Event::ConvictionVotingMessagesReceived { count });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::ConvictionVoting,
+			count,
+		});
 
 		for message in messages {
 			Self::do_receive_conviction_voting_message(message);
 		}
 
-		Self::deposit_event(Event::ConvictionVotingMessagesProcessed { count_good: count });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::ConvictionVoting,
+			count_good: count,
+			count_bad: 0,
+		});
 
 		Ok(())
 	}

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -111,6 +111,20 @@ pub enum PalletEventName {
 	BagsList,
 	Vesting,
 	Bounties,
+	Balances,
+	Multisig,
+	Claims,
+	ProxyProxies,
+	ProxyAnnouncements,
+	PreimageChunk,
+	PreimageRequestStatus,
+	PreimageLegacyStatus,
+	NomPools,
+	ReferendaValues,
+	ReferendaReferendums,
+	Scheduler,
+	ConvictionVoting,
+	AssetRates,
 }
 
 /// The migration stage on the Asset Hub.
@@ -283,8 +297,6 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// The event that should to be replaced by something meaningful.
-		TODO,
 		/// A stage transition has occurred.
 		StageTransition {
 			/// The old stage before the transition.
@@ -292,165 +304,10 @@ pub mod pallet {
 			/// The new stage after the transition.
 			new: MigrationStage,
 		},
-		/// We received a batch of accounts that we are going to integrate.
-		AccountBatchReceived {
-			/// How many accounts are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of accounts that we received.
-		AccountBatchProcessed {
-			/// How many accounts were successfully integrated.
-			count_good: u32,
-			/// How many accounts failed to integrate.
-			count_bad: u32,
-		},
-		/// We received a batch of multisigs that we are going to integrate.
-		MultisigBatchReceived {
-			/// How many multisigs are in the batch.
-			count: u32,
-		},
-		MultisigBatchProcessed {
-			/// How many multisigs were successfully integrated.
-			count_good: u32,
-			/// How many multisigs failed to integrate.
-			count_bad: u32,
-		},
-		/// We received a batch of claims that we are going to integrate.
-		ClaimsBatchReceived {
-			/// How many claims are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of claims that we received.
-		ClaimsBatchProcessed {
-			/// How many claims were successfully integrated.
-			count_good: u32,
-			/// How many claims failed to integrate.
-			count_bad: u32,
-		},
-		/// We received a batch of proxies that we are going to integrate.
-		ProxyProxiesBatchReceived {
-			/// How many proxies are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of proxies that we received.
-		ProxyProxiesBatchProcessed {
-			/// How many proxies were successfully integrated.
-			count_good: u32,
-			/// How many proxies failed to integrate.
-			count_bad: u32,
-		},
-		/// We received a batch of proxy announcements that we are going to integrate.
-		ProxyAnnouncementsBatchReceived {
-			/// How many proxy announcements are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of proxy announcements that we received.
-		ProxyAnnouncementsBatchProcessed {
-			/// How many proxy announcements were successfully integrated.
-			count_good: u32,
-			/// How many proxy announcements failed to integrate.
-			count_bad: u32,
-		},
-		/// Received a batch of `RcPreimageChunk` that are going to be integrated.
-		PreimageChunkBatchReceived {
-			/// How many preimage chunks are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of `RcPreimageChunk` that we received.
-		PreimageChunkBatchProcessed {
-			/// How many preimage chunks were successfully integrated.
-			count_good: u32,
-			/// How many preimage chunks failed to integrate.
-			count_bad: u32,
-		},
-		/// We received a batch of `RcPreimageRequestStatus` that we are going to integrate.
-		PreimageRequestStatusBatchReceived {
-			/// How many preimage request status are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of `RcPreimageRequestStatus` that we received.
-		PreimageRequestStatusBatchProcessed {
-			/// How many preimage request status were successfully integrated.
-			count_good: u32,
-			/// How many preimage request status failed to integrate.
-			count_bad: u32,
-		},
-		/// We received a batch of `RcPreimageLegacyStatus` that we are going to integrate.
-		PreimageLegacyStatusBatchReceived {
-			/// How many preimage legacy status are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of `RcPreimageLegacyStatus` that we received.
-		PreimageLegacyStatusBatchProcessed {
-			/// How many preimage legacy status were successfully integrated.
-			count_good: u32,
-			/// How many preimage legacy status failed to integrate.
-			count_bad: u32,
-		},
-		/// Received a batch of `RcNomPoolsMessage` that we are going to integrate.
-		NomPoolsMessagesBatchReceived {
-			/// How many nom pools messages are in the batch.
-			count: u32,
-		},
-		/// Processed a batch of `RcNomPoolsMessage` that we received.
-		NomPoolsMessagesBatchProcessed {
-			/// How many nom pools messages were successfully integrated.
-			count_good: u32,
-			/// How many nom pools messages failed to integrate.
-			count_bad: u32,
-		},
 		/// We received a batch of messages that will be integrated into a pallet.
-		BatchReceived {
-			pallet: PalletEventName,
-			count: u32,
-		},
+		BatchReceived { pallet: PalletEventName, count: u32 },
 		/// We processed a batch of messages for this pallet.
-		BatchProcessed {
-			pallet: PalletEventName,
-			count_good: u32,
-			count_bad: u32,
-		},
-		/// We received a batch of referendums that we are going to integrate.
-		ReferendumsBatchReceived {
-			/// How many referendums are in the batch.
-			count: u32,
-		},
-		/// We processed a batch of referendums that we received.
-		ReferendumsBatchProcessed {
-			/// How many referendums were successfully integrated.
-			count_good: u32,
-			/// How many referendums failed to integrate.
-			count_bad: u32,
-		},
-		ReferendaProcessed,
-		SchedulerMessagesReceived {
-			/// How many scheduler messages are in the batch.
-			count: u32,
-		},
-		SchedulerMessagesProcessed {
-			/// How many scheduler messages were successfully integrated.
-			count_good: u32,
-			/// How many scheduler messages failed to integrate.
-			count_bad: u32,
-		},
-		ConvictionVotingMessagesReceived {
-			/// How many conviction voting messages are in the batch.
-			count: u32,
-		},
-		ConvictionVotingMessagesProcessed {
-			/// How many conviction voting messages were successfully integrated.
-			count_good: u32,
-		},
-		AssetRatesReceived {
-			/// How many asset rates are in the batch.
-			count: u32,
-		},
-		AssetRatesProcessed {
-			/// How many asset rates were successfully integrated.
-			count_good: u32,
-			/// How many asset rates failed to integrate.
-			count_bad: u32,
-		},
+		BatchProcessed { pallet: PalletEventName, count_good: u32, count_bad: u32 },
 	}
 
 	#[pallet::pallet]

--- a/pallets/ah-migrator/src/multisig.rs
+++ b/pallets/ah-migrator/src/multisig.rs
@@ -32,7 +32,10 @@ const KNOWN_BAD_MULTISIGS: &[AccountId32] = &[
 
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_multisigs(multisigs: Vec<RcMultisigOf<T>>) -> Result<(), Error<T>> {
-		Self::deposit_event(Event::MultisigBatchReceived { count: multisigs.len() as u32 });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::Multisig,
+			count: multisigs.len() as u32,
+		});
 		let (mut count_good, mut count_bad) = (0, 0);
 		log::info!(target: LOG_TARGET, "Integrating {} multisigs", multisigs.len());
 
@@ -45,7 +48,11 @@ impl<T: Config> Pallet<T> {
 				},
 			}
 		}
-		Self::deposit_event(Event::MultisigBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::Multisig,
+			count_good,
+			count_bad,
+		});
 
 		Ok(())
 	}

--- a/pallets/ah-migrator/src/preimage.rs
+++ b/pallets/ah-migrator/src/preimage.rs
@@ -22,7 +22,10 @@ use sp_runtime::traits::{BlakeTwo256, Hash};
 
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_preimage_chunks(chunks: Vec<RcPreimageChunk>) -> Result<(), Error<T>> {
-		Self::deposit_event(Event::PreimageChunkBatchReceived { count: chunks.len() as u32 });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::PreimageChunk,
+			count: chunks.len() as u32,
+		});
 		let (mut count_good, mut count_bad) = (0, 0);
 		log::info!(target: LOG_TARGET, "Integrating {} preimage chunks", chunks.len());
 
@@ -35,7 +38,11 @@ impl<T: Config> Pallet<T> {
 				},
 			}
 		}
-		Self::deposit_event(Event::PreimageChunkBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::PreimageChunk,
+			count_good,
+			count_bad,
+		});
 
 		Ok(())
 	}
@@ -92,7 +99,8 @@ impl<T: Config> Pallet<T> {
 	pub fn do_receive_preimage_request_statuses(
 		request_status: Vec<RcPreimageRequestStatusOf<T>>,
 	) -> Result<(), Error<T>> {
-		Self::deposit_event(Event::PreimageRequestStatusBatchReceived {
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::PreimageRequestStatus,
 			count: request_status.len() as u32,
 		});
 		log::info!(target: LOG_TARGET, "Integrating {} preimage request status", request_status.len());
@@ -108,7 +116,11 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		Self::deposit_event(Event::PreimageRequestStatusBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::PreimageRequestStatus,
+			count_good,
+			count_bad,
+		});
 		Ok(())
 	}
 
@@ -169,7 +181,8 @@ impl<T: Config> Pallet<T> {
 	pub fn do_receive_preimage_legacy_statuses(
 		statuses: Vec<RcPreimageLegacyStatusOf<T>>,
 	) -> Result<(), Error<T>> {
-		Self::deposit_event(Event::PreimageLegacyStatusBatchReceived {
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::PreimageLegacyStatus,
 			count: statuses.len() as u32,
 		});
 		log::info!(target: LOG_TARGET, "Integrating {} preimage legacy status", statuses.len());
@@ -184,7 +197,11 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		Self::deposit_event(Event::PreimageLegacyStatusBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::PreimageLegacyStatus,
+			count_good,
+			count_bad,
+		});
 		Ok(())
 	}
 

--- a/pallets/ah-migrator/src/proxy.rs
+++ b/pallets/ah-migrator/src/proxy.rs
@@ -21,7 +21,10 @@ use sp_runtime::{traits::Zero, BoundedSlice};
 
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_proxies(proxies: Vec<RcProxyOf<T, T::RcProxyType>>) -> Result<(), Error<T>> {
-		Self::deposit_event(Event::ProxyProxiesBatchReceived { count: proxies.len() as u32 });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::ProxyProxies,
+			count: proxies.len() as u32,
+		});
 		let (mut count_good, mut count_bad) = (0, 0);
 		log::info!(target: LOG_TARGET, "Integrating batch proxies of with len {}", proxies.len());
 
@@ -34,7 +37,11 @@ impl<T: Config> Pallet<T> {
 				},
 			}
 		}
-		Self::deposit_event(Event::ProxyProxiesBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::ProxyProxies,
+			count_good,
+			count_bad,
+		});
 
 		Ok(())
 	}
@@ -84,7 +91,8 @@ impl<T: Config> Pallet<T> {
 	pub fn do_receive_proxy_announcements(
 		announcements: Vec<RcProxyAnnouncementOf<T>>,
 	) -> Result<(), Error<T>> {
-		Self::deposit_event(Event::ProxyAnnouncementsBatchReceived {
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::ProxyAnnouncements,
 			count: announcements.len() as u32,
 		});
 
@@ -101,7 +109,11 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		Self::deposit_event(Event::ProxyAnnouncementsBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::ProxyAnnouncements,
+			count_good,
+			count_bad,
+		});
 
 		Ok(())
 	}

--- a/pallets/ah-migrator/src/referenda.rs
+++ b/pallets/ah-migrator/src/referenda.rs
@@ -83,7 +83,10 @@ impl<T: Config> Pallet<T> {
 		referendums: Vec<(u32, RcReferendumInfoOf<T, ()>)>,
 	) -> Result<(), Error<T>> {
 		log::info!(target: LOG_TARGET, "Integrating {} referendums", referendums.len());
-		Self::deposit_event(Event::ReferendumsBatchReceived { count: referendums.len() as u32 });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::ReferendaReferendums,
+			count: referendums.len() as u32,
+		});
 		let (mut count_good, mut count_bad) = (0, 0);
 
 		for (id, referendum) in referendums {
@@ -93,7 +96,11 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		Self::deposit_event(Event::ReferendumsBatchProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::ReferendaReferendums,
+			count_good,
+			count_bad,
+		});
 		log::info!(target: LOG_TARGET, "Processed {} referendums", count_good);
 
 		Ok(())
@@ -181,6 +188,10 @@ impl<T: Config> Pallet<T> {
 		track_queue: Vec<(TrackIdOf<T, ()>, Vec<(u32, u128)>)>,
 	) -> Result<(), Error<T>> {
 		log::info!(target: LOG_TARGET, "Integrating referenda pallet");
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::ReferendaValues,
+			count: 1,
+		});
 
 		ReferendumCount::<T, ()>::put(referendum_count);
 		deciding_count.iter().for_each(|(track_id, count)| {
@@ -191,7 +202,11 @@ impl<T: Config> Pallet<T> {
 			TrackQueue::<T, ()>::insert(track_id, queue);
 		});
 
-		Self::deposit_event(Event::ReferendaProcessed);
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::ReferendaValues,
+			count_good: 1,
+			count_bad: 0,
+		});
 		log::info!(target: LOG_TARGET, "Referenda pallet integrated");
 		Ok(())
 	}

--- a/pallets/ah-migrator/src/scheduler.rs
+++ b/pallets/ah-migrator/src/scheduler.rs
@@ -31,7 +31,10 @@ impl<T: Config> Pallet<T> {
 		messages: Vec<RcSchedulerMessageOf<T>>,
 	) -> Result<(), Error<T>> {
 		log::info!(target: LOG_TARGET, "Processing {} scheduler messages", messages.len());
-		Self::deposit_event(Event::SchedulerMessagesReceived { count: messages.len() as u32 });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::Scheduler,
+			count: messages.len() as u32,
+		});
 		let (mut count_good, mut count_bad) = (0, 0);
 
 		for message in messages {
@@ -41,7 +44,11 @@ impl<T: Config> Pallet<T> {
 			}
 		}
 
-		Self::deposit_event(Event::SchedulerMessagesProcessed { count_good, count_bad });
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::Scheduler,
+			count_good,
+			count_bad,
+		});
 		log::info!(target: LOG_TARGET, "Processed {} scheduler messages", count_good);
 
 		Ok(())

--- a/pallets/ah-migrator/src/staking/nom_pools.rs
+++ b/pallets/ah-migrator/src/staking/nom_pools.rs
@@ -29,14 +29,18 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(), Error<T>> {
 		let mut good = 0;
 		log::info!(target: LOG_TARGET, "Integrating {} NomPoolsMessages", messages.len());
-		Self::deposit_event(Event::NomPoolsMessagesBatchReceived { count: messages.len() as u32 });
+		Self::deposit_event(Event::BatchReceived {
+			pallet: PalletEventName::NomPools,
+			count: messages.len() as u32,
+		});
 
 		for message in messages {
 			Self::do_receive_nom_pools_message(message);
 			good += 1;
 		}
 
-		Self::deposit_event(Event::NomPoolsMessagesBatchProcessed {
+		Self::deposit_event(Event::BatchProcessed {
+			pallet: PalletEventName::NomPools,
 			count_good: good as u32,
 			count_bad: 0,
 		});

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -388,6 +388,8 @@ pub mod pallet {
 		XcmError,
 		/// Failed to withdraw account from RC for migration to AH.
 		FailedToWithdrawAccount,
+		/// Indicates that the specified block number is in the past.
+		PastBlockNumber,
 	}
 
 	#[pallet::event]
@@ -462,6 +464,7 @@ pub mod pallet {
 			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
 			let now = frame_system::Pallet::<T>::block_number();
 			let block_number = start_moment.evaluate(now);
+			ensure!(block_number > now, Error::<T>::PastBlockNumber);
 			Self::transition(MigrationStage::Scheduled { block_number });
 			Ok(())
 		}

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -511,10 +511,7 @@ pub mod pallet {
 
 			match stage {
 				MigrationStage::Pending => {
-					// TODO: we should do nothing on pending stage.
-					// On production the AH will send a message and initialize the migration.
-					// Now we transition to `AccountsMigrationInit` to run tests
-					Self::transition(MigrationStage::AccountsMigrationInit);
+					return weight_counter.consumed();
 				},
 				MigrationStage::Scheduled { block_number } =>
 					if now >= block_number {
@@ -533,6 +530,7 @@ pub mod pallet {
 					},
 				MigrationStage::Initializing => {
 					// waiting AH to send a message and to start sending the data
+					return weight_counter.consumed();
 				},
 				MigrationStage::AccountsMigrationInit => {
 					// TODO: weights


### PR DESCRIPTION
Refactor events and enable scheduled migration initiation.

The migration must now be initiated using the `rc_migrator::schedule_migration(scheduled_at)` call on Relay Chain, triggered by the Root or Fellows origins.