### PR TITLE
[AHM] Test call decoding

### DIFF
--- a/integration-tests/ahm/src/mock.rs
+++ b/integration-tests/ahm/src/mock.rs
@@ -196,8 +196,9 @@ fn sanity_check_xcm<Call: Decode>(msg: &[u8]) {
 		match instruction {
 			xcm::v3::Instruction::Transact { call, .. } => {
 				// Interesting part here: ensure that the receiving runtime can decode the call
-				let call: Call = Decode::decode(&mut &call.into_encoded()[..]).expect("Must decode DMP XCM call");
-			}
+				let call: Call = Decode::decode(&mut &call.into_encoded()[..])
+					.expect("Must decode DMP XCM call");
+			},
 			_ => (), // Fine, we only check Transacts
 		}
 	}
@@ -215,8 +216,9 @@ fn sanity_check_xcm<Call: Decode>(msg: &[u8]) {
 		match instruction {
 			xcm::v5::Instruction::Transact { call, .. } => {
 				// Interesting part here: ensure that the receiving runtime can decode the call
-				let call: Call = Decode::decode(&mut &call.into_encoded()[..]).expect("Must decode DMP XCM call");
-			}
+				let call: Call = Decode::decode(&mut &call.into_encoded()[..])
+					.expect("Must decode DMP XCM call");
+			},
 			_ => (), // Fine, we only check Transacts
 		}
 	}

--- a/integration-tests/ahm/src/mock.rs
+++ b/integration-tests/ahm/src/mock.rs
@@ -39,6 +39,7 @@ use runtime_parachains::{
 };
 use sp_runtime::{BoundedVec, Perbill};
 use std::str::FromStr;
+use xcm::prelude::*;
 //use frame_support::traits::QueueFootprintQuery; // Only on westend
 
 pub const AH_PARA_ID: ParaId = ParaId::new(1000);
@@ -160,18 +161,51 @@ pub fn next_block_ah() {
 pub fn enqueue_dmp(msgs: Vec<InboundDownwardMessage>) {
 	log::info!("Enqueuing {} DMP messages", msgs.len());
 	for msg in msgs {
-		// Sanity check that we can decode it
-		if let Err(e) =
-			xcm::VersionedXcm::<asset_hub_polkadot_runtime::RuntimeCall>::decode(&mut &msg.msg[..])
-		{
-			panic!("Failed to decode XCM: 0x{}: {:?}", hex::encode(&msg.msg), e);
-		}
+		sanity_check_dmp::<asset_hub_polkadot_runtime::RuntimeCall>(&msg.msg);
 
 		let bounded_msg: BoundedVec<u8, _> = msg.msg.try_into().expect("DMP message too big");
 		asset_hub_polkadot_runtime::MessageQueue::enqueue_message(
 			bounded_msg.as_bounded_slice(),
 			ParachainMessageOrigin::Parent,
 		);
+	}
+}
+
+#[cfg(feature = "ahm-polkadot")] // XCM V3
+fn sanity_check_dmp<Call: Decode>(msg: &[u8]) {
+	let xcm = xcm::VersionedXcm::<Call>::decode(&mut &msg[..]).expect("Must decode DMP XCM");
+	let xcm = match xcm {
+		VersionedXcm::V3(inner) => inner.0,
+		_ => panic!("Wrong XCM version: {:?}", xcm),
+	};
+
+	for instruction in xcm {
+		match instruction {
+			xcm::v3::Instruction::Transact { call, .. } => {
+				// Interesting part here: ensure that the receiving runtime can decode the call
+				let call: Call = Decode::decode(&mut &call.into_encoded()[..]).expect("Must decode DMP XCM call");
+			}
+			_ => (), // Fine, we only check Transacts
+		}
+	}
+}
+
+#[cfg(feature = "ahm-westend")] // XCM V5
+fn sanity_check_dmp<Call: Decode>(msg: &[u8]) {
+	let xcm = xcm::VersionedXcm::<Call>::decode(&mut &msg[..]).expect("Must decode DMP XCM");
+	let xcm = match xcm {
+		VersionedXcm::V5(inner) => inner.0,
+		_ => panic!("Wrong XCM version: {:?}", xcm),
+	};
+
+	for instruction in xcm {
+		match instruction {
+			xcm::v5::Instruction::Transact { call, .. } => {
+				// Interesting part here: ensure that the receiving runtime can decode the call
+				let call: Call = Decode::decode(&mut &call.into_encoded()[..]).expect("Must decode DMP XCM call");
+			}
+			_ => (), // Fine, we only check Transacts
+		}
 	}
 }
 

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -852,7 +852,7 @@ pub mod pallet {
 		#[pallet::weight({1})] // TODO: weight
 		pub fn receive_staking_messages(
 			origin: OriginFor<T>,
-			messages: Vec<AhEquivalentStakingMessageOf<T>>,
+			messages: Vec<T::RcStakingMessage>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -25,9 +25,7 @@ impl<T: Config> Pallet<T> {
 
 	pub fn staking_migration_finish_hook() {}
 
-	pub fn do_receive_staking_messages(
-		messages: Vec<T::RcStakingMessage>,
-	) -> Result<(), Error<T>> {
+	pub fn do_receive_staking_messages(messages: Vec<T::RcStakingMessage>) -> Result<(), Error<T>> {
 		let (mut good, mut bad) = (0, 0);
 		log::info!(target: LOG_TARGET, "Integrating {} StakingMessages", messages.len());
 		Self::deposit_event(Event::BatchReceived {

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -26,7 +26,7 @@ impl<T: Config> Pallet<T> {
 	pub fn staking_migration_finish_hook() {}
 
 	pub fn do_receive_staking_messages(
-		messages: Vec<AhEquivalentStakingMessageOf<T>>,
+		messages: Vec<T::RcStakingMessage>,
 	) -> Result<(), Error<T>> {
 		let (mut good, mut bad) = (0, 0);
 		log::info!(target: LOG_TARGET, "Integrating {} StakingMessages", messages.len());
@@ -36,7 +36,8 @@ impl<T: Config> Pallet<T> {
 		});
 
 		for message in messages {
-			match Self::do_receive_staking_message(message) {
+			let translated = T::RcStakingMessage::intoAh(message);
+			match Self::do_receive_staking_message(translated) {
 				Ok(_) => good += 1,
 				Err(_) => bad += 1,
 			}


### PR DESCRIPTION
Check that the XCM::Transact calls can be decoded by the receiving runtime to not risk having them silently dropped as discovered in https://github.com/paritytech/polkadot-sdk/pull/8401