### PR TITLE
[AHM] Pallet multisig tests

### DIFF
--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -68,6 +68,10 @@ type RcChecks = (
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<Polkadot>,
 	pallet_rc_migrator::treasury::TreasuryMigrator<Polkadot>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<Polkadot>,
+	pallet_rc_migrator::multisig::MultisigMigrator<
+		Polkadot,
+		<polkadot_runtime::Runtime as pallet_rc_migrator::Config>::RcWeightInfo,
+	>,
 	// other pallets go here
 	ProxiesStillWork,
 );
@@ -85,6 +89,10 @@ type AhChecks = (
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<AssetHub>,
 	pallet_rc_migrator::treasury::TreasuryMigrator<AssetHub>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<AssetHub>,
+	pallet_rc_migrator::multisig::MultisigMigrator<
+		AssetHub,
+		<asset_hub_polkadot_runtime::Runtime as pallet_ah_migrator::Config>::AhWeightInfo,
+	>,
 	// other pallets go here
 	ProxiesStillWork,
 );

--- a/pallets/ah-migrator/src/multisig.rs
+++ b/pallets/ah-migrator/src/multisig.rs
@@ -17,6 +17,7 @@
 
 use crate::*;
 use hex_literal::hex;
+use pallet_rc_migrator::types::AccountIdOf;
 
 /// These multisigs have historical issues where the deposit is missing for the creator.
 const KNOWN_BAD_MULTISIGS: &[AccountId32] = &[
@@ -78,5 +79,33 @@ impl<T: Config> Pallet<T> {
 		}
 
 		Ok(())
+	}
+}
+
+#[cfg(feature = "std")]
+impl<T: Config, W> crate::types::AhMigrationCheck for MultisigMigrator<T, W> {
+	// List of multisig account ids with non-zero balance on Relay Chain before migration
+	type RcPrePayload = Vec<AccountIdOf<T>>;
+	// Number of multisigs on Asset Hub before migration
+	type AhPrePayload = u32;
+
+	fn pre_check(_: Self::RcPrePayload) -> Self::AhPrePayload {
+		pallet_multisig::Multisigs::<T>::iter_keys().count() as u32
+	}
+
+	fn post_check(rc_pre_payload: Self::RcPrePayload, ah_pre_payload: Self::AhPrePayload) {
+		// Assert storage 'Multisig::Multisigs::ah_post::correct'
+		assert_eq!(
+			pallet_multisig::Multisigs::<T>::iter_keys().count() as u32,
+			ah_pre_payload,
+			"Number of multisigs on Asset Hub should be the same before and after migration"
+		);
+		for account_id in rc_pre_payload {
+			assert!(
+				frame_system::Account::<T>::contains_key(&account_id),
+				"Multisig account {:?} from Relay Chain should be present on Asset Hub",
+				account_id.to_ss58check()
+			);
+		}
 	}
 }


### PR DESCRIPTION
1. Removing migrated multisigs from the relay chain
2. Add pre and post migration tests.

Notice that multisigs storage items are not actually migrated to Asset Hub, but only the multisig accounts (with non-zero balance) are, so that they can be re-created on asset hub by users if they want to. Thus, we only need to check that multisig storage items are deleted from the relay chain and relevant multisig accounts are migrated to asset hub.