### PR TITLE
testnet genesis: enable relay node features present on polkadot and kusama

### DIFF
--- a/integration-tests/zombienet/src/lib.rs
+++ b/integration-tests/zombienet/src/lib.rs
@@ -22,6 +22,7 @@ pub fn small_network() -> Result<NetworkConfig, Error> {
 				.with_default_command("polkadot")
 				.with_default_image(images.polkadot.as_str())
 				.with_chain_spec_command(CMD_TPL)
+				.with_default_args(vec!["-lparachain=debug,runtime=debug".into()])
 				.chain_spec_command_is_local(true)
 				.with_node(|node| node.with_name(ALICE))
 				.with_node(|node| node.with_name(BOB))

--- a/relay/kusama/src/genesis_config_presets.rs
+++ b/relay/kusama/src/genesis_config_presets.rs
@@ -22,7 +22,9 @@ use alloc::format;
 use babe_primitives::AuthorityId as BabeId;
 use kusama_runtime_constants::currency::UNITS as KSM;
 use pallet_staking::{Forcing, StakerStatus};
-use polkadot_primitives::{AccountPublic, AssignmentId, AsyncBackingParams};
+use polkadot_primitives::{
+	node_features::FeatureIndex, AccountPublic, AssignmentId, AsyncBackingParams,
+};
 use runtime_parachains::configuration::HostConfiguration;
 use sp_core::{sr25519, Pair, Public};
 use sp_genesis_builder::PresetId;
@@ -122,7 +124,10 @@ fn default_parachains_host_configuration() -> HostConfiguration<polkadot_primiti
 		},
 		dispute_post_conclusion_acceptance_period: 100u32,
 		minimum_backing_votes: 1,
-		node_features: NodeFeatures::EMPTY,
+		node_features: NodeFeatures::from_element(
+			1u8 << (FeatureIndex::ElasticScalingMVP as usize) |
+				1u8 << (FeatureIndex::EnableAssignmentsV2 as usize),
+		),
 		async_backing_params: AsyncBackingParams {
 			max_candidate_depth: 2,
 			allowed_ancestry_len: 2,

--- a/relay/polkadot/src/genesis_config_presets.rs
+++ b/relay/polkadot/src/genesis_config_presets.rs
@@ -21,7 +21,9 @@ use crate::*;
 use alloc::format;
 use babe_primitives::AuthorityId as BabeId;
 use pallet_staking::{Forcing, StakerStatus};
-use polkadot_primitives::{AccountPublic, AssignmentId, AsyncBackingParams};
+use polkadot_primitives::{
+	node_features::FeatureIndex, AccountPublic, AssignmentId, AsyncBackingParams,
+};
 use polkadot_runtime_constants::currency::UNITS as DOT;
 use runtime_parachains::configuration::HostConfiguration;
 use sp_core::{sr25519, Pair, Public};
@@ -122,7 +124,10 @@ fn default_parachains_host_configuration() -> HostConfiguration<polkadot_primiti
 		},
 		dispute_post_conclusion_acceptance_period: 100u32,
 		minimum_backing_votes: 1,
-		node_features: NodeFeatures::EMPTY,
+		node_features: NodeFeatures::from_element(
+			1u8 << (FeatureIndex::ElasticScalingMVP as usize) |
+				1u8 << (FeatureIndex::EnableAssignmentsV2 as usize),
+		),
 		async_backing_params: AsyncBackingParams {
 			max_candidate_depth: 2,
 			allowed_ancestry_len: 2,


### PR DESCRIPTION
Fixes https://github.com/polkadot-fellows/runtimes/issues/682.

See https://github.com/polkadot-fellows/runtimes/issues/682#issuecomment-2826721214 for reasoning

- [x] Does not require a CHANGELOG entry