### PR TITLE
[CI] Align ubuntu version for runners and use fixed version

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   set-auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: master
     timeout-minutes: 10
     # Important! This forces the job to run only on comments on Pull Requests that starts with '/merge'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
   # Job required by "confirmChangelogChecksPassed"
   verify-changelog-updated:
     name: Verify that Changelog is Updated
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
@@ -35,7 +35,7 @@ jobs:
   # Job required by "confirmChangelogChecksPassed"
   verify-changelog-valid:
     name: Verify that Changelog is valid
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
@@ -52,7 +52,7 @@ jobs:
   # it will still require all the steps to succeed.
   # If you add more jobs, remember to add them to the "needs" array.
   confirmChangelogChecksPassed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: All changelog checks passed
     # If any new job gets added, be sure to add it to this list
     needs:

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   # This generates a matrix with all the required jobs which will be run in the next step
   runtime-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     name: Extract tasks from matrix
@@ -44,7 +44,7 @@ jobs:
   # if they all pass, that job will pass too.
   check-migrations:
     needs: [runtime-matrix]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       # Ensure the other jobs continue
       fail-fast: false
@@ -142,7 +142,7 @@ jobs:
   # it will still require all the steps to succeed.
   # If you add more jobs, remember to add them to the "needs" array.
   confirmMigrationsPassed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: All migrations passed
     # If any new job gets added, be sure to add it to this array
     needs: [check-migrations]

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -12,7 +12,7 @@ permissions: # allow the action to comment on the PR
 
 jobs:
   fellows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       github-handles: ${{ steps.load-fellows.outputs.github-handles }}
     steps:
@@ -26,7 +26,7 @@ jobs:
   reject-non-fellows:
     needs: fellows
     if: ${{ startsWith(github.event.comment.body, '/cmd') && !contains(needs.fellows.outputs.github-handles, github.event.sender.login) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Add reaction to rejected comment
         uses: actions/github-script@v7
@@ -55,7 +55,7 @@ jobs:
   acknowledge:
     needs: fellows
     if: ${{ startsWith(github.event.comment.body, '/cmd') && contains(needs.fellows.outputs.github-handles, github.event.sender.login) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Add reaction to triggered comment
         uses: actions/github-script@v7
@@ -71,7 +71,7 @@ jobs:
 
   clean:
     needs: fellows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
   help:
     needs: [clean, fellows]
     if: ${{ startsWith(github.event.comment.body, '/cmd') && contains(github.event.comment.body, '--help') && contains(needs.fellows.outputs.github-handles, github.event.sender.login) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -176,7 +176,7 @@ jobs:
   # Get PR branch name, because the issue_comment event does not contain the PR branch name
   get-pr-branch:
     needs: [clean, fellows]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       pr-branch: ${{ steps.get-pr.outputs.pr_branch }}
       repo: ${{ steps.get-pr.outputs.repo }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   collect-release-information:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       should-release: ${{ steps.run.outputs.should-release }}
       version: ${{ steps.run.outputs.version }}
@@ -23,7 +23,7 @@ jobs:
   runtime-matrix:
     needs: [ collect-release-information ]
     if: needs.collect-release-information.outputs.should-release == '1'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     steps:
@@ -37,7 +37,7 @@ jobs:
   build-runtimes:
     needs: [ runtime-matrix ]
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
@@ -83,7 +83,7 @@ jobs:
             ${{ steps.srtool_build.outputs.wasm_compressed }}
 
   publish-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ build-runtimes, collect-release-information ]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
@@ -165,7 +165,7 @@ jobs:
   publish-runtimes:
     needs: [ runtime-matrix, publish-release ]
     continue-on-error: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RUNTIME_DIR: runtime
     strategy:

--- a/.github/workflows/review-bot.yml
+++ b/.github/workflows/review-bot.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   review-approvals:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Extract content of artifact
         id: number

--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -17,7 +17,7 @@ jobs:
   trigger-review-bot:
     # (It is not a draft) && (it is not a review || it is an approving review)
     if: ${{ github.event.pull_request.draft != true && (github.event_name != 'pull_request_review' || (github.event.review && github.event.review.state == 'APPROVED')) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: trigger review bot
     steps:
       - name: Get PR data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   # This generates a matrix with all the required jobs which will be run in the next step
   runtime-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     name: Extract runtimes from matrix
@@ -33,7 +33,7 @@ jobs:
           echo "runtime=$TASKS" >> $GITHUB_OUTPUT
 
   integration-test-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       itest: ${{ steps.itest.outputs.itest }}
     name: Extract integration tests from matrix
@@ -151,7 +151,7 @@ jobs:
 
   # Job required by "confirmTestPassed"
   build-chain-spec-generator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # v0.11.0
@@ -189,7 +189,7 @@ jobs:
   # Job required by "confirmTestPassed"
   zombienet-smoke:
     needs: [build-chain-spec-generator]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@b173b6ec0100793626c2d9e6b90435061f4fc3e5 # v0.11.0
@@ -230,7 +230,7 @@ jobs:
 
   build-runtimes:
     needs: [ runtime-matrix ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       # Ensure the other jobs are continue
       fail-fast: false
@@ -325,7 +325,7 @@ jobs:
   # it will still require all the steps to succeed.
   # If you add more jobs, remember to add them to the "needs" array.
   confirmTestPassed:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: All tests passed
     # If any new job gets added, be sure to add it to this list
     needs:

--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   updatePullRequests:
     name: Keep PRs up to date
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: master
     steps:
       - name: Generate token

--- a/docs/weight-generation.md
+++ b/docs/weight-generation.md
@@ -1,7 +1,7 @@
 # Weight Generation
 
 To generate weights for a runtime. 
-Weights generation is using self-hosted runner which is provided by [Amforc](https://amforc.com/), the rest commands are using standard Github runners on `ubuntu-latest` or `ubuntu-20.04`.
+Weights generation is using self-hosted runner which is provided by [Amforc](https://amforc.com/), the rest commands are using standard Github runners on `ubuntu-latest` or `ubuntu-22.04`.
 Self-hosted runner for benchmarks is configured to meet requirements of reference hardware for running validators https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot#reference-hardware
 
 In a PR run the actions through comment:


### PR DESCRIPTION
Addressing comment: https://github.com/polkadot-fellows/runtimes/pull/637/files#r2012149573

Actually, some workflows use `runs-on: ubuntu-22.04`, while others use `runs-on: ubuntu-latest`. Additionally, there are several other places where either `ubuntu-22.04` or `ubuntu-latest` is used.  

## **Open questions**  

- [ ] Decide whether to use `ubuntu-22.04` or a higher version like `ubuntu-24.04` ([Ubuntu Releases](https://releases.ubuntu.com/))  
- [ ] Consider an easier configuration method:  
  - Using `runs-on: ${{ vars.UBUNTU_VERSION }}` (but this requires repo admin access to modify variables, which is probably not ideal)  
  - Using `$GITHUB_ENV` and an `.env` file (though, as I understand, this only works at the step level, not the job level)  
  - Using a matrix strategy with several versions (probably not needed)
  - Sticking to manual updates (maybe that's the best option. Anyway, how often do we actually need to change it?)
- [x] Does not require a CHANGELOG entry
