### PR TITLE
[AHM] Adapt XCM configuration to account for changes before and after migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7640,6 +7640,7 @@ name = "pallet-ah-migrator"
 version = "0.1.0"
 dependencies = [
  "assets-common",
+ "collectives-polkadot-runtime-constants",
  "cumulus-primitives-core",
  "frame-benchmarking",
  "frame-support",

--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
@@ -21,6 +21,6 @@ xcm = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true }
 
 # Runtimes
-asset-hub-kusama-runtime = { workspace = true }
+asset-hub-kusama-runtime = { workspace = true, default-features = true }
 kusama-emulated-chain = { workspace = true }
 penpal-emulated-chain = { workspace = true }

--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
@@ -21,6 +21,6 @@ xcm = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true }
 
 # Runtimes
-asset-hub-polkadot-runtime = { workspace = true }
+asset-hub-polkadot-runtime = { workspace = true, default-features = true }
 polkadot-emulated-chain = { workspace = true }
 penpal-emulated-chain = { workspace = true }

--- a/integration-tests/emulated/chains/relays/kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/relays/kusama/Cargo.toml
@@ -25,4 +25,4 @@ emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 kusama-runtime-constants = { workspace = true, default-features = true }
-kusama-runtime = { workspace = true }
+kusama-runtime = { workspace = true, default-features = true }

