### PR TITLE
Let "/cmd bench" accept ":" for "pallet_xcm_benchmarks::generic"

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -117,7 +117,7 @@ jobs:
         id: get-pr-comment
         with:
           text: ${{ github.event.comment.body }}
-          regex: '^(\/cmd )([\s\w-]+)$'
+          regex: '^(\/cmd )([\s\w-:]+)$'
 
       - name: Save output of help
         id: help


### PR DESCRIPTION
Trying to use the bench bot for running benchmarks for "pallet_xcm_benchmarks::generic", I found out the regex in the github workflow is missing the colon.
This PR aims to unblock https://github.com/polkadot-fellows/runtimes/pull/700 that's aiming to run those exact benchmarks.
