### PR TITLE
[AHM] Pallet treasury tests

### DIFF
--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -65,6 +65,7 @@ type RcChecks = (
 	pallet_rc_migrator::proxy::ProxyProxiesMigrator<Polkadot>,
 	pallet_rc_migrator::staking::bags_list::BagsListMigrator<Polkadot>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<Polkadot>,
+	pallet_rc_migrator::treasury::TreasuryMigrator<Polkadot>,
 	// other pallets go here
 	ProxiesStillWork,
 );
@@ -79,6 +80,7 @@ type AhChecks = (
 	pallet_rc_migrator::proxy::ProxyProxiesMigrator<AssetHub>,
 	pallet_rc_migrator::staking::bags_list::BagsListMigrator<AssetHub>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<AssetHub>,
+	pallet_rc_migrator::treasury::TreasuryMigrator<AssetHub>,
 	// other pallets go here
 	ProxiesStillWork,
 );

--- a/pallets/ah-migrator/src/treasury.rs
+++ b/pallets/ah-migrator/src/treasury.rs
@@ -15,7 +15,10 @@
 // limitations under the License.
 
 use crate::*;
-use pallet_rc_migrator::treasury::alias as treasury_alias;
+use pallet_rc_migrator::treasury::{
+	alias as treasury_alias, RcSpendStatus, RcSpendStatusOf, TreasuryMigrator,
+};
+use pallet_treasury::{ProposalIndex, SpendIndex};
 
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_treasury_messages(messages: Vec<RcTreasuryMessageOf<T>>) -> DispatchResult {
@@ -179,5 +182,91 @@ impl<T: Config> Pallet<T> {
 				e
 			),
 		};
+	}
+}
+
+#[cfg(feature = "std")]
+impl<T: Config> crate::types::AhMigrationCheck for TreasuryMigrator<T> {
+	type RcPrePayload =
+		(Vec<ProposalIndex>, Vec<ProposalIndex>, Vec<(SpendIndex, RcSpendStatusOf<T>)>);
+	type AhPrePayload = ();
+
+	fn pre_check(_: Self::RcPrePayload) -> Self::AhPrePayload {
+		// Assert storage 'Treasury::ProposalCount::ah_pre::empty'
+		assert_eq!(
+			pallet_treasury::ProposalCount::<T>::get(),
+			0,
+			"ProposalCount should be 0 on Asset Hub before migration"
+		);
+
+		// Assert storage 'Treasury::Approvals::ah_pre::empty'
+		assert!(
+			pallet_treasury::Approvals::<T>::get().is_empty(),
+			"Approvals should be empty on Asset Hub before migration"
+		);
+
+		// Assert storage 'Treasury::Proposals::ah_pre::empty'
+		assert!(
+			pallet_treasury::Proposals::<T>::iter().next().is_none(),
+			"Proposals should be empty on Asset Hub before migration"
+		);
+
+		// Assert storage 'Treasury::SpendCount::ah_pre::empty'
+		assert_eq!(
+			treasury_alias::SpendCount::<T>::get(),
+			0,
+			"SpendCount should be 0 on Asset Hub before migration"
+		);
+
+		// Assert storage 'Treasury::Spends::ah_pre::empty'
+		assert!(
+			treasury_alias::Spends::<T>::iter().next().is_none(),
+			"Spends should be empty on Asset Hub before migration"
+		);
+	}
+
+	fn post_check((proposals, approvals, spends): Self::RcPrePayload, _: Self::AhPrePayload) {
+		// Assert storage 'Treasury::ProposalCount::ah_post::consistent'
+		assert_eq!(
+			pallet_treasury::Proposals::<T>::iter_keys().count() as u32,
+			proposals.len() as u32,
+			"ProposalCount on Asset Hub should match RC value"
+		);
+
+		// Assert storage 'Treasury::Proposals::ah_post::consistent'
+		assert_eq!(
+			proposals,
+			pallet_treasury::Proposals::<T>::iter_keys().collect::<Vec<_>>(),
+			"Proposals on Asset Hub should match RC proposals"
+		);
+
+		// Assert storage 'Treasury::Approvals::ah_post::consistent'
+		assert_eq!(
+			pallet_treasury::Approvals::<T>::get().into_inner(),
+			approvals,
+			"Approvals on Asset Hub should match RC value"
+		);
+
+		// Assert storage 'Treasury::SpendCount::ah_post::consistent'
+		assert_eq!(
+			treasury_alias::Spends::<T>::iter_keys().count() as u32,
+			spends.len() as u32,
+			"SpendCount on Asset Hub should match RC value"
+		);
+
+		// Assert storage 'Treasury::Spends::ah_post::consistent'
+		let mut ah_spends = Vec::new();
+		for (spend_id, spend) in treasury_alias::Spends::<T>::iter() {
+			ah_spends.push((
+				spend_id,
+				RcSpendStatus {
+					amount: spend.amount,
+					valid_from: spend.valid_from,
+					expire_at: spend.expire_at,
+					status: spend.status,
+				},
+			));
+		}
+		assert_eq!(ah_spends.len(), spends.len(), "Spends on Asset Hub should match RC values");
 	}
 }