--- a/integration-tests/emulated/chains/relays/polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/relays/polkadot/Cargo.toml
@@ -27,4 +27,4 @@ emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 polkadot-runtime-constants = { workspace = true, default-features = true }
-polkadot-runtime = { workspace = true }
+polkadot-runtime = { workspace = true, default-features = true }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge.rs
@@ -15,7 +15,7 @@
 use crate::*;
 use asset_hub_polkadot_runtime::xcm_config::{
 	bridging::to_ethereum::{BridgeHubEthereumBaseFee, EthereumNetwork},
-	RelayTreasuryPalletAccount,
+	PreMigrationRelayTreasuryPalletAccount as RelayTreasuryPalletAccount,
 };
 use bp_bridge_hub_polkadot::snowbridge::CreateAssetCall;
 use bridge_hub_polkadot_runtime::{

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -42,6 +42,7 @@ pallet-timestamp = { workspace = true }
 polkadot-parachain-primitives = { workspace = true }
 polkadot-runtime-common = { workspace = true }
 polkadot-runtime-constants = { workspace = true }
+collectives-polkadot-runtime-constants = { workspace = true }
 runtime-parachains = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 serde = { features = ["derive"], optional = true, workspace = true }

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -185,6 +185,7 @@ try-runtime = [
 	"sp-runtime/try-runtime",
 ]
 
+ahm-kusama = []
 ahm-polkadot = [
 	"pallet-ah-ops/ahm-polkadot",
 	"pallet-rc-migrator/ahm-polkadot",

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -83,7 +83,6 @@ use pallet_rc_migrator::crowdloan::RcCrowdloanMessageOf;
 #[cfg(not(feature = "ahm-westend"))]
 use pallet_rc_migrator::treasury::RcTreasuryMessage;
 
-use crate::types::GetAhMigrationStage;
 use pallet_rc_migrator::{
 	accounts::Account as RcAccount,
 	conviction_voting::RcConvictionVotingMessageOf,
@@ -1057,12 +1056,6 @@ pub mod pallet {
 		fn is_finished() -> bool {
 			AhMigrationStage::<T>::get().is_finished()
 		}
-	}
-}
-
-impl<T: Config> GetAhMigrationStage for Pallet<T> {
-	fn ah_migration_stage() -> MigrationStage {
-		AhMigrationStage::<T>::get()
 	}
 }
 

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -83,6 +83,7 @@ use pallet_rc_migrator::crowdloan::RcCrowdloanMessageOf;
 #[cfg(not(feature = "ahm-westend"))]
 use pallet_rc_migrator::treasury::RcTreasuryMessage;
 
+use crate::types::GetAhMigrationStage;
 use pallet_rc_migrator::{
 	accounts::Account as RcAccount,
 	conviction_voting::RcConvictionVotingMessageOf,
@@ -202,8 +203,6 @@ pub type BalanceOf<T> = <T as pallet_balances::Config>::Balance;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use crate::xcm_config::common::{TrustedTeleportersBeforeAfter, TrustedTeleportersDuring};
-	use frame_support::traits::ContainsPair;
 
 	/// Super config trait for all pallets that the migration depends on, providing convenient
 	/// access to their items.
@@ -1059,25 +1058,11 @@ pub mod pallet {
 			AhMigrationStage::<T>::get().is_finished()
 		}
 	}
+}
 
-	// To be used for `IsTeleport` filter. Disallows DOT teleports during the migration.
-	impl<T: Config> ContainsPair<Asset, Location> for Pallet<T> {
-		fn contains(asset: &Asset, origin: &Location) -> bool {
-			let stage = AhMigrationStage::<T>::get();
-			log::trace!(target: "xcm::IsTeleport::contains", "migration stage: {:?}", stage);
-			let result = if stage.is_ongoing() {
-				TrustedTeleportersDuring::contains(asset, origin)
-			} else {
-				// before and after migration use normal filter
-				TrustedTeleportersBeforeAfter::contains(asset, origin)
-			};
-			log::trace!(
-				target: "xcm::IsTeleport::contains",
-				"asset: {:?} origin {:?} result {:?}",
-				asset, origin, result
-			);
-			result
-		}
+impl<T: Config> GetAhMigrationStage for Pallet<T> {
+	fn ah_migration_stage() -> MigrationStage {
+		AhMigrationStage::<T>::get()
 	}
 }
 

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -202,7 +202,7 @@ pub type BalanceOf<T> = <T as pallet_balances::Config>::Balance;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use crate::xcm_config::{TrustedTeleportersBeforeAfter, TrustedTeleportersDuring};
+	use crate::xcm_config::common::{TrustedTeleportersBeforeAfter, TrustedTeleportersDuring};
 	use frame_support::traits::ContainsPair;
 
 	/// Super config trait for all pallets that the migration depends on, providing convenient

--- a/pallets/ah-migrator/src/types.rs
+++ b/pallets/ah-migrator/src/types.rs
@@ -42,12 +42,6 @@ pub enum RcMigratorCall {
 	UpdateAhMsgProcessedCount(u32),
 }
 
-/// Trait to provide the current stage of the AH migration.
-pub trait GetAhMigrationStage {
-	/// Return the current stage of the AH migration.
-	fn ah_migration_stage() -> MigrationStage;
-}
-
 /// Trait to run some checks on the Asset Hub before and after a pallet migration.
 ///
 /// This needs to be called by the test harness.

--- a/pallets/ah-migrator/src/types.rs
+++ b/pallets/ah-migrator/src/types.rs
@@ -42,6 +42,12 @@ pub enum RcMigratorCall {
 	UpdateAhMsgProcessedCount(u32),
 }
 
+/// Trait to provide the current stage of the AH migration.
+pub trait GetAhMigrationStage {
+	/// Return the current stage of the AH migration.
+	fn ah_migration_stage() -> MigrationStage;
+}
+
 /// Trait to run some checks on the Asset Hub before and after a pallet migration.
 ///
 /// This needs to be called by the test harness.

--- a/pallets/ah-migrator/src/xcm_config.rs
+++ b/pallets/ah-migrator/src/xcm_config.rs
@@ -125,9 +125,16 @@ mod before {
 		*,
 	};
 
+	#[cfg(feature = "ahm-kusama")]
+	use kusama_runtime_constants::TREASURY_PALLET_ID;
+	#[cfg(feature = "ahm-polkadot")]
+	use polkadot_runtime_constants::TREASURY_PALLET_ID;
+	#[cfg(feature = "ahm-westend")]
+	use westend_runtime_constants::TREASURY_PALLET_ID;
+
 	parameter_types! {
 		pub RelayTreasuryLocation: Location =
-			(Parent, PalletInstance(polkadot_runtime_constants::TREASURY_PALLET_ID)).into();
+			(Parent, PalletInstance(TREASURY_PALLET_ID)).into();
 	}
 
 	pub struct ParentOrParentsPlurality;
@@ -246,10 +253,10 @@ pub struct WaivedLocations<Stage>(PhantomData<Stage>);
 impl<Stage: MigrationStatus> Contains<Location> for WaivedLocations<Stage> {
 	fn contains(location: &Location) -> bool {
 		if Stage::is_finished() {
-			log::trace!(target: "xcm::WaivedLocations::contains", "migration finished");
+			log::trace!(target: "xcm::WaivedLocations::contains", "{location:?} (migration finished)");
 			after::WaivedLocationsAfter::contains(location)
 		} else {
-			log::trace!(target: "xcm::WaivedLocations::contains", "migration not finished");
+			log::trace!(target: "xcm::WaivedLocations::contains", "{location:?} (migration not finished)");
 			before::WaivedLocationsBeforeDuring::contains(location)
 		}
 	}

--- a/pallets/ah-migrator/src/xcm_config.rs
+++ b/pallets/ah-migrator/src/xcm_config.rs
@@ -19,29 +19,144 @@
 use assets_common::matching::{FromSiblingParachain, IsForeignConcreteAsset};
 use cumulus_primitives_core::ParaId;
 use frame_support::parameter_types;
-use parachains_common::xcm_config::ConcreteAssetFromSystem;
+use frame_support::traits::{Contains, Equals};
+use parachains_common::xcm_config::{ConcreteAssetFromSystem, ParentRelayOrSiblingParachains};
 use xcm::latest::prelude::*;
+use xcm_builder::AllowExplicitUnpaidExecutionFrom;
 
 #[cfg(feature = "ahm-polkadot")]
-use polkadot_runtime_constants::system_parachain::ASSET_HUB_ID;
+use polkadot_runtime_constants::system_parachain;
 #[cfg(feature = "ahm-westend")]
-use westend_runtime_constants::system_parachain::ASSET_HUB_ID;
+use westend_runtime_constants::system_parachain;
 
-parameter_types! {
-	pub const AssetHubParaId: ParaId = ParaId::new(ASSET_HUB_ID);
-	pub const DotLocation: Location = Location::parent();
+pub mod common {
+	use super::*;
+	parameter_types! {
+		pub const AssetHubParaId: ParaId = ParaId::new(system_parachain::ASSET_HUB_ID);
+		pub const DotLocation: Location = Location::parent();
+	}
+
+	pub struct FellowshipEntities;
+	impl Contains<Location> for FellowshipEntities {
+		fn contains(location: &Location) -> bool {
+			matches!(
+			location.unpack(),
+			(
+				1,
+				[
+					Parachain(system_parachain::COLLECTIVES_ID),
+					Plurality { id: BodyId::Technical, .. }
+				]
+			) | (
+				1,
+				[
+					Parachain(system_parachain::COLLECTIVES_ID),
+					PalletInstance(
+						collectives_polkadot_runtime_constants::FELLOWSHIP_SALARY_PALLET_INDEX
+					)
+				]
+			) | (
+				1,
+				[
+					Parachain(system_parachain::COLLECTIVES_ID),
+					PalletInstance(
+						collectives_polkadot_runtime_constants::FELLOWSHIP_TREASURY_PALLET_INDEX
+					)
+				]
+			)
+		)
+		}
+	}
+
+	pub struct AmbassadorEntities;
+	impl Contains<Location> for AmbassadorEntities {
+		fn contains(location: &Location) -> bool {
+			matches!(
+			location.unpack(),
+			(
+				1,
+				[
+					Parachain(system_parachain::COLLECTIVES_ID),
+					PalletInstance(
+						collectives_polkadot_runtime_constants::AMBASSADOR_SALARY_PALLET_INDEX
+					)
+				]
+			) | (
+				1,
+				[
+					Parachain(system_parachain::COLLECTIVES_ID),
+					PalletInstance(
+						collectives_polkadot_runtime_constants::AMBASSADOR_TREASURY_PALLET_INDEX
+					)
+				]
+			)
+		)
+		}
+	}
+
+	// Teleport filters are a special case because we might want to have finer control over which
+	// one to use at fine-grained stages of the migration.
+
+	/// Cases where a remote origin is accepted as trusted Teleporter for a given asset:
+	///
+	/// - DOT with the parent Relay Chain and sibling system parachains; and
+	/// - Sibling parachains' assets from where they originate (as `ForeignCreators`).
+	pub type TrustedTeleportersBeforeAfter = (
+		ConcreteAssetFromSystem<DotLocation>,
+		IsForeignConcreteAsset<FromSiblingParachain<AssetHubParaId>>,
+	);
+
+	/// During migration we only allow teleports of foreign assets (not DOT).
+	///
+	/// - Sibling parachains' assets from where they originate (as `ForeignCreators`).
+	pub type TrustedTeleportersDuring =
+		IsForeignConcreteAsset<FromSiblingParachain<AssetHubParaId>>;
 }
 
-/// Cases where a remote origin is accepted as trusted Teleporter for a given asset:
-///
-/// - DOT with the parent Relay Chain and sibling system parachains; and
-/// - Sibling parachains' assets from where they originate (as `ForeignCreators`).
-pub type TrustedTeleportersBeforeAfter = (
-	ConcreteAssetFromSystem<DotLocation>,
-	IsForeignConcreteAsset<FromSiblingParachain<AssetHubParaId>>,
-);
+pub mod before {
+	use super::common::{AmbassadorEntities, FellowshipEntities};
+	use super::*;
 
-/// During migration we only allow teleports of foreign assets (not DOT).
-///
-/// - Sibling parachains' assets from where they originate (as `ForeignCreators`).
-pub type TrustedTeleportersDuring = IsForeignConcreteAsset<FromSiblingParachain<AssetHubParaId>>;
+	parameter_types! {
+		pub RelayTreasuryLocation: Location =
+			(Parent, PalletInstance(polkadot_runtime_constants::TREASURY_PALLET_ID)).into();
+	}
+
+	pub struct ParentOrParentsPlurality;
+	impl Contains<Location> for ParentOrParentsPlurality {
+		fn contains(location: &Location) -> bool {
+			matches!(location.unpack(), (1, []) | (1, [Plurality { .. }]))
+		}
+	}
+
+	/// The locations listed below get free execution:
+	///
+	/// Parent, its pluralities (i.e. governance bodies), the Fellows plurality, AmbassadorEntities
+	/// and sibling parachains' root get free execution.
+	pub type UnpaidExecutionBeforeDuring = AllowExplicitUnpaidExecutionFrom<(
+		ParentOrParentsPlurality,
+		FellowshipEntities,
+		Equals<RelayTreasuryLocation>,
+		AmbassadorEntities,
+		ParentRelayOrSiblingParachains,
+	)>;
+}
+
+pub mod during {
+	use super::*;
+}
+
+pub mod after {
+	use super::common::{AmbassadorEntities, FellowshipEntities};
+	use super::*;
+
+	/// The locations listed below get free execution:
+	///
+	/// Parent, its pluralities (i.e. governance bodies), the Fellows plurality, AmbassadorEntities
+	/// and sibling parachains' root get free execution.
+	pub type UnpaidExecutionAfter = AllowExplicitUnpaidExecutionFrom<(
+		FellowshipEntities,
+		AmbassadorEntities,
+		ParentRelayOrSiblingParachains,
+	)>;
+}

--- a/pallets/ah-migrator/src/xcm_config.rs
+++ b/pallets/ah-migrator/src/xcm_config.rs
@@ -19,8 +19,10 @@
 use crate::PhantomData;
 use assets_common::matching::{FromSiblingParachain, IsForeignConcreteAsset, ParentLocation};
 use cumulus_primitives_core::ParaId;
-use frame_support::parameter_types;
-use frame_support::traits::{Contains, ContainsPair, Equals, ProcessMessageError, TypedGet};
+use frame_support::{
+	parameter_types,
+	traits::{Contains, ContainsPair, Equals, ProcessMessageError, TypedGet},
+};
 use pallet_rc_migrator::types::MigrationStatus;
 use parachains_common::xcm_config::ConcreteAssetFromSystem;
 use sp_runtime::{traits::Get, AccountId32};
@@ -118,8 +120,10 @@ pub mod common {
 }
 
 mod before {
-	use super::common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities};
-	use super::*;
+	use super::{
+		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities},
+		*,
+	};
 
 	parameter_types! {
 		pub RelayTreasuryLocation: Location =
@@ -158,16 +162,18 @@ mod before {
 }
 
 mod after {
-	use super::common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities};
-	use super::*;
+	use super::{
+		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities},
+		*,
+	};
 
 	/// For use in XCM Barriers: the locations listed below get free execution:
 	///
 	/// Parent, the Fellows plurality, AmbassadorEntities and sibling system parachains' root
 	/// get free execution.
 	pub type UnpaidExecutionAfter = AllowExplicitUnpaidExecutionFrom<(
-		// outside this pallet, when the `Runtime` type is available, the below can be replaced with
-		// `RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>`
+		// outside this pallet, when the `Runtime` type is available, the below can be replaced
+		// with `RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>`
 		Equals<ParentLocation>,
 		IsSiblingSystemParachain<ParaId, AssetHubParaId>,
 		FellowshipEntities,
@@ -178,8 +184,8 @@ mod after {
 	///
 	/// We only waive fees for system functions, which these locations represent.
 	pub type WaivedLocationsAfter = (
-		// outside this pallet, when the `Runtime` type is available, the below can be replaced with
-		// `RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>`
+		// outside this pallet, when the `Runtime` type is available, the below can be replaced
+		// with `RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>`
 		Equals<ParentLocation>,
 		IsSiblingSystemParachain<ParaId, AssetHubParaId>,
 		FellowshipEntities,

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -339,9 +339,9 @@ impl<AccountId, BlockNumber, BagsListScore, VotingClass, AssetKind, SchedulerBlo
 	pub fn is_ongoing(&self) -> bool {
 		!matches!(
 			self,
-			MigrationStage::Pending
-				| MigrationStage::Scheduled { .. }
-				| MigrationStage::MigrationDone
+			MigrationStage::Pending |
+				MigrationStage::Scheduled { .. } |
+				MigrationStage::MigrationDone
 		)
 	}
 }

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -63,7 +63,6 @@ pub use weights::*;
 use crate::{
 	accounts::MigratedBalances,
 	types::{MigrationFinishedData, XcmBatch, XcmBatchAndMeter},
-	xcm_config::TrustedTeleportersBeforeAndAfter,
 };
 use accounts::AccountsMigrator;
 #[cfg(not(feature = "ahm-westend"))]
@@ -76,8 +75,8 @@ use frame_support::{
 		fungible::{Inspect, InspectFreeze, Mutate, MutateFreeze, MutateHold},
 		schedule::DispatchTime,
 		tokens::{Fortitude, Pay, Precision, Preservation},
-		Contains, ContainsPair, Defensive, DefensiveTruncateFrom, LockableCurrency,
-		ReservableCurrency, VariantCount,
+		Contains, Defensive, DefensiveTruncateFrom, LockableCurrency, ReservableCurrency,
+		VariantCount,
 	},
 	weights::{Weight, WeightMeter},
 	PalletId,
@@ -340,9 +339,9 @@ impl<AccountId, BlockNumber, BagsListScore, VotingClass, AssetKind, SchedulerBlo
 	pub fn is_ongoing(&self) -> bool {
 		!matches!(
 			self,
-			MigrationStage::Pending |
-				MigrationStage::Scheduled { .. } |
-				MigrationStage::MigrationDone
+			MigrationStage::Pending
+				| MigrationStage::Scheduled { .. }
+				| MigrationStage::MigrationDone
 		)
 	}
 }
@@ -1695,26 +1694,5 @@ impl<T: Config> Contains<<T as frame_system::Config>::RuntimeCall> for Pallet<T>
 		// Otherwise, allow the call.
 		// This also implicitly allows _any_ call if the migration has not yet started.
 		ALLOWED
-	}
-}
-
-// To be used for `IsTeleport` filter. Disallows teleports during the migration.
-impl<T: Config> ContainsPair<Asset, Location> for Pallet<T> {
-	fn contains(asset: &Asset, origin: &Location) -> bool {
-		let stage = RcMigrationStage::<T>::get();
-		log::trace!(target: "xcm::IsTeleport::contains", "migration stage: {:?}", stage);
-		let result = if stage.is_ongoing() {
-			// during migration, no teleports (in or out) allowed
-			false
-		} else {
-			// before and after migration use normal filter
-			TrustedTeleportersBeforeAndAfter::contains(asset, origin)
-		};
-		log::trace!(
-			target: "xcm::IsTeleport::contains",
-			"asset: {:?} origin {:?} result {:?}",
-			asset, origin, result
-		);
-		result
 	}
 }

--- a/pallets/rc-migrator/src/xcm.md
+++ b/pallets/rc-migrator/src/xcm.md
@@ -1,4 +1,53 @@
-TODOs:
-- Consider a dedicated migration stage for updating the teleport/reserve location, adjusting total
+# XCM configuration changes for AHM
+
+## TODOs:
+-[ ] Consider a dedicated migration stage for updating the teleport/reserve location, adjusting total
 issuance and checking account balances. This approach prevents XCM teleport locking during the 
 entire migration and requires only a two-block lock for the switch.
+-[ ] Post migration we need to switch all system chains XCM transport fees beneficiary from
+`RelayTreasuryLocation` to the new `AssetHubTreasuryLocation`. Does not necessarily need to be done
+_synchronously during AHM_, so let's do it after the migration ends successfully. Besides the
+configuration change to use sovereign account of AH Treasury, we will also move the funds to the new
+account.
+
+## RC XCM changes
+
+1. DOT/KSM in/out teleports are disabled for RC for the duration of the migration. The reasoning for this
+is discussed in detail in [accounts.md](./accounts.md) document.
+2. Changed the list of `WaivedLocations` that do not have to pay XCM transport fees:
+   - removed `LocalPlurality` from the list,
+   - kept System Parachains and local Root (which continue to get free delivery).
+3. Did NOT change the destination/beneficiary of XCM delivery/transport fees. They will continue to go
+to the local Treasury account, even if the Treasury moves to Asset Hub. See 2nd TODO above for details.
+
+## User Impact (on RC)
+
+Users will not be able to teleport DOT/KSM cross-chain in or out of the Relay chain during the migration.
+Note this only affects RC<>SysChains, since with the other parachains we still keep reserve transfers alive.  
+Since their accounts are being migrated anyway at a random/non-deterministic point during the migration,
+this does not really make much of a difference to UX. Users will likely have to not use their DOT/KSM
+accounts/balances during migration.
+
+The rest of the XCM config changes do not affect users.
+
+## AH XCM changes
+
+1. DOT/KSM in/out teleports are disabled for AH for the duration of the migration. The reasoning for this
+   is discussed in detail in [accounts.md](./accounts.md) document.
+2. Changed the list of locations allowed to execute `UnpaidExecution` XCM instruction:
+    - removed `RelayTreasuryLocation` from the list,
+    - kept Sibling System Parachains, Relay Chain, Fellowship and Ambassador entities (which continue to
+      get free delivery).
+3. Changed the list of `WaivedLocations` that do not have to pay XCM transport fees:
+    - removed `RelayTreasuryLocation` and Relay chain `Plurality` locations from the list,
+    - kept Sibling System Parachains, Relay Chain, Fellowship and Ambassador entities (which continue to
+      get free delivery).
+4. Changed the destination/beneficiary of XCM delivery/transport fees. Instead of going to RC Treasury
+sovereign account, they will go to the local Treasury (new migrated treasury) account.
+
+## User Impact (on AH)
+
+Users will not be able to teleport DOT/KSM cross-chain in or out of Asset Hub during the migration.
+Note this only affects AH<>SysChains, since with the other parachains we still keep reserve transfers alive.
+
+The rest of the XCM config changes do not affect users.

--- a/pallets/rc-migrator/src/xcm_config.rs
+++ b/pallets/rc-migrator/src/xcm_config.rs
@@ -96,10 +96,10 @@ pub struct WaivedLocations<Stage>(PhantomData<Stage>);
 impl<Stage: MigrationStatus> Contains<Location> for WaivedLocations<Stage> {
 	fn contains(location: &Location) -> bool {
 		if Stage::is_finished() {
-			log::trace!(target: "xcm::WaivedLocations::contains", "migration finished");
+			log::trace!(target: "xcm::WaivedLocations::contains", "{location:?} (migration finished)");
 			after::WaivedLocationsAfter::contains(location)
 		} else {
-			log::trace!(target: "xcm::WaivedLocations::contains", "migration not finished");
+			log::trace!(target: "xcm::WaivedLocations::contains", "{location:?} (migration not finished)");
 			before::WaivedLocationsBeforeDuring::contains(location)
 		}
 	}

--- a/pallets/rc-migrator/src/xcm_config.rs
+++ b/pallets/rc-migrator/src/xcm_config.rs
@@ -17,10 +17,9 @@
 //! XCM configurations for the Relay Chain for the AHM migration.
 
 use crate::{types::MigrationStatus, PhantomData};
-use frame_support::traits::Contains;
 use frame_support::{
 	parameter_types,
-	traits::{ContainsPair, Equals},
+	traits::{Contains, ContainsPair, Equals},
 };
 use xcm::latest::prelude::*;
 use xcm_builder::Case;

--- a/relay/polkadot/src/xcm_config.rs
+++ b/relay/polkadot/src/xcm_config.rs
@@ -46,7 +46,7 @@ use xcm_builder::{
 	WeightInfoBounds, WithComputedOrigin, WithUniqueTopic, XcmFeeManagerFromComponents,
 };
 
-pub use pallet_rc_migrator::xcm_config::*;
+pub use pallet_rc_migrator::xcm_config::{AssetHubLocation, CollectivesLocation};
 
 parameter_types! {
 	pub const RootLocation: Location = Here.into_location();
@@ -195,7 +195,7 @@ impl xcm_executor::Config for XcmConfig {
 	type OriginConverter = LocalOriginConverter;
 	// Polkadot Relay recognises no chains which act as reserves.
 	type IsReserve = ();
-	type IsTeleporter = crate::RcMigrator;
+	type IsTeleporter = pallet_rc_migrator::xcm_config::TrustedTeleporters<crate::RcMigrator>;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = WeightInfoBounds<

--- a/relay/polkadot/src/xcm_config.rs
+++ b/relay/polkadot/src/xcm_config.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use frame_support::{
 	parameter_types,
-	traits::{Contains, Equals, Everything, Nothing},
+	traits::{Contains, Everything, Nothing},
 };
 use frame_system::EnsureRoot;
 use pallet_xcm::XcmPassthrough;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs
@@ -33,7 +33,7 @@ impl Get<(AccountId, Vec<Location>)> for TreasuryAccounts {
 	fn get() -> (AccountId, Vec<Location>) {
 		let assets_id = <crate::Assets as PalletInfoAccess>::index() as u8;
 		(
-			xcm_config::RelayTreasuryPalletAccount::get(),
+			xcm_config::PreMigrationRelayTreasuryPalletAccount::get(),
 			vec![
 				// USDT
 				Location::new(0, [PalletInstance(assets_id), GeneralIndex(1984)]),

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1035,7 +1035,7 @@ impl pallet_asset_conversion::Config for Runtime {
 	type PoolAssets = PoolAssets;
 	type PoolSetupFee = PoolSetupFee;
 	type PoolSetupFeeAsset = DotLocation;
-	type PoolSetupFeeTarget = ResolveAssetTo<xcm_config::RelayTreasuryPalletAccount, Self::Assets>;
+	type PoolSetupFeeTarget = ResolveAssetTo<xcm_config::TreasuryAccount, Self::Assets>;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;
 	type LPFee = ConstU32<3>;
 	type PalletId = AssetConversionPalletId;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
@@ -380,7 +380,7 @@ impl xcm_executor::Config for XcmConfig {
 	type AssetExchanger = PoolAssetsExchanger;
 	type FeeManager = XcmFeeManagerFromComponents<
 		pallet_ah_migrator::xcm_config::WaivedLocations<crate::AhMigrator>,
-		// TODO: post-ahm-migration move the Treasury funds from this sov account to a local account.
+		// TODO: post-ahm move the Treasury funds from this sov account to a local account.
 		SendXcmFeeToAccount<Self::AssetTransactor, RelayTreasuryPalletAccount>,
 	>;
 	type MessageExporter = ();

--- a/system-parachains/asset-hubs/asset-hub-polkadot/tests/tests.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/tests/tests.rs
@@ -1042,9 +1042,9 @@ pub mod remove_when_updated_to_stable2409 {
 						);
 					let asset_to_teleport_away = asset_minimum_asset_balance * 3;
 					assert!(
-						asset_to_teleport_away
-							< (target_account_balance_before_teleport
-								- asset_minimum_asset_balance.into())
+						asset_to_teleport_away <
+							(target_account_balance_before_teleport -
+								asset_minimum_asset_balance.into())
 							.into()
 					);
 
@@ -1147,9 +1147,8 @@ pub mod remove_when_updated_to_stable2409 {
 			})
 			.expect("expected instruction BuyExecution")
 			.match_next_inst(|instr| match instr {
-				DepositAsset { assets: _, beneficiary } if beneficiary == expected_beneficiary => {
-					Ok(())
-				},
+				DepositAsset { assets: _, beneficiary } if beneficiary == expected_beneficiary =>
+					Ok(()),
 				_ => Err(ProcessMessageError::BadFormat),
 			})
 			.expect("expected instruction DepositAsset");

--- a/system-parachains/asset-hubs/asset-hub-polkadot/tests/tests.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/tests/tests.rs
@@ -21,8 +21,8 @@ use asset_hub_polkadot_runtime::{
 	xcm_config::{
 		bridging::{self, XcmBridgeHubRouterFeeAssetId},
 		CheckingAccount, DotLocation, ForeignCreatorsSovereignAccountOf, LocationToAccountId,
-		RelayTreasuryLocation, RelayTreasuryPalletAccount, StakingPot,
-		TrustBackedAssetsPalletLocation, XcmConfig,
+		PreMigrationRelayTreasuryPalletAccount as RelayTreasuryPalletAccount,
+		RelayTreasuryLocation, StakingPot, TrustBackedAssetsPalletLocation, XcmConfig,
 	},
 	AllPalletsWithoutSystem, AssetConversion, AssetDeposit, Assets, Balances, Block,
 	ExistentialDeposit, ForeignAssets, ForeignAssetsInstance, MetadataDepositBase,
@@ -1042,9 +1042,9 @@ pub mod remove_when_updated_to_stable2409 {
 						);
 					let asset_to_teleport_away = asset_minimum_asset_balance * 3;
 					assert!(
-						asset_to_teleport_away <
-							(target_account_balance_before_teleport -
-								asset_minimum_asset_balance.into())
+						asset_to_teleport_away
+							< (target_account_balance_before_teleport
+								- asset_minimum_asset_balance.into())
 							.into()
 					);
 
@@ -1147,8 +1147,9 @@ pub mod remove_when_updated_to_stable2409 {
 			})
 			.expect("expected instruction BuyExecution")
 			.match_next_inst(|instr| match instr {
-				DepositAsset { assets: _, beneficiary } if beneficiary == expected_beneficiary =>
-					Ok(()),
+				DepositAsset { assets: _, beneficiary } if beneficiary == expected_beneficiary => {
+					Ok(())
+				},
 				_ => Err(ProcessMessageError::BadFormat),
 			})
 			.expect("expected instruction DepositAsset");


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-sdk/issues/7626

## RC XCM changes

1. DOT/KSM in/out teleports are disabled for RC for the duration of the migration. The reasoning for this
is discussed in detail in [accounts.md](./accounts.md) document.
2. Changed the list of `WaivedLocations` that do not have to pay XCM transport fees:
   - removed `LocalPlurality` from the list,
   - kept System Parachains and local Root (which continue to get free delivery).
3. Did NOT change the destination/beneficiary of XCM delivery/transport fees. They will continue to go
to the local Treasury account, even if the Treasury moves to Asset Hub.

## AH XCM changes

1. DOT/KSM in/out teleports are disabled for AH for the duration of the migration. The reasoning for this
   is discussed in detail in [accounts.md](./accounts.md) document.
2. Changed the list of locations allowed to execute `UnpaidExecution` XCM instruction:
    - removed `RelayTreasuryLocation` from the list,
    - kept Sibling System Parachains, Relay Chain, Fellowship and Ambassador entities (which continue to
      get free delivery).
3. Changed the list of `WaivedLocations` that do not have to pay XCM transport fees:
    - removed `RelayTreasuryLocation` and Relay chain `Plurality` locations from the list,
    - kept Sibling System Parachains, Relay Chain, Fellowship and Ambassador entities (which continue to
      get free delivery).
4. Changed the destination/beneficiary of XCM delivery/transport fees. Instead of going to RC Treasury
sovereign account, they will go to the local Treasury (new migrated treasury) account.

- [x] Does not require a CHANGELOG entry
