### PR TITLE
[AHM] Keep ED and consumer ref for accounts with keys in session pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8887,6 +8887,7 @@ dependencies = [
  "pallet-proxy",
  "pallet-referenda",
  "pallet-scheduler",
+ "pallet-session",
  "pallet-staking",
  "pallet-treasury",
  "pallet-vesting",

--- a/pallets/rc-migrator/Cargo.toml
+++ b/pallets/rc-migrator/Cargo.toml
@@ -27,6 +27,7 @@ pallet-bounties = { workspace = true }
 pallet-conviction-voting = { workspace = true }
 pallet-scheduler = { workspace = true }
 pallet-staking = { workspace = true }
+pallet-session = { workspace = true }
 # pallet-staking-async = { workspace = true } # Only on westend
 # pallet-staking-async-ah-client = { workspace = true } # Only on westend
 pallet-proxy = { workspace = true }
@@ -71,6 +72,7 @@ std = [
 	"pallet-proxy/std",
 	"pallet-referenda/std",
 	"pallet-scheduler/std",
+	"pallet-session/std",
 	"pallet-staking/std",
 	"pallet-treasury/std",
 	"pallet-vesting/std",
@@ -139,6 +141,7 @@ try-runtime = [
 	"pallet-proxy/try-runtime",
 	"pallet-referenda/try-runtime",
 	"pallet-scheduler/try-runtime",
+	"pallet-session/try-runtime",
 	"pallet-staking/try-runtime",
 	"pallet-treasury/try-runtime",
 	"pallet-vesting/try-runtime",

--- a/pallets/rc-migrator/src/accounts.md
+++ b/pallets/rc-migrator/src/accounts.md
@@ -101,13 +101,11 @@ accounts, and a decrease without a prior increase will not cause any issues.
 See test: `polkadot_integration_tests_ahm::tests::test_account_references`
 Source: https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/substrate/frame/recovery/src/lib.rs#L610
 
-- session (P/K/W): Validator accounts may be removed from RC during migration (unless they maintain
-HRMP channels or register a parachain). Validators who later wish to interact with the session
-pallet (e.g., set/remove keys) will need to teleport funds to RC and reinitialize their account. The
-only possible inconsistency is if a validator removes already existing keys, causing the consumer
-count to decrement from 0 (if no holds/freezes) or from 1 otherwise. Case 1: From 0 — no issue.
-Case 2: From 1 — results in a temporarily incorrect consumer count, which will self-correct on any
-account update.
+- session (P/K/W): Validator accounts that set keys in the session pallet receive an additional
+consumer reference to prevent the existential deposit (ED) from being withdrawn, preserving it as a
+deposit. During migration, these EDs with the consumer reference will remain on the Relay Chain if
+the validator account has sufficient balance. If a validator account has insufficient balance, which
+would indicate a data inconsistency, we will proceed with migrating those accounts anyway.
 See test: `polkadot_integration_tests_ahm::tests::test_account_references`
 Source: https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/substrate/frame/session/src/lib.rs#L812
 

--- a/pallets/rc-migrator/src/accounts.rs
+++ b/pallets/rc-migrator/src/accounts.rs
@@ -177,7 +177,6 @@ impl<Balance: BalanceT> AccountState<Balance> {
 		}
 	}
 	/// Get the reserved balance on RC.
-
 	pub fn get_rc_reserved(&self) -> Balance {
 		match self {
 			AccountState::Part { reserved, .. } => *reserved,

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -416,6 +416,7 @@ pub mod pallet {
 		+ pallet_asset_rate::Config
 		+ pallet_slots::Config
 		+ pallet_crowdloan::Config
+		+ pallet_session::Config<ValidatorId = AccountId32>
 		+ pallet_staking::Config // Not on westend
 		+ pallet_claims::Config // Not on westend
 		+ pallet_bounties::Config // Not on westend


### PR DESCRIPTION
Keep ED and consumer reference for accounts with keys in session pallet.

Read .md file for more info.