### PR TITLE
[AHM] Docs and simpler events

### DIFF
--- a/integration-tests/ahm/README.md
+++ b/integration-tests/ahm/README.md
@@ -1,0 +1,25 @@
+## Westend Migration Tests
+
+How to run the Rust migration test for Westend.
+
+You need to have the `polkadot-sdk` and the `runtimes` repo both checked out. Polkadot-SDK must be on
+branch `donal-ahm`. Then go into the runtimes repo, navigate to the correct subfolder and run the
+Just command.
+
+You only need to modify the first argument to where you have checked out the `polkadot-sdk`.
+
+⚠️ Run this only after you committed all you work.
+
+```bash
+cd integration-tests/ahm
+just port /home/user/polkadot-sdk cumulus/test/ahm
+```
+You should see a lot of console output and eventually the Rust test running:
+
+```pre
+... lots of output ...
+test tests::pallet_migration_works has been running for over 60 seconds
+```
+
+It should take about 3 minutes to run. If you want to run the test again, please undo all changes in the
+SDK. There is currently no command for this, but I normally use `git add --all && git stash push && git stash drop`.

--- a/pallets/rc-migrator/src/accounts.md
+++ b/pallets/rc-migrator/src/accounts.md
@@ -9,6 +9,10 @@ Users need to be aware that all of their funds will be moved from the Relay chai
 The Account ID will stay the same. This ensures that normal user accounts will be to control their
 funds on Asset Hub.
 
+- 🚨 All funds will be **moved** from the Relay Chain to the Asset Hub.
+- 🚨 Account IDs of parachain sovereign accounts will be translated from their Relay child to their sibling parachain account.
+- The Account ID of normal accounts will stay the same.
+
 ## Sovereign Account Translation
 
 For parachain sovereign accounts, it is not possible to just use the same account ID. The sovereign

--- a/pallets/rc-migrator/src/accounts.md
+++ b/pallets/rc-migrator/src/accounts.md
@@ -34,3 +34,8 @@ funds on their relay sovereign account. However, please note that someone could 
 that address before or after the migration.
 
 Example for Bifrost: this is the [relay sovereign account](https://polkadot.subscan.io/account/13YMK2eeopZtUNpeHnJ1Ws2HqMQG6Ts9PGCZYGyFbSYoZfcm) and it gets translated to this [sibling sovereign account](https://assethub-polkadot.subscan.io/account/13cKp89TtYknbyYnqnF6dWN75q5ZosvFSuqzoEVkUAaNR47A).
+
+## XCM
+
+The migration happens over XCM. There will be events emitted for the balance being removed from the
+Relay Chain and events emitted for the balance being deposited into Asset Hub.

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -480,6 +480,16 @@ pub mod pallet {
 			/// The new stage after the transition.
 			new: MigrationStageOf<T>,
 		},
+		/// The Asset Hub Migration started and is active until `AssetHubMigrationFinished` is emitted.
+		///
+		/// This event is equivalent to `StageTransition { new: Initializing, .. }` but is easier to
+		/// understand. The activation is immediate and affects all events happening afterwards.
+		AssetHubMigrationStarted,
+		/// The Asset Hub Migration finished.
+		///
+		/// This event is equivalent to `StageTransition { new: MigrationDone, .. }` but is easier to
+		/// understand. The finishing is immediate and affects all events happening afterwards.
+		AssetHubMigrationFinished,
 	}
 
 	/// The Relay Chain migration state.
@@ -1435,6 +1445,17 @@ pub mod pallet {
 		/// Execute a stage transition and log it.
 		fn transition(new: MigrationStageOf<T>) {
 			let old = RcMigrationStage::<T>::get();
+
+			if new == MigrationStage::Initializing {
+				defensive_assert!(matches!(old, MigrationStage::Scheduled { .. }), "Data migration can only enter from Scheduled");
+				Self::deposit_event(Event::AssetHubMigrationStarted);
+			}
+
+			if new == MigrationStage::MigrationDone {
+				defensive_assert!(old == MigrationStage::SignalMigrationFinish, "MigrationDone can only enter from SignalMigrationFinish");
+				Self::deposit_event(Event::AssetHubMigrationFinished);
+			}
+
 			RcMigrationStage::<T>::put(&new);
 			log::info!(target: LOG_TARGET, "[Block {:?}] Stage transition: {:?} -> {:?}", frame_system::Pallet::<T>::block_number(), &old, &new);
 			Self::deposit_event(Event::StageTransition { old, new });

--- a/pallets/rc-migrator/src/multisig.md
+++ b/pallets/rc-migrator/src/multisig.md
@@ -1,5 +1,12 @@
 ## Pallet Multisig
 
+### User Impact
+
+- 🚨 Multisigs are **not migrated** to the Asset Hub. They need to be re-announced by the user on AH.
+- Multisig deposits will be migrated and unlocked on AH.
+
+### Context
+
 The issue with the `multisig` pallet is that every Multisig is scoped to a specific call hash. It is
 not possible to just create a Multisig between Alice and Bob - it must always be scoped to a
 specific call hash. A Multisig is only valid for its specific call hash.
@@ -17,6 +24,7 @@ could happen that a Multisig cannot be re-created and loses funds to its associa
 Note: I considered an XCM where the call is sent back to the relay to execute instead of executing
 on AH. This would allow to migrate Multisigs, but we either need to create a new pallet for this or
 change the existing one. Both probably not worth it for us now.
+
 ### Actionable
 
 The only thing that we should do is to unlock the deposits on the AH since they were migrated to AH

--- a/pallets/rc-migrator/src/proxy.md
+++ b/pallets/rc-migrator/src/proxy.md
@@ -10,7 +10,6 @@ Information on the migration of the `Proxy` pallet from Polkadot Relay Chain to 
 - Existing proxies on Asset Hub will have more permissions and will be able to access the new pallets as well. For example, the `NonTransfer` proxy will also be able to use nomination pools. This may affect security assumptions of previously created proxies. Users are advised to review the new proxy permissions.
 - Pure proxies are treated like any other proxy. In order to access them on the Relay Chain, you need to use the AHM account recovery mechanism (todo) or remote proxy pallet (todo). There should be no use in accessing them on the Relay Chain though, since nearly all balances are transferred to Asset Hub.
 
-
 ## Proxy Delegations
 
 The [Proxies](https://github.com/paritytech/polkadot-sdk/blob/7c5224cb01710d0c14c87bf3463cc79e49b3e7b5/substrate/frame/proxy/src/lib.rs#L564-L579) storage maps a delegator to its delegatees. It is migrated one-to-one by mapping the `ProxyType` and `Delay` fields.


### PR DESCRIPTION
Changes:
- Adding some docs on how to run tests
- Adding simpler events like `AssetHubMigrationStarted` and `AssetHubMigrationFinished` to both pallets since `StageTransitioned { old, new }` is apparently too "complicated" for some integrations