### PR TITLE
Fix regex for cmd (for real this time)

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -226,7 +226,7 @@ jobs:
         id: get-pr-comment
         with:
           text: ${{ github.event.comment.body }}
-          regex: '^(\/cmd )([\s\w-]+)$'
+          regex: '^(\/cmd )([\s\w-:]+)$'
 
       - name: Build workflow link
         if:  ${{ !contains(github.event.comment.body, '--quiet') }}


### PR DESCRIPTION
I modified the wrong regex in https://github.com/polkadot-fellows/runtimes/pull/703 😅. This PR does the same change but in the correct regex in the workflow file.
