### PR TITLE
Testing for bounties migration

### DIFF
--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -57,6 +57,7 @@ use xcm_emulator::{assert_ok, ConvertLocation, WeightMeter};
 
 type RcChecks = (
 	pallet_rc_migrator::accounts::AccountsMigrator<Polkadot>,
+	pallet_rc_migrator::bounties::BountiesMigrator<Polkadot>,
 	pallet_rc_migrator::preimage::PreimageChunkMigrator<Polkadot>,
 	pallet_rc_migrator::preimage::PreimageRequestStatusMigrator<Polkadot>,
 	pallet_rc_migrator::preimage::PreimageLegacyRequestStatusMigrator<Polkadot>,
@@ -71,6 +72,7 @@ type RcChecks = (
 
 type AhChecks = (
 	pallet_rc_migrator::accounts::AccountsMigrator<AssetHub>,
+	pallet_rc_migrator::bounties::BountiesMigrator<AssetHub>,
 	pallet_rc_migrator::preimage::PreimageChunkMigrator<AssetHub>,
 	pallet_rc_migrator::preimage::PreimageRequestStatusMigrator<AssetHub>,
 	pallet_rc_migrator::preimage::PreimageLegacyRequestStatusMigrator<AssetHub>,

--- a/pallets/ah-migrator/src/bounties.rs
+++ b/pallets/ah-migrator/src/bounties.rs
@@ -146,16 +146,18 @@ impl<T: Config> crate::types::AhMigrationCheck for BountiesMigrator<T> {
 
 		// Assert storage 'Bounties::BountyDescriptions::ah_post::correct'
 		assert_eq!(
-			pallet_bounties::BountyDescriptions::<T>::iter().collect::<Vec<_>>(),
+			pallet_bounties::BountyDescriptions::<T>::iter().map(|(key, bounded_vec)| {
+				(key, bounded_vec.into_inner())
+			}).collect::<Vec<_>>(),
 			rc_descriptions,
-			"Bount descript map value on Asset Hub should match RC value"
+			"Bounty descriptions map value on Asset Hub should match RC value"
 		);
 
 		// Assert storage 'Bounties::BountyApprovals::ah_post::correct'
 		assert_eq!(
 			pallet_bounties::BountyApprovals::<T>::get(),
 			rc_approvals, 
-			"Bount approvals vec value on Asset Hub should match RC values"
+			"Bounty approvals vec value on Asset Hub should match RC values"
 		);
 	}
 }

--- a/pallets/ah-migrator/src/bounties.rs
+++ b/pallets/ah-migrator/src/bounties.rs
@@ -15,7 +15,10 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::*;
-use pallet_rc_migrator::bounties::{RcBountiesMessage, RcBountiesMessageOf};
+use pallet_rc_migrator::bounties::{RcBountiesMessage, RcBountiesMessageOf, BountiesMigrator};
+use pallet_bounties::{Bounty, BountyIndex};
+
+pub type BalanceOf<T, I = ()> = pallet_treasury::BalanceOf<T, I>;
 
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_bounties_messages(
@@ -77,5 +80,91 @@ impl<T: Config> Pallet<T> {
 
 		log::debug!(target: LOG_TARGET, "Processed bounties message");
 		Ok(())
+	}
+}
+
+impl<T: Config> crate::types::AhMigrationCheck for BountiesMigrator<T> {
+	type RcPrePayload = (
+		BountyIndex,
+		Vec<(BountyIndex, Bounty<T::AccountId, BalanceOf<T>, BlockNumberFor<T>>)>,
+		Vec<(BountyIndex, BoundedVec<u8, <T as pallet_bounties::Config>::MaximumReasonLength>)>,
+		BoundedVec<BountyIndex, <T as pallet_treasury::Config>::MaxApprovals>,
+	);
+	type AhPrePayload = ();
+
+	fn pre_check(_rc_pre_payload: Self::RcPrePayload) -> Self::AhPrePayload {
+
+		// "Assert storage 'Bounties::BountyCount::ah_pre::empty'"
+		assert_eq!(
+			pallet_bounties::BountyCount::<T>::get(),
+			Default::default(),
+			"Bounty count should be empty on asset hub before migration"
+		);
+
+		// "Assert storage 'Bounties::Bounties::ah_pre::empty'"
+		assert!(
+			pallet_bounties::Bounties::<T>::iter().next().is_none(),
+			"The Bounties map should be empty on asset hub before migration"
+		);
+
+		// "Assert storage 'Bounties::BountyDescriptions::ah_pre::empty'"
+		assert!(
+			pallet_bounties::BountyDescriptions::<T>::iter().next().is_none(),
+			"The Bounty Descriptions map should be empty on asset hub before migration"
+		);
+
+		"Assert storage 'Bounties::BountyApprovals::ah_pre::empty'"
+		assert!(
+			pallet_bounties::BountyApprovals::<T>::get().is_empty(),
+			"The Bounty Approvals vec should be empty on asset hub before migration"
+		);
+	}
+
+	fn post_check(rc_pre_payload: Self::RcPrePayload, _ah_pre_payload: Self::AhPrePayload) {
+		let (rc_count, rc_bounties, rc_descriptions, rc_approvals) = rc_pre_payload;
+
+		// Assert storage 'Bounties::BountyCount::ah_post::correct'
+		assert_eq!(
+			pallet_bounties::BountyCount::<T>::get(), 
+			rc_count,
+			"Bounty count on Asset Hub should match the RC value"
+		);
+
+		// Assert storage 'Bounties::Bounties::ah_post::length'
+		assert_eq!(
+			pallet_bounties::Bounties::<T>::iter_keys().count() as u32,
+			rc_bounties.len() as u32,
+			"Bounties map length on Asset Hub should match the RC value"
+		);
+
+		// Assert storage 'Bounties::Bounties::ah_post::correct'
+		assert_eq!(
+			pallet_bounties::Bounties::<T>::iter().collect::<Vec<_>>(),
+			rc_bounties, 
+			"Bounties map value on Asset Hub should match the RC value"
+		);
+
+		// Assert storage 'Bounties::BountyDescriptions::ah_post::length'
+		let ah_descriptions: Vec<_> = pallet_bounties::BountyDescriptions::<T>::iter().collect();
+		assert_eq!(
+			pallet_bounties::BountyDescriptions::<T>::iter_keys().count() as u32,
+			rc_descriptions.len(),
+			"Bounty description map length on Asset Hub should match RC value"
+			
+		);
+
+		// Assert storage 'Bounties::BountyDescriptions::ah_post::correct'
+		assert_eq!(
+			pallet_bounties::BountyDescriptions::<T>::iter().collect::<Vec<_>>(),
+			rc_descriptions,
+			"Bount descript map value on Asset Hub should match RC value"
+		);
+
+		// Assert storage 'Bounties::BountyApprovals::ah_post::correct'
+		assert_eq!(
+			pallet_bounties::BountyApprovals::<T>::get(),
+			rc_approvals, 
+			"Bount approvals vec value on Asset Hub should match RC values"
+		);
 	}
 }

--- a/pallets/ah-migrator/src/bounties.rs
+++ b/pallets/ah-migrator/src/bounties.rs
@@ -17,8 +17,6 @@
 use crate::*;
 use pallet_rc_migrator::bounties::{RcBountiesMessage, RcBountiesMessageOf, BountiesMigrator, RcPrePayload};
 
-pub type BalanceOf<T, I = ()> = pallet_treasury::BalanceOf<T, I>;
-
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_bounties_messages(
 		messages: Vec<RcBountiesMessageOf<T>>,

--- a/pallets/ah-migrator/src/bounties.rs
+++ b/pallets/ah-migrator/src/bounties.rs
@@ -15,7 +15,9 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::*;
-use pallet_rc_migrator::bounties::{RcBountiesMessage, RcBountiesMessageOf, BountiesMigrator, RcPrePayload};
+use pallet_rc_migrator::bounties::{
+	BountiesMigrator, RcBountiesMessage, RcBountiesMessageOf, RcPrePayload,
+};
 
 impl<T: Config> Pallet<T> {
 	pub fn do_receive_bounties_messages(
@@ -116,7 +118,7 @@ impl<T: Config> crate::types::AhMigrationCheck for BountiesMigrator<T> {
 
 		// Assert storage 'Bounties::BountyCount::ah_post::correct'
 		assert_eq!(
-			pallet_bounties::BountyCount::<T>::get(), 
+			pallet_bounties::BountyCount::<T>::get(),
 			rc_count,
 			"Bounty count on Asset Hub should match the RC value"
 		);
@@ -131,7 +133,7 @@ impl<T: Config> crate::types::AhMigrationCheck for BountiesMigrator<T> {
 		// Assert storage 'Bounties::Bounties::ah_post::correct'
 		assert_eq!(
 			pallet_bounties::Bounties::<T>::iter().collect::<Vec<_>>(),
-			rc_bounties, 
+			rc_bounties,
 			"Bounties map value on Asset Hub should match the RC value"
 		);
 
@@ -139,14 +141,14 @@ impl<T: Config> crate::types::AhMigrationCheck for BountiesMigrator<T> {
 		assert_eq!(
 			pallet_bounties::BountyDescriptions::<T>::iter_keys().count() as u32,
 			rc_descriptions.len() as u32,
-			"Bounty description map length on Asset Hub should match RC value"	
+			"Bounty description map length on Asset Hub should match RC value"
 		);
 
 		// Assert storage 'Bounties::BountyDescriptions::ah_post::correct'
 		assert_eq!(
-			pallet_bounties::BountyDescriptions::<T>::iter().map(|(key, bounded_vec)| {
-				(key, bounded_vec.into_inner())
-			}).collect::<Vec<_>>(),
+			pallet_bounties::BountyDescriptions::<T>::iter()
+				.map(|(key, bounded_vec)| { (key, bounded_vec.into_inner()) })
+				.collect::<Vec<_>>(),
 			rc_descriptions,
 			"Bounty descriptions map value on Asset Hub should match RC value"
 		);
@@ -154,7 +156,7 @@ impl<T: Config> crate::types::AhMigrationCheck for BountiesMigrator<T> {
 		// Assert storage 'Bounties::BountyApprovals::ah_post::correct'
 		assert_eq!(
 			pallet_bounties::BountyApprovals::<T>::get().into_inner(),
-			rc_approvals, 
+			rc_approvals,
 			"Bounty approvals vec value on Asset Hub should match RC values"
 		);
 	}

--- a/pallets/ah-migrator/src/bounties.rs
+++ b/pallets/ah-migrator/src/bounties.rs
@@ -153,7 +153,7 @@ impl<T: Config> crate::types::AhMigrationCheck for BountiesMigrator<T> {
 
 		// Assert storage 'Bounties::BountyApprovals::ah_post::correct'
 		assert_eq!(
-			pallet_bounties::BountyApprovals::<T>::get(),
+			pallet_bounties::BountyApprovals::<T>::get().into_inner(),
 			rc_approvals, 
 			"Bounty approvals vec value on Asset Hub should match RC values"
 		);

--- a/pallets/rc-migrator/src/bounties.rs
+++ b/pallets/rc-migrator/src/bounties.rs
@@ -160,7 +160,10 @@ impl<T: Config> PalletMigration for BountiesMigrator<T> {
 
 pub type RcPrePayload<T> = (
 	BountyIndex,
-	Vec<(BountyIndex, Bounty<<T as frame_system::Config>::AccountId, BalanceOf<T>, BlockNumberFor<T>>)>,
+	Vec<(
+		BountyIndex,
+		Bounty<<T as frame_system::Config>::AccountId, BalanceOf<T>, BlockNumberFor<T>>,
+	)>,
 	Vec<(BountyIndex, Vec<u8>)>,
 	Vec<BountyIndex>,
 );
@@ -171,9 +174,9 @@ impl<T: Config> crate::types::RcMigrationCheck for BountiesMigrator<T> {
 	fn pre_check() -> Self::RcPrePayload {
 		let count = pallet_bounties::BountyCount::<T>::get();
 		let bounties: Vec<_> = pallet_bounties::Bounties::<T>::iter().collect();
-		let descriptions: Vec<_> = pallet_bounties::BountyDescriptions::<T>::iter().map(|(key, bounded_vec)| {
-            (key, bounded_vec.into_inner())
-        }).collect();
+		let descriptions: Vec<_> = pallet_bounties::BountyDescriptions::<T>::iter()
+			.map(|(key, bounded_vec)| (key, bounded_vec.into_inner()))
+			.collect();
 		let approvals = pallet_bounties::BountyApprovals::<T>::get().into_inner();
 		(count, bounties, descriptions, approvals)
 	}

--- a/pallets/rc-migrator/src/bounties.rs
+++ b/pallets/rc-migrator/src/bounties.rs
@@ -161,8 +161,8 @@ impl<T: Config> PalletMigration for BountiesMigrator<T> {
 pub type RcPrePayload<T> = (
 	BountyIndex,
 	Vec<(BountyIndex, Bounty<<T as frame_system::Config>::AccountId, BalanceOf<T>, BlockNumberFor<T>>)>,
-	Vec<(BountyIndex, BoundedVec<u8, <T as pallet_bounties::Config>::MaximumReasonLength>)>,
-	BoundedVec<BountyIndex, <T as pallet_treasury::Config>::MaxApprovals>,
+	Vec<(BountyIndex, Vec<u8>)>,
+	Vec<BountyIndex>,
 );
 
 impl<T: Config> crate::types::RcMigrationCheck for BountiesMigrator<T> {
@@ -171,8 +171,10 @@ impl<T: Config> crate::types::RcMigrationCheck for BountiesMigrator<T> {
 	fn pre_check() -> Self::RcPrePayload {
 		let count = pallet_bounties::BountyCount::<T>::get();
 		let bounties: Vec<_> = pallet_bounties::Bounties::<T>::iter().collect();
-		let descriptions: Vec<_> = pallet_bounties::BountyDescriptions::<T>::iter().collect();
-		let approvals = pallet_bounties::BountyApprovals::<T>::get();
+		let descriptions: Vec<_> = pallet_bounties::BountyDescriptions::<T>::iter().map(|(key, bounded_vec)| {
+            (key, bounded_vec.into_inner())
+        }).collect();
+		let approvals = pallet_bounties::BountyApprovals::<T>::get().into_inner();
 		(count, bounties, descriptions, approvals)
 	}
 

--- a/pallets/rc-migrator/src/bounties.rs
+++ b/pallets/rc-migrator/src/bounties.rs
@@ -158,13 +158,15 @@ impl<T: Config> PalletMigration for BountiesMigrator<T> {
 	}
 }
 
+pub type RcPrePayload<T> = (
+	BountyIndex,
+	Vec<(BountyIndex, Bounty<<T as frame_system::Config>::AccountId, BalanceOf<T>, BlockNumberFor<T>>)>,
+	Vec<(BountyIndex, BoundedVec<u8, <T as pallet_bounties::Config>::MaximumReasonLength>)>,
+	BoundedVec<BountyIndex, <T as pallet_treasury::Config>::MaxApprovals>,
+);
+
 impl<T: Config> crate::types::RcMigrationCheck for BountiesMigrator<T> {
-	type RcPrePayload = (
-		BountyCount,
-		Vec<(BountyIndex, Bounty<T::AccountId, BalanceOf<T>, BlockNumberFor<T>>)>,
-		Vec<(BountyIndex, BoundedVec<u8, <T as BountiesConfig>::MaximumReasonLength>)>,
-		BoundedVec<BountyIndex, <T as TreasuryConfig>::MaxApprovals>,
-	);
+	type RcPrePayload = RcPrePayload<T>;
 
 	fn pre_check() -> Self::RcPrePayload {
 		let count = pallet_bounties::BountyCount::<T>::get();
@@ -178,7 +180,7 @@ impl<T: Config> crate::types::RcMigrationCheck for BountiesMigrator<T> {
 		// Assert storage 'Bounties::BountyCount::rc_post::empty'
 		assert_eq!(
 			pallet_bounties::BountyCount::<T>::get(),
-			Default::default(),
+			0,
 			"Bounty count should be 0 on RC after migration"
 		);
 


### PR DESCRIPTION
Tests
- All storage items don't exist beforehand on AH
- That they equal the RC values after migration

Notes:
I noticed child-bounties isn't migrated. I assume this was on purpose but wanted to note just in case.