--- a/pallets/ah-migrator/src/treasury.rs
+++ b/pallets/ah-migrator/src/treasury.rs
@@ -187,6 +187,7 @@ impl<T: Config> Pallet<T> {
 
 #[cfg(feature = "std")]
 impl<T: Config> crate::types::AhMigrationCheck for TreasuryMigrator<T> {
+	// (proposals ids, historical proposals count, approvals ids, spends, historical spends count)
 	type RcPrePayload =
 		(Vec<ProposalIndex>, u32, Vec<ProposalIndex>, Vec<(SpendIndex, RcSpendStatusOf<T>)>, u32);
 	type AhPrePayload = ();
@@ -229,14 +230,14 @@ impl<T: Config> crate::types::AhMigrationCheck for TreasuryMigrator<T> {
 		(proposals, proposals_count, approvals, spends, spends_count): Self::RcPrePayload,
 		_: Self::AhPrePayload,
 	) {
-		// Assert storage 'Treasury::ProposalCount::ah_post::consistent'
+		// Assert storage 'Treasury::ProposalCount::ah_post::correct'
 		assert_eq!(
 			pallet_treasury::ProposalCount::<T>::get(),
 			proposals_count,
 			"ProposalCount on Asset Hub should match RC value"
 		);
 
-		// Assert storage 'Treasury::SpendCount::ah_post::consistent'
+		// Assert storage 'Treasury::SpendCount::ah_post::correct'
 		assert_eq!(
 			treasury_alias::SpendCount::<T>::get(),
 			spends_count,
@@ -257,7 +258,7 @@ impl<T: Config> crate::types::AhMigrationCheck for TreasuryMigrator<T> {
 			"Proposals on Asset Hub should match RC proposals"
 		);
 
-		// Assert storage 'Treasury::Approvals::ah_post::consistent'
+		// Assert storage 'Treasury::Approvals::ah_post::correct'
 		assert_eq!(
 			pallet_treasury::Approvals::<T>::get().into_inner(),
 			approvals,

--- a/pallets/rc-migrator/src/treasury.rs
+++ b/pallets/rc-migrator/src/treasury.rs
@@ -247,7 +247,7 @@ pub type RcSpendStatusOf<T> = RcSpendStatus<
 
 #[cfg(feature = "std")]
 impl<T: Config> crate::types::RcMigrationCheck for TreasuryMigrator<T> {
-	// (proposals ids, proposals count, approvals ids, spends, spends count)
+	// (proposals ids, historicalproposals count, approvals ids, spends, historical spends count)
 	type RcPrePayload =
 		(Vec<ProposalIndex>, u32, Vec<ProposalIndex>, Vec<(SpendIndex, RcSpendStatusOf<T>)>, u32);
 
@@ -274,7 +274,7 @@ impl<T: Config> crate::types::RcMigrationCheck for TreasuryMigrator<T> {
 	}
 
 	fn post_check(_rc_payload: Self::RcPrePayload) {
-		// Assert storage 'Treasury::ProposalCount::rc_post::zero'
+		// Assert storage 'Treasury::ProposalCount::rc_post::empty'
 		assert_eq!(
 			pallet_treasury::ProposalCount::<T>::get(),
 			0,
@@ -293,7 +293,7 @@ impl<T: Config> crate::types::RcMigrationCheck for TreasuryMigrator<T> {
 			"Proposals should be empty on relay chain after migration"
 		);
 
-		// Assert storage 'Treasury::SpendCount::rc_post::zero'
+		// Assert storage 'Treasury::SpendCount::rc_post::empty'
 		assert_eq!(
 			alias::SpendCount::<T>::get(),
 			0,

--- a/pallets/rc-migrator/src/treasury.rs
+++ b/pallets/rc-migrator/src/treasury.rs
@@ -68,7 +68,7 @@ pub type RcTreasuryMessageOf<T> = RcTreasuryMessage<
 	<<T as pallet_treasury::Config>::Paymaster as Pay>::Id,
 >;
 
-pub struct TreasuryMigrator<T: Config> {
+pub struct TreasuryMigrator<T> {
 	_phantom: PhantomData<T>,
 }
 
@@ -228,5 +228,80 @@ pub mod alias {
 		pub expire_at: BlockNumber,
 		/// The status of the payout/claim.
 		pub status: pallet_treasury::PaymentState<PaymentId>,
+	}
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct RcSpendStatus<AssetBalance, BlockNumber, PaymentId> {
+	pub amount: AssetBalance,
+	pub valid_from: BlockNumber,
+	pub expire_at: BlockNumber,
+	pub status: PaymentId,
+}
+
+pub type RcSpendStatusOf<T> = RcSpendStatus<
+	pallet_treasury::AssetBalanceOf<T, ()>,
+	BlockNumberFor<T>,
+	pallet_treasury::PaymentState<<<T as pallet_treasury::Config>::Paymaster as Pay>::Id>,
+>;
+
+#[cfg(feature = "std")]
+impl<T: Config> crate::types::RcMigrationCheck for TreasuryMigrator<T> {
+	// (proposals ids, approvals ids, spends)
+	type RcPrePayload =
+		(Vec<ProposalIndex>, Vec<ProposalIndex>, Vec<(SpendIndex, RcSpendStatusOf<T>)>);
+
+	fn pre_check() -> Self::RcPrePayload {
+		// Store the counts and approvals before migration
+		let proposals = pallet_treasury::Proposals::<T>::iter_keys().collect::<Vec<_>>();
+		let approvals = pallet_treasury::Approvals::<T>::get().into_inner();
+		let spends = alias::Spends::<T>::iter()
+			.map(|(spend_id, spend_status)| {
+				(
+					spend_id,
+					RcSpendStatus {
+						amount: spend_status.amount,
+						valid_from: spend_status.valid_from,
+						expire_at: spend_status.expire_at,
+						status: spend_status.status,
+					},
+				)
+			})
+			.collect::<Vec<_>>();
+		(proposals, approvals, spends)
+	}
+
+	fn post_check(_rc_payload: Self::RcPrePayload) {
+		// Assert storage 'Treasury::ProposalCount::rc_post::zero'
+		assert_eq!(
+			pallet_treasury::ProposalCount::<T>::get(),
+			0,
+			"ProposalCount should be 0 on relay chain after migration"
+		);
+
+		// Assert storage 'Treasury::Approvals::rc_post::empty'
+		assert!(
+			pallet_treasury::Approvals::<T>::get().is_empty(),
+			"Approvals should be empty on relay chain after migration"
+		);
+
+		// Assert storage 'Treasury::Proposals::rc_post::empty'
+		assert!(
+			pallet_treasury::Proposals::<T>::iter().next().is_none(),
+			"Proposals should be empty on relay chain after migration"
+		);
+
+		// Assert storage 'Treasury::SpendCount::rc_post::zero'
+		assert_eq!(
+			alias::SpendCount::<T>::get(),
+			0,
+			"SpendCount should be 0 on relay chain after migration"
+		);
+
+		// Assert storage 'Treasury::Spends::rc_post::empty'
+		assert!(
+			alias::Spends::<T>::iter().next().is_none(),
+			"Spends should be empty on relay chain after migration"
+		);
 	}
 }


### PR DESCRIPTION
Add tests for the following storage items of pallet treasury:

- `ProposalsCount` constant correctly migrated
- `SpendCount` constant correctly migrated
- `Proposals` length is preserved on Asset Hub with all the proposal IDs
- `Approvals` elements are all preserved on Asset Hub
- `Spends` length is preserved on Asset Hub and some `Spend` fields are checked (validity interval blocks, asset amount, spend status)

**What's NOT tested**

- Perfect equality of preserved `Proposals` w.r.t. Relay Chain (they are deprecated and will soon be removed)
- `AssetKind` and `Beneficiary` checks on migrated `Spends` (migration logic is involved and would essentially require duplicating the migration code)