### PR TITLE
Enable RFC103 node side feature on Kusama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Bounties Pallet: add approve_bounty_with_curator call ([paritytech/polkadot-sdk/pull/5961](https://github.com/paritytech/polkadot-sdk/pull/5961))
   - Collective: Dynamic deposit based on number of proposals ([paritytech/polkadot-sdk/pull/3151](https://github.com/paritytech/polkadot-sdk/pull/3151))
   - New runtime api that returns the associated pool accounts with a nomination pool ([paritytech/polkadot-sdk/pull/6357](https://github.com/paritytech/polkadot-sdk/pull/6357))
-  - Enable RFC103 on Kusama
+- Enable RFC103 on Kusama ([polkadot-fellows/runtimes/pull/681](https://github.com/polkadot-fellows/runtimes/pull/681/))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Bounties Pallet: add approve_bounty_with_curator call ([paritytech/polkadot-sdk/pull/5961](https://github.com/paritytech/polkadot-sdk/pull/5961))
   - Collective: Dynamic deposit based on number of proposals ([paritytech/polkadot-sdk/pull/3151](https://github.com/paritytech/polkadot-sdk/pull/3151))
   - New runtime api that returns the associated pool accounts with a nomination pool ([paritytech/polkadot-sdk/pull/6357](https://github.com/paritytech/polkadot-sdk/pull/6357))
+  - Enable RFC103 on Kusama
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Bounties Pallet: add approve_bounty_with_curator call ([paritytech/polkadot-sdk/pull/5961](https://github.com/paritytech/polkadot-sdk/pull/5961))
   - Collective: Dynamic deposit based on number of proposals ([paritytech/polkadot-sdk/pull/3151](https://github.com/paritytech/polkadot-sdk/pull/3151))
   - New runtime api that returns the associated pool accounts with a nomination pool ([paritytech/polkadot-sdk/pull/6357](https://github.com/paritytech/polkadot-sdk/pull/6357))
-- Enable RFC103 on Kusama ([polkadot-fellows/runtimes/pull/681](https://github.com/polkadot-fellows/runtimes/pull/681/))
+  - Enable RFC103 on Kusama ([polkadot-fellows/runtimes/pull/681](https://github.com/polkadot-fellows/runtimes/pull/681/))
 
 ### Changed
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1921,8 +1921,8 @@ pub type Migrations = (migrations::Unreleased, migrations::Permanent);
 pub mod migrations {
 	use super::*;
 	use pallet_balances::WeightInfo;
-	use runtime_parachains::configuration::WeightInfo as ParachainsWeightInfo;
 	use polkadot_primitives::node_features::FeatureIndex;
+	use runtime_parachains::configuration::WeightInfo as ParachainsWeightInfo;
 	/// Enable RFC103 feature.
 	///
 	/// This will make the Kusama relay chain runtime accept v2 candidate receipts.

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -38,7 +38,6 @@ use frame_support::{
 use kusama_runtime_constants::{proxy::ProxyType, system_parachain::coretime::TIMESLICE_PERIOD};
 use pallet_nis::WithMaximumOf;
 use polkadot_primitives::{
-	node_features::FeatureIndex,
 	slashing,
 	vstaging::{CandidateEvent, CommittedCandidateReceiptV2, CoreState, ScrapedOnChainVotes},
 	AccountId, AccountIndex, ApprovalVotingParams, Balance, BlockNumber, CandidateHash, CoreIndex,
@@ -1923,7 +1922,7 @@ pub mod migrations {
 	use super::*;
 	use pallet_balances::WeightInfo;
 	use runtime_parachains::configuration::WeightInfo as ParachainsWeightInfo;
-
+	use polkadot_primitives::node_features::FeatureIndex;
 	/// Enable RFC103 feature.
 	///
 	/// This will make the Kusama relay chain runtime accept v2 candidate receipts.

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -258,7 +258,7 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 		match (left, right) {
 			// Root is greater than anything.
-			(OriginCaller::system(frame_system::RawOrigin::Root), _) => Some(Ordering::Greater),
+			(OriginCaller::system(RawOrigin::Root), _) => Some(Ordering::Greater),
 			// For every other origin we don't care, as they are not used for `ScheduleOrigin`.
 			_ => None,
 		}


### PR DESCRIPTION
This will enable candidate receipt v2 format at the runtime upgrade time on Kusama. It is a dependency for Elastic Scaling.

- [ ] Does not require a CHANGELOG entry
