### PR TITLE
[AHM] Add referenda checks to Westend migration

### DIFF
--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -76,6 +76,7 @@ type RcChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<Polkadot>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<Polkadot>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<Polkadot>,
+	pallet_rc_migrator::referenda::ReferendaMigrator<Polkadot>,
 	RcPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,
@@ -86,7 +87,6 @@ type RcChecks = (
 pub type RcPolkadotChecks = (
 	pallet_rc_migrator::bounties::BountiesMigrator<Polkadot>,
 	pallet_rc_migrator::treasury::TreasuryMigrator<Polkadot>,
-	pallet_rc_migrator::referenda::ReferendaMigrator<Polkadot>,
 	pallet_rc_migrator::claims::ClaimsMigrator<Polkadot>,
 	pallet_rc_migrator::crowdloan::CrowdloanMigrator<Polkadot>,
 );
@@ -107,6 +107,7 @@ type AhChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<AssetHub>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<AssetHub>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<AssetHub>,
+	pallet_rc_migrator::referenda::ReferendaMigrator<AssetHub>,
 	AhPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,
@@ -118,7 +119,6 @@ type AhChecks = (
 pub type AhPolkadotChecks = (
 	pallet_rc_migrator::bounties::BountiesMigrator<AssetHub>,
 	pallet_rc_migrator::treasury::TreasuryMigrator<AssetHub>,
-	pallet_rc_migrator::referenda::ReferendaMigrator<AssetHub>,
 	pallet_rc_migrator::claims::ClaimsMigrator<AssetHub>,
 	pallet_rc_migrator::crowdloan::CrowdloanMigrator<AssetHub>,
 );


### PR DESCRIPTION
Originally I had only added Referenda migration checks to Polkadot. This adds them to Westend as well now that [this fix](https://github.com/paritytech/polkadot-sdk/pull/8401) is in. Part of #644 
