### PR TITLE
[AHM] Staking migration storage item checks

### DIFF
--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -57,7 +57,7 @@ rand = { workspace = true, default-feature = true }
 # testnet-parachains-constants = { workspace = true } # Only on westend
 
 [features]
-default = ["ahm-polkadot", "std", "ahm-staking-migration"]
+default = ["ahm-polkadot", "std"]
 std = [
 	"cumulus-pallet-parachain-system/std",
 	"frame-benchmarking/std",

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -54,7 +54,7 @@ pallet-xcm = { workspace = true, default-features = true }
 frame-benchmarking = { workspace = true }
 
 [features]
-default = ["ahm-polkadot", "std"]
+default = ["ahm-polkadot", "std", "ahm-staking-migration"]
 std = [
 	"cumulus-pallet-parachain-system/std",
 	"frame-benchmarking/std",

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -108,9 +108,7 @@ pub type RcPolkadotChecks = ();
 
 // Checks that are specific to Staking on relay chain
 #[cfg(feature = "ahm-staking-migration")]
-pub type RcStakingChecks = (
-	pallet_rc_migrator::staking::staking::StakingMigrator<Polkadot>,
-);
+pub type RcStakingChecks = (pallet_rc_migrator::staking::staking::StakingMigrator<Polkadot>,);
 
 #[cfg(not(feature = "ahm-staking-migration"))]
 pub type RcStakingChecks = ();
@@ -155,9 +153,7 @@ pub type AhPolkadotChecks = ();
 
 // Checks that are specific to Staking on AssetHub
 #[cfg(feature = "ahm-staking-migration")]
-pub type AhStakingChecks = (
-	pallet_rc_migrator::staking::staking::StakingMigrator<AssetHub>,
-);
+pub type AhStakingChecks = (pallet_rc_migrator::staking::staking::StakingMigrator<AssetHub>,);
 
 #[cfg(not(feature = "ahm-staking-migration"))]
 pub type AhStakingChecks = ();

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -76,7 +76,8 @@ type RcChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<Polkadot>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<Polkadot>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<Polkadot>,
-	pallet_rc_migrator::staking::StakingMigrator<Polkadot>,
+	#[cfg(feature = "ahm-staking-migration")]
+	pallet_rc_migrator::staking::staking::StakingMigrator<Polkadot>,
 	RcPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,
@@ -108,7 +109,8 @@ type AhChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<AssetHub>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<AssetHub>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<AssetHub>,
-	// pallet_rc_migrator::staking::StakingMigrator<AssetHub>,
+	#[cfg(feature = "ahm-staking-migration")]
+	pallet_rc_migrator::staking::StakingMigrator<AssetHub>,
 	AhPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -76,8 +76,7 @@ type RcChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<Polkadot>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<Polkadot>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<Polkadot>,
-	#[cfg(feature = "ahm-staking-migration")]
-	pallet_rc_migrator::staking::staking::StakingMigrator<Polkadot>,
+	RcStakingChecks,
 	RcPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,
@@ -96,6 +95,15 @@ pub type RcPolkadotChecks = (
 #[cfg(not(feature = "ahm-polkadot"))]
 pub type RcPolkadotChecks = ();
 
+// Checks that are specific to Staking on relay chain
+#[cfg(feature = "ahm-staking-migration")]
+pub type RcStakingChecks = (
+	pallet_rc_migrator::staking::staking::StakingMigrator<Polkadot>,
+);
+
+#[cfg(not(feature = "ahm-staking-migration"))]
+pub type RcStakingChecks = ();
+
 type AhChecks = (
 	SanityChecks,
 	pallet_rc_migrator::accounts::AccountsMigrator<AssetHub>,
@@ -109,8 +117,7 @@ type AhChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<AssetHub>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<AssetHub>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<AssetHub>,
-	#[cfg(feature = "ahm-staking-migration")]
-	pallet_rc_migrator::staking::StakingMigrator<AssetHub>,
+	AhStakingChecks,
 	AhPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,
@@ -129,6 +136,15 @@ pub type AhPolkadotChecks = (
 
 #[cfg(not(feature = "ahm-polkadot"))]
 pub type AhPolkadotChecks = ();
+
+// Checks that are specific to Staking on AssetHub
+#[cfg(feature = "ahm-staking-migration")]
+pub type AhStakingChecks = (
+	pallet_rc_migrator::staking::staking::StakingMigrator<AssetHub>,
+);
+
+#[cfg(not(feature = "ahm-staking-migration"))]
+pub type AhStakingChecks = ();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pallet_migration_works() {

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -76,6 +76,7 @@ type RcChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<Polkadot>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<Polkadot>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<Polkadot>,
+	pallet_rc_migrator::staking::StakingMigrator<Polkadot>,
 	RcPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,
@@ -107,6 +108,7 @@ type AhChecks = (
 	pallet_rc_migrator::staking::fast_unstake::FastUnstakeMigrator<AssetHub>,
 	pallet_rc_migrator::conviction_voting::ConvictionVotingMigrator<AssetHub>,
 	pallet_rc_migrator::asset_rate::AssetRateMigrator<AssetHub>,
+	// pallet_rc_migrator::staking::StakingMigrator<AssetHub>,
 	AhPolkadotChecks,
 	// other checks go here (if available on Polkadot, Kusama and Westend)
 	ProxiesStillWork,

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -34,7 +34,7 @@ pallet-message-queue = { workspace = true }
 pallet-rc-migrator = { workspace = true }
 pallet-referenda = { workspace = true }
 pallet-scheduler = { workspace = true }
-pallet-staking = { workspace = true }
+pallet-staking = { workspace = true}
 pallet-state-trie-migration = { workspace = true }
 pallet-vesting = { workspace = true }
 pallet-treasury = { workspace = true }
@@ -50,7 +50,7 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
-sp-staking = { workspace = true }
+sp-staking = { workspace = true, optional = true }
 hex-literal = { workspace = true }
 hex = { workspace = true }
 xcm = { workspace = true }
@@ -198,4 +198,5 @@ stable2503 = [
 ]
 ahm-staking-migration = [
 	"pallet-rc-migrator/ahm-staking-migration",
+	"dep:sp-staking"
 ]

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -34,7 +34,7 @@ pallet-message-queue = { workspace = true }
 pallet-rc-migrator = { workspace = true }
 pallet-referenda = { workspace = true }
 pallet-scheduler = { workspace = true }
-pallet-staking = { workspace = true}
+pallet-staking = { workspace = true }
 pallet-state-trie-migration = { workspace = true }
 pallet-vesting = { workspace = true }
 pallet-treasury = { workspace = true }

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -50,6 +50,7 @@ sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
+sp-staking = { workspace = true }
 hex-literal = { workspace = true }
 hex = { workspace = true }
 xcm = { workspace = true }

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -465,7 +465,6 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
                 NominatorSlashInEra { era, validator, slash } => { expected_nominator_slash_in_era.insert((era, validator.clone()), slash); },
                 SlashingSpans { account, spans } => { expected_slashing_spans.insert(account, spans); },
                 SpanSlash { account, span, slash } => { expected_span_slash.insert((account, span), slash); },
-                _ => todo!(), // Spanslash removed from master branch, remove for now
             }
         }
 

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -161,222 +161,222 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
 	type AhPrePayload = ();
 
 	fn pre_check(_rc_pre_payload: Self::RcPrePayload) -> Self::AhPrePayload {
-        // "Assert storage 'StakingAsync::ValidatorCount::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ValidatorCount::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::ValidatorCount::<T>::get(),
             0,
-            "StakingAsync::ValidatorCount should be 0 on AH before migration"
+            "pallet_staking_async::ValidatorCount should be 0 on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::MinNominatorBond::ah_pre::empty'"
+        // Assert storage 'StakingAsync::MinNominatorBond::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::MinNominatorBond::<T>::get(),
             Default::default(),
-            "StakingAsync::MinNominatorBond should be default on AH before migration"
+            "pallet_staking_async::MinNominatorBond should be default on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::MinValidatorBond::ah_pre::empty'"
+        // Assert storage 'StakingAsync::MinValidatorBond::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::MinValidatorBond::<T>::get(),
             Default::default(),
-            "StakingAsync::MinValidatorBond should be default on AH before migration"
+            "pallet_staking_async::MinValidatorBond should be default on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::MinimumActiveStake::ah_pre::empty'"
+        // Assert storage 'StakingAsync::MinimumActiveStake::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::MinimumActiveStake::<T>::get(),
             Default::default(),
-            "StakingAsync::MinimumActiveStake should be default on AH before migration"
+            "pallet_staking_async::MinimumActiveStake should be default on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::MinCommission::ah_pre::empty'"
+        // Assert storage 'StakingAsync::MinCommission::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::MinCommission::<T>::get(),
             Default::default(),
-            "StakingAsync::MinCommission should be default on AH before migration"
+            "pallet_staking_async::MinCommission should be default on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::MaxValidatorsCount::ah_pre::empty'"
+        // Assert storage 'StakingAsync::MaxValidatorsCount::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::MaxValidatorsCount::<T>::get(),
             None,
-            "StakingAsync::MaxValidatorsCount should be None on AH before migration"
+            "pallet_staking_async::MaxValidatorsCount should be None on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::MaxNominatorsCount::ah_pre::empty'"
+        // Assert storage 'StakingAsync::MaxNominatorsCount::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::MaxNominatorsCount::<T>::get(),
             None,
-            "StakingAsync::MaxNominatorsCount should be None on AH before migration"
+            "pallet_staking_async::MaxNominatorsCount should be None on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::CurrentEra::ah_pre::empty'"
+        // Assert storage 'StakingAsync::CurrentEra::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::CurrentEra::<T>::get(),
             None,
-            "StakingAsync::CurrentEra should be None on AH before migration"
+            "pallet_staking_async::CurrentEra should be None on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ActiveEra::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ActiveEra::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::ActiveEra::<T>::get(),
             None,
-            "StakingAsync::ActiveEra should be None on AH before migration"
+            "pallet_staking_async::ActiveEra should be None on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ForceEra::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ForceEra::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::ForceEra::<T>::get(),
             Default::default(), // Assumes Forcing::NotForcing or similar is default
-            "StakingAsync::ForceEra should be default on AH before migration"
+            "pallet_staking_async::ForceEra should be default on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::MaxStakedRewards::ah_pre::empty'"
+        // Assert storage 'StakingAsync::MaxStakedRewards::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::MaxStakedRewards::<T>::get(),
             None,
-            "StakingAsync::MaxStakedRewards should be None on AH before migration"
+            "pallet_staking_async::MaxStakedRewards should be None on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::SlashRewardFraction::ah_pre::empty'"
+        // Assert storage 'StakingAsync::SlashRewardFraction::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::SlashRewardFraction::<T>::get(),
             Default::default(),
-            "StakingAsync::SlashRewardFraction should be default on AH before migration"
+            "pallet_staking_async::SlashRewardFraction should be default on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::CanceledSlashPayout::ah_pre::empty'"
+        // Assert storage 'StakingAsync::CanceledSlashPayout::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::CanceledSlashPayout::<T>::get(),
             Default::default(),
-            "StakingAsync::CanceledSlashPayout should be default on AH before migration"
+            "pallet_staking_async::CanceledSlashPayout should be default on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ChillThreshold::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ChillThreshold::ah_pre::empty'
         assert_eq!(
             pallet_staking_async::ChillThreshold::<T>::get(),
             None,
-            "StakingAsync::ChillThreshold should be None on AH before migration"
+            "pallet_staking_async::ChillThreshold should be None on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::Invulnerables::ah_pre::empty'"
+        // Assert storage 'StakingAsync::Invulnerables::ah_pre::empty'
         assert!(
             pallet_staking_async::Invulnerables::<T>::get().is_empty(),
-            "StakingAsync::Invulnerables should be empty on AH before migration"
+            "pallet_staking_async::Invulnerables should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::BondedEras::ah_pre::empty'"
+        // Assert storage 'StakingAsync::BondedEras::ah_pre::empty'
         assert!(
             pallet_staking_async::BondedEras::<T>::get().is_empty(),
-            "StakingAsync::BondedEras should be empty on AH before migration"
+            "pallet_staking_async::BondedEras should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::Bonded::ah_pre::empty'"
+        // Assert storage 'StakingAsync::Bonded::ah_pre::empty'
         assert!(
             pallet_staking_async::Bonded::<T>::iter().next().is_none(),
-            "StakingAsync::Bonded map should be empty on AH before migration"
+            "pallet_staking_async::Bonded map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::Ledger::ah_pre::empty'"
+        // Assert storage 'StakingAsync::Ledger::ah_pre::empty'
         assert!(
             pallet_staking_async::Ledger::<T>::iter().next().is_none(),
-            "StakingAsync::Ledger map should be empty on AH before migration"
+            "pallet_staking_async::Ledger map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::Payee::ah_pre::empty'"
+        // Assert storage 'StakingAsync::Payee::ah_pre::empty'
         assert!(
             pallet_staking_async::Payee::<T>::iter().next().is_none(),
-            "StakingAsync::Payee map should be empty on AH before migration"
+            "pallet_staking_async::Payee map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::Validators::ah_pre::empty'"
+        // Assert storage 'StakingAsync::Validators::ah_pre::empty'
         assert!(
             pallet_staking_async::Validators::<T>::iter().next().is_none(),
-            "StakingAsync::Validators map should be empty on AH before migration"
+            "pallet_staking_async::Validators map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::Nominators::ah_pre::empty'"
+        // Assert storage 'StakingAsync::Nominators::ah_pre::empty'
         assert!(
             pallet_staking_async::Nominators::<T>::iter().next().is_none(),
-            "StakingAsync::Nominators map should be empty on AH before migration"
+            "pallet_staking_async::Nominators map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::VirtualStakers::ah_pre::empty'"
+        // Assert storage 'StakingAsync::VirtualStakers::ah_pre::empty'
         assert!(
             pallet_staking_async::VirtualStakers::<T>::iter().next().is_none(),
-            "StakingAsync::VirtualStakers map should be empty on AH before migration"
+            "pallet_staking_async::VirtualStakers map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ErasStakersOverview::ah_pre::empty'
         assert!(
             pallet_staking_async::ErasStakersOverview::<T>::iter().next().is_none(),
-            "StakingAsync::ErasStakersOverview map should be empty on AH before migration"
+            "pallet_staking_async::ErasStakersOverview map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ErasStakersPaged::ah_pre::empty'
         assert!(
             pallet_staking_async::ErasStakersPaged::<T>::iter().next().is_none(),
-            "StakingAsync::ErasStakersPaged map should be empty on AH before migration"
+            "pallet_staking_async::ErasStakersPaged map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ErasClaimedRewards::ah_pre::empty'
         assert!(
             pallet_staking_async::ErasClaimedRewards::<T>::iter().next().is_none(),
-            "StakingAsync::ErasClaimedRewards map should be empty on AH before migration"
+            "pallet_staking_async::ErasClaimedRewards map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ErasValidatorPrefs::ah_pre::empty'
         assert!(
             pallet_staking_async::ErasValidatorPrefs::<T>::iter().next().is_none(),
-            "StakingAsync::ErasValidatorPrefs map should be empty on AH before migration"
+            "pallet_staking_async::ErasValidatorPrefs map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ErasValidatorReward::ah_pre::empty'
         assert!(
             pallet_staking_async::ErasValidatorReward::<T>::iter().next().is_none(),
-            "StakingAsync::ErasValidatorReward map should be empty on AH before migration"
+            "pallet_staking_async::ErasValidatorReward map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ErasRewardPoints::ah_pre::empty'
         assert!(
             pallet_staking_async::ErasRewardPoints::<T>::iter().next().is_none(),
-            "StakingAsync::ErasRewardPoints map should be empty on AH before migration"
+            "pallet_staking_async::ErasRewardPoints map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasTotalStake::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ErasTotalStake::ah_pre::empty'
         assert!(
             pallet_staking_async::ErasTotalStake::<T>::iter().next().is_none(),
-            "StakingAsync::ErasTotalStake map should be empty on AH before migration"
+            "pallet_staking_async::ErasTotalStake map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::UnappliedSlashes::ah_pre::empty'"
+        // Assert storage 'StakingAsync::UnappliedSlashes::ah_pre::empty'
         assert!(
             pallet_staking_async::UnappliedSlashes::<T>::iter().next().is_none(),
-            "StakingAsync::UnappliedSlashes map should be empty on AH before migration"
+            "pallet_staking_async::UnappliedSlashes map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_pre::empty'"
+        // Assert storage 'StakingAsync::ValidatorSlashInEra::ah_pre::empty'
         assert!(
             pallet_staking_async::ValidatorSlashInEra::<T>::iter().next().is_none(),
-            "StakingAsync::ValidatorSlashInEra map should be empty on AH before migration"
+            "pallet_staking_async::ValidatorSlashInEra map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_pre::empty'"
+        // Assert storage 'StakingAsync::NominatorSlashInEra::ah_pre::empty'
         assert!(
             pallet_staking_async::NominatorSlashInEra::<T>::iter().next().is_none(),
-            "StakingAsync::NominatorSlashInEra map should be empty on AH before migration"
+            "pallet_staking_async::NominatorSlashInEra map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::SlashingSpans::ah_pre::empty'"
+        // Assert storage 'StakingAsync::SlashingSpans::ah_pre::empty'
         assert!(
             pallet_staking_async::SlashingSpans::<T>::iter().next().is_none(),
-            "StakingAsync::SlashingSpans map should be empty on AH before migration"
+            "pallet_staking_async::SlashingSpans map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::SpanSlash::ah_pre::empty'"
+        // Assert storage 'StakingAsync::SpanSlash::ah_pre::empty'
         assert!(
             pallet_staking_async::SpanSlash::<T>::iter().next().is_none(),
-            "StakingAsync::SpanSlash map should be empty on AH before migration"
+            "pallet_staking_async::SpanSlash map should be empty on AH before migration"
         );
     }
 
@@ -468,139 +468,139 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         if let Some(values) = expected_values_opt {
             let expected_force_era = expected_force_era_opt.expect("Bundled with values");
 
-            // "Assert storage 'StakingAsync::ValidatorCount::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::ValidatorCount::<T>::get(), values.validator_count, "StakingAsync::ValidatorCount mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinNominatorBond::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::MinNominatorBond::<T>::get(), values.min_nominator_bond, "StakingAsync::MinNominatorBond mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinValidatorBond::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::MinValidatorBond::<T>::get(), values.min_validator_bond, "StakingAsync::MinValidatorBond mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinimumActiveStake::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::MinimumActiveStake::<T>::get(), values.min_active_stake, "StakingAsync::MinimumActiveStake mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinCommission::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::MinCommission::<T>::get(), values.min_commission, "StakingAsync::MinCommission mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MaxValidatorsCount::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::MaxValidatorsCount::<T>::get(), values.max_validators_count, "StakingAsync::MaxValidatorsCount mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MaxNominatorsCount::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::MaxNominatorsCount::<T>::get(), values.max_nominators_count, "StakingAsync::MaxNominatorsCount mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::CurrentEra::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::CurrentEra::<T>::get(), expected_active_era_opt.clone().map(|a| a.index), "StakingAsync::CurrentEra mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::ActiveEra::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::ActiveEra::<T>::get(), expected_active_era_opt, "StakingAsync::ActiveEra mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::ForceEra::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::ForceEra::<T>::get(), expected_force_era, "StakingAsync::ForceEra mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MaxStakedRewards::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::MaxStakedRewards::<T>::get(), values.max_staked_rewards, "StakingAsync::MaxStakedRewards mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::SlashRewardFraction::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::SlashRewardFraction::<T>::get(), values.slash_reward_fraction, "StakingAsync::SlashRewardFraction mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::CanceledSlashPayout::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::CanceledSlashPayout::<T>::get(), values.canceled_slash_payout, "StakingAsync::CanceledSlashPayout mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::ChillThreshold::ah_post::consistent'"
-            assert_eq!(pallet_staking_async::ChillThreshold::<T>::get(), values.chill_threshold, "StakingAsync::ChillThreshold mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::ValidatorCount::ah_post::consistent'
+            assert_eq!(pallet_staking_async::ValidatorCount::<T>::get(), values.validator_count, "pallet_staking_async::ValidatorCount mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::MinNominatorBond::ah_post::consistent'
+            assert_eq!(pallet_staking_async::MinNominatorBond::<T>::get(), values.min_nominator_bond, "pallet_staking_async::MinNominatorBond mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::MinValidatorBond::ah_post::consistent'
+            assert_eq!(pallet_staking_async::MinValidatorBond::<T>::get(), values.min_validator_bond, "pallet_staking_async::MinValidatorBond mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::MinimumActiveStake::ah_post::consistent'
+            assert_eq!(pallet_staking_async::MinimumActiveStake::<T>::get(), values.min_active_stake, "pallet_staking_async::MinimumActiveStake mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::MinCommission::ah_post::consistent'
+            assert_eq!(pallet_staking_async::MinCommission::<T>::get(), values.min_commission, "pallet_staking_async::MinCommission mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::MaxValidatorsCount::ah_post::consistent'
+            assert_eq!(pallet_staking_async::MaxValidatorsCount::<T>::get(), values.max_validators_count, "pallet_staking_async::MaxValidatorsCount mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::MaxNominatorsCount::ah_post::consistent'
+            assert_eq!(pallet_staking_async::MaxNominatorsCount::<T>::get(), values.max_nominators_count, "pallet_staking_async::MaxNominatorsCount mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::CurrentEra::ah_post::consistent'
+            assert_eq!(pallet_staking_async::CurrentEra::<T>::get(), expected_active_era_opt.clone().map(|a| a.index), "pallet_staking_async::CurrentEra mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::ActiveEra::ah_post::consistent'
+            assert_eq!(pallet_staking_async::ActiveEra::<T>::get(), expected_active_era_opt, "pallet_staking_async::ActiveEra mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::ForceEra::ah_post::consistent'
+            assert_eq!(pallet_staking_async::ForceEra::<T>::get(), expected_force_era, "pallet_staking_async::ForceEra mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::MaxStakedRewards::ah_post::consistent'
+            assert_eq!(pallet_staking_async::MaxStakedRewards::<T>::get(), values.max_staked_rewards, "pallet_staking_async::MaxStakedRewards mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::SlashRewardFraction::ah_post::consistent'
+            assert_eq!(pallet_staking_async::SlashRewardFraction::<T>::get(), values.slash_reward_fraction, "pallet_staking_async::SlashRewardFraction mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::CanceledSlashPayout::ah_post::consistent'
+            assert_eq!(pallet_staking_async::CanceledSlashPayout::<T>::get(), values.canceled_slash_payout, "pallet_staking_async::CanceledSlashPayout mismatch on AH post-migration");
+            // Assert storage 'StakingAsync::ChillThreshold::ah_post::consistent'
+            assert_eq!(pallet_staking_async::ChillThreshold::<T>::get(), values.chill_threshold, "pallet_staking_async::ChillThreshold mismatch on AH post-migration");
         }
 
-        // "Assert storage 'StakingAsync::Invulnerables::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::Invulnerables::<T>::get().into_inner(), expected_invulnerables, "StakingAsync::Invulnerables mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Invulnerables::ah_post::consistent'
+        assert_eq!(pallet_staking_async::Invulnerables::<T>::get().into_inner(), expected_invulnerables, "pallet_staking_async::Invulnerables mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::BondedEras::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::BondedEras::<T>::get().into_inner(), expected_bonded_eras, "StakingAsync::BondedEras mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::BondedEras::ah_post::consistent'
+        assert_eq!(pallet_staking_async::BondedEras::<T>::get().into_inner(), expected_bonded_eras, "pallet_staking_async::BondedEras mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::Bonded::ah_post::length'"
-        assert_eq!(pallet_staking_async::Bonded::<T>::iter_keys().count(), expected_bonded.len(), "StakingAsync::Bonded map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Bonded::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_,_>>(), expected_bonded, "StakingAsync::Bonded map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Bonded::ah_post::length'
+        assert_eq!(pallet_staking_async::Bonded::<T>::iter_keys().count(), expected_bonded.len(), "pallet_staking_async::Bonded map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Bonded::ah_post::consistent'
+        assert_eq!(pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_,_>>(), expected_bonded, "pallet_staking_async::Bonded map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::Ledger::ah_post::length'"
-        assert_eq!(pallet_staking_async::Ledger::<T>::iter_keys().count(), expected_ledger.len(), "StakingAsync::Ledger map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Ledger::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_,_>>(), expected_ledger, "StakingAsync::Ledger map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Ledger::ah_post::length'
+        assert_eq!(pallet_staking_async::Ledger::<T>::iter_keys().count(), expected_ledger.len(), "pallet_staking_async::Ledger map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Ledger::ah_post::consistent'
+        assert_eq!(pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_,_>>(), expected_ledger, "pallet_staking_async::Ledger map content mismatch on AH post-migration");
         
-        // "Assert storage 'StakingAsync::Payee::ah_post::length'"
-        assert_eq!(pallet_staking_async::Payee::<T>::iter_keys().count(), expected_payee.len(), "StakingAsync::Payee map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Payee::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "StakingAsync::Payee map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Payee::ah_post::length'
+        assert_eq!(pallet_staking_async::Payee::<T>::iter_keys().count(), expected_payee.len(), "pallet_staking_async::Payee map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Payee::ah_post::consistent'
+        assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "pallet_staking_async::Payee map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::Validators::ah_post::length'"
-        assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "StakingAsync::Validators map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Validators::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validators, "StakingAsync::Validators map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Validators::ah_post::length'
+        assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "pallet_staking_async::Validators map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Validators::ah_post::consistent'
+        assert_eq!(pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validators, "pallet_staking_async::Validators map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::Nominators::ah_post::length'"
-        assert_eq!(pallet_staking_async::Nominators::<T>::iter_keys().count(), expected_nominators.len(), "StakingAsync::Nominators map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Nominators::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominators, "StakingAsync::Nominators map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Nominators::ah_post::length'
+        assert_eq!(pallet_staking_async::Nominators::<T>::iter_keys().count(), expected_nominators.len(), "pallet_staking_async::Nominators map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::Nominators::ah_post::consistent'
+        assert_eq!(pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominators, "pallet_staking_async::Nominators map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::VirtualStakers::ah_post::length'"
-        assert_eq!(pallet_staking_async::VirtualStakers::<T>::iter_keys().count(), expected_virtual_stakers.len(), "StakingAsync::VirtualStakers length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::VirtualStakers::ah_post::consistent'"
+        // Assert storage 'StakingAsync::VirtualStakers::ah_post::length'
+        assert_eq!(pallet_staking_async::VirtualStakers::<T>::iter_keys().count(), expected_virtual_stakers.len(), "pallet_staking_async::VirtualStakers length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::VirtualStakers::ah_post::consistent'
         let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
-        assert_eq!(current_virtual_stakers, expected_virtual_stakers, "StakingAsync::VirtualStakers content mismatch on AH post-migration");
+        assert_eq!(current_virtual_stakers, expected_virtual_stakers, "pallet_staking_async::VirtualStakers content mismatch on AH post-migration");
         
-        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'"
-        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "StakingAsync::ErasStakersOverview map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().map(|(era, account_id, metadata)| ((era, account_id), metadata)).collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "StakingAsync::ErasStakersOverview map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'
+        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "pallet_staking_async::ErasStakersOverview map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasStakersOverview::ah_post::consistent'
+        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().map(|(era, account_id, metadata)| ((era, account_id), metadata)).collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "pallet_staking_async::ErasStakersOverview map content mismatch on AH post-migration");
         
-        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'"
-        assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "StakingAsync::ErasStakersPaged map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::consistent'"
+        // Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'
+        assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "pallet_staking_async::ErasStakersPaged map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasStakersPaged::ah_post::consistent'
         let current_eras_stakers_paged = pallet_staking_async::ErasStakersPaged::<T>::iter().collect::<BTreeMap<_,_>>();
-        assert_eq!(current_eras_stakers_paged, expected_eras_stakers_paged, "StakingAsync::ErasStakersPaged map content mismatch on AH post-migration");
+        assert_eq!(current_eras_stakers_paged, expected_eras_stakers_paged, "pallet_staking_async::ErasStakersPaged map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'"
-        assert_eq!(pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(), expected_claimed_rewards.len(), "StakingAsync::ErasClaimedRewards map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::consistent'"
+        // Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'
+        assert_eq!(pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(), expected_claimed_rewards.len(), "pallet_staking_async::ErasClaimedRewards map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::consistent'
         let current_claimed_rewards = pallet_staking_async::ErasClaimedRewards::<T>::iter()
             .map(|(k1, k2, v_weak_bounded)| ((k1, k2), v_weak_bounded.into_inner()))
             .collect::<BTreeMap<_,_>>();
-        assert_eq!(current_claimed_rewards, expected_claimed_rewards, "StakingAsync::ErasClaimedRewards map content mismatch on AH post-migration");
+        assert_eq!(current_claimed_rewards, expected_claimed_rewards, "pallet_staking_async::ErasClaimedRewards map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'"
-        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(), expected_eras_validator_prefs.len(), "StakingAsync::ErasValidatorPrefs map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter().map(|(era, account, prefs)| ((era, account), prefs)).collect::<BTreeMap<_,_>>(), expected_eras_validator_prefs, "StakingAsync::ErasValidatorPrefs map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'
+        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(), expected_eras_validator_prefs.len(), "pallet_staking_async::ErasValidatorPrefs map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::consistent'
+        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter().map(|(era, account, prefs)| ((era, account), prefs)).collect::<BTreeMap<_,_>>(), expected_eras_validator_prefs, "pallet_staking_async::ErasValidatorPrefs map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'"
-        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(), expected_eras_validator_reward.len(), "StakingAsync::ErasValidatorReward map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_reward, "StakingAsync::ErasValidatorReward map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'
+        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(), expected_eras_validator_reward.len(), "pallet_staking_async::ErasValidatorReward map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasValidatorReward::ah_post::consistent'
+        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_reward, "pallet_staking_async::ErasValidatorReward map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'"
-        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(), expected_eras_reward_points.len(), "StakingAsync::ErasRewardPoints map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_reward_points, "StakingAsync::ErasRewardPoints map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'
+        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(), expected_eras_reward_points.len(), "pallet_staking_async::ErasRewardPoints map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasRewardPoints::ah_post::consistent'
+        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_reward_points, "pallet_staking_async::ErasRewardPoints map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::length'"
-        assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter_keys().count(), expected_eras_total_stake.len(), "StakingAsync::ErasTotalStake map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_total_stake, "StakingAsync::ErasTotalStake map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasTotalStake::ah_post::length'
+        assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter_keys().count(), expected_eras_total_stake.len(), "pallet_staking_async::ErasTotalStake map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ErasTotalStake::ah_post::consistent'
+        assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_total_stake, "pallet_staking_async::ErasTotalStake map content mismatch on AH post-migration");
         
-        // "Assert storage 'StakingAsync::UnappliedSlashes::ah_post::length'"
-        assert_eq!(pallet_staking_async::UnappliedSlashes::<T>::iter_keys().count(), expected_unapplied_slashes.len(), "StakingAsync::UnappliedSlashes map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::UnappliedSlashes::ah_post::consistent'"
+        // Assert storage 'StakingAsync::UnappliedSlashes::ah_post::length'
+        assert_eq!(pallet_staking_async::UnappliedSlashes::<T>::iter_keys().count(), expected_unapplied_slashes.len(), "pallet_staking_async::UnappliedSlashes map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::UnappliedSlashes::ah_post::consistent'
         let current_unapplied_slashes = pallet_staking_async::UnappliedSlashes::<T>::iter()
             .map(|(k1_era, k2_tuple, v_slash)| ((k1_era, k2_tuple), v_slash))
             .collect::<BTreeMap<_,_>>();
-        assert_eq!(current_unapplied_slashes, expected_unapplied_slashes, "StakingAsync::UnappliedSlashes map content mismatch on AH post-migration");
+        assert_eq!(current_unapplied_slashes, expected_unapplied_slashes, "pallet_staking_async::UnappliedSlashes map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::length'"
-        assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter_keys().count(), expected_validator_slash_in_era.len(), "StakingAsync::ValidatorSlashInEra map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter().map(|(era, account, slash)| ((era, account), slash)).collect::<BTreeMap<_,_>>(), expected_validator_slash_in_era, "StakingAsync::ValidatorSlashInEra map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::length'
+        assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter_keys().count(), expected_validator_slash_in_era.len(), "pallet_staking_async::ValidatorSlashInEra map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::consistent'
+        assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter().map(|(era, account, slash)| ((era, account), slash)).collect::<BTreeMap<_,_>>(), expected_validator_slash_in_era, "pallet_staking_async::ValidatorSlashInEra map content mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::length'"
-        assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter_keys().count(), expected_nominator_slash_in_era.len(), "StakingAsync::NominatorSlashInEra map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter().map(|(era, account, balance)| ((era, account), balance)).collect::<BTreeMap<_,_>>(), expected_nominator_slash_in_era, "StakingAsync::NominatorSlashInEra map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::length'
+        assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter_keys().count(), expected_nominator_slash_in_era.len(), "pallet_staking_async::NominatorSlashInEra map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::consistent'
+        assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter().map(|(era, account, balance)| ((era, account), balance)).collect::<BTreeMap<_,_>>(), expected_nominator_slash_in_era, "pallet_staking_async::NominatorSlashInEra map content mismatch on AH post-migration");
 
         // SlashSpans gone in latest polkadot-sdk master branch
-        // "Assert storage 'StakingAsync::SlashingSpans::ah_post::length'"
-        assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter_keys().count(), expected_slashing_spans.len(), "StakingAsync::SlashingSpans map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::SlashingSpans::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter().collect::<BTreeMap<_,_>>(), expected_slashing_spans, "StakingAsync::SlashingSpans map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::SlashingSpans::ah_post::length'
+        assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter_keys().count(), expected_slashing_spans.len(), "pallet_staking_async::SlashingSpans map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::SlashingSpans::ah_post::consistent'
+        assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter().collect::<BTreeMap<_,_>>(), expected_slashing_spans, "pallet_staking_async::SlashingSpans map content mismatch on AH post-migration");
         
-        // "Assert storage 'StakingAsync::SpanSlash::ah_post::length'"
-        assert_eq!(pallet_staking_async::SpanSlash::<T>::iter_keys().count(), expected_span_slash.len(), "StakingAsync::SpanSlash map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::SpanSlash::ah_post::consistent'"
-        assert_eq!(pallet_staking_async::SpanSlash::<T>::iter().collect::<BTreeMap<_,_>>(), expected_span_slash, "StakingAsync::SpanSlash map content mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::SpanSlash::ah_post::length'
+        assert_eq!(pallet_staking_async::SpanSlash::<T>::iter_keys().count(), expected_span_slash.len(), "pallet_staking_async::SpanSlash map length mismatch on AH post-migration");
+        // Assert storage 'StakingAsync::SpanSlash::ah_post::consistent'
+        assert_eq!(pallet_staking_async::SpanSlash::<T>::iter().collect::<BTreeMap<_,_>>(), expected_span_slash, "pallet_staking_async::SpanSlash map content mismatch on AH post-migration");
     }
 }

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -445,7 +445,6 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
                 Validators { stash, validators } => { expected_validators.insert(stash, validators); },
                 Nominators { stash, nominations } => { expected_nominators.insert(stash, nominations); },
                 VirtualStakers(staker) => { expected_virtual_stakers.insert(staker); },
-    //          ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
                 ErasStakersOverview { era, validator, exposure } => { expected_eras_stakers_overview.insert((era, validator.clone()), exposure); },
                 ErasStakersPaged { era, validator, page, exposure } => { expected_eras_stakers_paged.insert((era, validator.clone(), page), exposure.into()); },
                 ClaimedRewards { era, validator, rewards } => { 
@@ -538,12 +537,6 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
         assert_eq!(current_virtual_stakers, expected_virtual_stakers, "StakingAsync::VirtualStakers content mismatch on AH post-migration");
         
-        // No longer migrated
-    //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::length'"
-    //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter_keys().count(), expected_eras_start_session_index.len(), "StakingAsync::ErasStartSessionIndex map length mismatch on AH post-migration");
-    //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::consistent'"
-    //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_start_session_index, "StakingAsync::ErasStartSessionIndex map content mismatch on AH post-migration");
-
         // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "StakingAsync::ErasStakersOverview map length mismatch on AH post-migration");
         // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::consistent'"

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -155,3 +155,19 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 }
+
+#[cfg(all(feature = "std", feature = "ahm-staking-migration"))]
+impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::StakingMigrator<T> {
+	use pallet_rc_migrator::RcPrePayload;
+	
+	type RcPrePayload = RcPrePayload<T>;
+	type AhPrePayload = ();
+
+	fn pre_check(_rc_pre_payload: Self::RcPrePayload) -> Self::AhPrePayload {
+
+	}
+
+	fn post_check(rc_pre_payload: Self::RcPrePayload, _ah_pre_payload: Self::AhPrePayload) {
+
+	}
+}

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -548,36 +548,36 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::correct'"
         assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().map(|(era, account_id, metadata)| ((era, account_id), metadata)).collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "StakingAsync::ErasStakersOverview map content mismatch on AH post-migration");
         
-    //     // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "StakingAsync::ErasStakersPaged map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::correct'"
-    //     let current_eras_stakers_paged = pallet_staking_async::ErasStakersPaged::<T>::iter()
-    //         .map(|(k, v_bounded)| (k, v_bounded.0))
-    //         .collect::<BTreeMap<_,_>>();
-    //     assert_eq!(current_eras_stakers_paged, expected_eras_stakers_paged, "StakingAsync::ErasStakersPaged map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'"
+        assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "StakingAsync::ErasStakersPaged map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::correct'"
+        let current_eras_stakers_paged = pallet_staking_async::ErasStakersPaged::<T>::iter()
+            // .map(|(key, v_bounded)| (key, v_bounded))
+            .collect::<BTreeMap<_,_>>();
+        assert_eq!(current_eras_stakers_paged, expected_eras_stakers_paged, "StakingAsync::ErasStakersPaged map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(), expected_claimed_rewards.len(), "StakingAsync::ErasClaimedRewards map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::correct'"
-    //     let current_claimed_rewards = pallet_staking_async::ErasClaimedRewards::<T>::iter()
-    //         .map(|(k1, k2, v_weak_bounded)| ((k1, k2), v_weak_bounded.into_inner()))
-    //         .collect::<BTreeMap<_,_>>();
-    //     assert_eq!(current_claimed_rewards, expected_claimed_rewards, "StakingAsync::ErasClaimedRewards map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'"
+        assert_eq!(pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(), expected_claimed_rewards.len(), "StakingAsync::ErasClaimedRewards map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::correct'"
+        let current_claimed_rewards = pallet_staking_async::ErasClaimedRewards::<T>::iter()
+            .map(|(k1, k2, v_weak_bounded)| ((k1, k2), v_weak_bounded.into_inner()))
+            .collect::<BTreeMap<_,_>>();
+        assert_eq!(current_claimed_rewards, expected_claimed_rewards, "StakingAsync::ErasClaimedRewards map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(), expected_eras_validator_prefs.len(), "StakingAsync::ErasValidatorPrefs map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_prefs, "StakingAsync::ErasValidatorPrefs map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'"
+        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(), expected_eras_validator_prefs.len(), "StakingAsync::ErasValidatorPrefs map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::correct'"
+        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter().map(|(era, account, prefs)| ((era, account), prefs)).collect::<BTreeMap<_,_>>(), expected_eras_validator_prefs, "StakingAsync::ErasValidatorPrefs map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(), expected_eras_validator_reward.len(), "StakingAsync::ErasValidatorReward map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_reward, "StakingAsync::ErasValidatorReward map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'"
+        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(), expected_eras_validator_reward.len(), "StakingAsync::ErasValidatorReward map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::correct'"
+        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_reward, "StakingAsync::ErasValidatorReward map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(), expected_eras_reward_points.len(), "StakingAsync::ErasRewardPoints map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_reward_points, "StakingAsync::ErasRewardPoints map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'"
+        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(), expected_eras_reward_points.len(), "StakingAsync::ErasRewardPoints map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::correct'"
+        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_reward_points, "StakingAsync::ErasRewardPoints map content mismatch on AH post-migration");
 
     //     // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::length'"
     //     assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter_keys().count(), expected_eras_total_stake.len(), "StakingAsync::ErasTotalStake map length mismatch on AH post-migration");

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -405,28 +405,28 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         type ActiveEraInfoAsync = pallet_staking_async::ActiveEraInfo;
         type ForcingAsync = pallet_staking_async::Forcing;
 
-    //     let mut expected_values_opt: Option<AhStakingValues<T>> = None;
-    //     let mut expected_invulnerables: Vec<AccountId<T>> = Vec::new();
-    //     let mut expected_bonded: BTreeMap<AccountId<T>, AccountId<T>> = BTreeMap::new();
-    //     let mut expected_ledger: BTreeMap<AccountId<T>, StakingLedgerAsync<T>> = BTreeMap::new();
-    //     let mut expected_payee: BTreeMap<AccountId<T>, RewardDestinationAsync<T>> = BTreeMap::new();
-    //     let mut expected_validators: BTreeMap<AccountId<T>, ValidatorPrefsAsync> = BTreeMap::new();
-    //     let mut expected_nominators: BTreeMap<AccountId<T>, NominationsAsync<T>> = BTreeMap::new();
-    //     let mut expected_virtual_stakers: HashSet<AccountId<T>> = HashSet::new();
-    //     let mut expected_eras_start_session_index: BTreeMap<EraIndex, SessionIndex> = BTreeMap::new();
-    //     let mut expected_eras_stakers_overview: BTreeMap<(EraIndex, AccountId<T>), PagedExposureMetadataAsync<T>> = BTreeMap::new();
-    //     let mut expected_eras_stakers_paged: BTreeMap<(EraIndex, AccountId<T>, Page), ExposurePageAsync<T>> = BTreeMap::new();
-    //     let mut expected_claimed_rewards: BTreeMap<(EraIndex, AccountId<T>), Vec<Page>> = BTreeMap::new();
-    //     let mut expected_eras_validator_prefs: BTreeMap<(EraIndex, AccountId<T>), ValidatorPrefsAsync> = BTreeMap::new();
-    //     let mut expected_eras_validator_reward: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
-    //     let mut expected_eras_reward_points: BTreeMap<EraIndex, EraRewardPointsAsync<T>> = BTreeMap::new();
-    //     let mut expected_eras_total_stake: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
-    //     let mut expected_unapplied_slashes: BTreeMap<(EraIndex, (AccountId<T>, Perbill, u32)), UnappliedSlashAsync<T>> = BTreeMap::new();
-    //     let mut expected_bonded_eras: Vec<(EraIndex, SessionIndex)> = Vec::new();
-    //     let mut expected_validator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), (Perbill, Balance<T>)> = BTreeMap::new();
-    //     let mut expected_nominator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), Balance<T>> = BTreeMap::new();
-    //     let mut expected_slashing_spans: BTreeMap<AccountId<T>, SlashingSpansAsync> = BTreeMap::new();
-    // //     let mut expected_span_slash: BTreeMap<(AccountId<T>, SpanIndex), SpanRecordAsync<T>> = BTreeMap::new();
+        let mut expected_values_opt: Option<AhStakingValues<T>> = None;
+        let mut expected_invulnerables: Vec<AccountId<T>> = Vec::new();
+        let mut expected_bonded: BTreeMap<AccountId<T>, AccountId<T>> = BTreeMap::new();
+        let mut expected_ledger: BTreeMap<AccountId<T>, StakingLedgerAsync<T>> = BTreeMap::new();
+        let mut expected_payee: BTreeMap<AccountId<T>, RewardDestinationAsync<T>> = BTreeMap::new();
+        let mut expected_validators: BTreeMap<AccountId<T>, ValidatorPrefsAsync> = BTreeMap::new();
+        let mut expected_nominators: BTreeMap<AccountId<T>, NominationsAsync<T>> = BTreeMap::new();
+        let mut expected_virtual_stakers: HashSet<AccountId<T>> = HashSet::new();
+        let mut expected_eras_start_session_index: BTreeMap<EraIndex, SessionIndex> = BTreeMap::new();
+        let mut expected_eras_stakers_overview: BTreeMap<(EraIndex, AccountId<T>), PagedExposureMetadataAsync<T>> = BTreeMap::new();
+        let mut expected_eras_stakers_paged: BTreeMap<(EraIndex, AccountId<T>, Page), ExposurePageAsync<T>> = BTreeMap::new();
+        let mut expected_claimed_rewards: BTreeMap<(EraIndex, AccountId<T>), Vec<Page>> = BTreeMap::new();
+        let mut expected_eras_validator_prefs: BTreeMap<(EraIndex, AccountId<T>), ValidatorPrefsAsync> = BTreeMap::new();
+        let mut expected_eras_validator_reward: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
+        let mut expected_eras_reward_points: BTreeMap<EraIndex, EraRewardPointsAsync<T>> = BTreeMap::new();
+        let mut expected_eras_total_stake: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
+        let mut expected_unapplied_slashes: BTreeMap<(EraIndex, (AccountId<T>, Perbill, u32)), UnappliedSlashAsync<T>> = BTreeMap::new();
+        let mut expected_bonded_eras: Vec<(EraIndex, SessionIndex)> = Vec::new();
+        let mut expected_validator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), (Perbill, Balance<T>)> = BTreeMap::new();
+        let mut expected_nominator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), Balance<T>> = BTreeMap::new();
+        let mut expected_slashing_spans: BTreeMap<AccountId<T>, SlashingSpansAsync> = BTreeMap::new();
+    //     let mut expected_span_slash: BTreeMap<(AccountId<T>, SpanIndex), SpanRecordAsync<T>> = BTreeMap::new();
 
     //     for rc_message in rc_pre_payload {
     //         let ah_message = T::RcStakingMessage::intoAh(rc_message);
@@ -457,7 +457,7 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
     //             NominatorSlashInEra { era, validator, slash } => { expected_nominator_slash_in_era.insert((era, validator.clone()), slash); },
     //             SlashingSpans { account, spans } => { expected_slashing_spans.insert(account, spans); },
     // //            SpanSlash { account, span, slash } => { expected_span_slash.insert((account, span), slash); },
-    //             _ => todo!(), // Spanslash removes from master branch
+    //             _ => todo!(), // Spanslash removed from master branch, remove for now
     //         }
     //     }
 

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -428,38 +428,38 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         let mut expected_slashing_spans: BTreeMap<AccountId<T>, SlashingSpansAsync> = BTreeMap::new();
     //     let mut expected_span_slash: BTreeMap<(AccountId<T>, SpanIndex), SpanRecordAsync<T>> = BTreeMap::new();
 
-    //     for rc_message in rc_pre_payload {
-    //         let ah_message = T::RcStakingMessage::intoAh(rc_message);
-    //         use pallet_rc_migrator::staking::message::RcStakingMessage::*;
-    //         match ah_message {
-    //             Values(v) => expected_values_opt = Some(v),
-    //             Invulnerables(inv) => expected_invulnerables = inv,
-    //             Bonded { stash, controller } => { expected_bonded.insert(stash, controller); },
-    //             Ledger { controller, ledger } => { expected_ledger.insert(controller, ledger); },
-    //             Payee { stash, payment } => { expected_payee.insert(stash, payment); },
-    //             Validators { stash, validators } => { expected_validators.insert(stash, validators); },
-    //             Nominators { stash, nominations } => { expected_nominators.insert(stash, nominations); },
-    //             VirtualStakers(staker) => { expected_virtual_stakers.insert(staker); },
-    // //             ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
-    //             ErasStakersOverview { era, validator, exposure } => { expected_eras_stakers_overview.insert((era, validator.clone()), exposure); },
-    //             ErasStakersPaged { era, validator, page, exposure } => { expected_eras_stakers_paged.insert((era, validator.clone(), page), exposure.into()); },
-    //             ClaimedRewards { era, validator, rewards } => { expected_claimed_rewards.insert((era, validator.clone()), rewards); },
-    //             ErasValidatorPrefs { era, validator, prefs } => { expected_eras_validator_prefs.insert((era, validator.clone()), prefs); },
-    //             ErasValidatorReward { era, reward } => { expected_eras_validator_reward.insert(era, reward); },
-    //             ErasRewardPoints { era, points } => { expected_eras_reward_points.insert(era, points); },
-    //             ErasTotalStake { era, total_stake } => { expected_eras_total_stake.insert(era, total_stake); },
-    //             UnappliedSlashes { era, slash } => {
-    //                 let slash_map_key_tuple = (slash.validator.clone(), Perbill::from_percent(99), 9999u32);
-    //                 expected_unapplied_slashes.insert((era, slash_map_key_tuple), slash);
-    //             },
-    //             BondedEras(be) => expected_bonded_eras = be,
-    //             ValidatorSlashInEra { era, validator, slash } => { expected_validator_slash_in_era.insert((era, validator.clone()), slash); },
-    //             NominatorSlashInEra { era, validator, slash } => { expected_nominator_slash_in_era.insert((era, validator.clone()), slash); },
-    //             SlashingSpans { account, spans } => { expected_slashing_spans.insert(account, spans); },
-    // //            SpanSlash { account, span, slash } => { expected_span_slash.insert((account, span), slash); },
-    //             _ => todo!(), // Spanslash removed from master branch, remove for now
-    //         }
-    //     }
+        for rc_message in rc_pre_payload {
+            let ah_message = T::RcStakingMessage::intoAh(rc_message);
+            use pallet_rc_migrator::staking::message::RcStakingMessage::*;
+            match ah_message {
+                Values(v) => expected_values_opt = Some(v),
+                Invulnerables(inv) => expected_invulnerables = inv,
+                Bonded { stash, controller } => { expected_bonded.insert(stash, controller); },
+                Ledger { controller, ledger } => { expected_ledger.insert(controller, ledger); },
+                Payee { stash, payment } => { expected_payee.insert(stash, payment); },
+                Validators { stash, validators } => { expected_validators.insert(stash, validators); },
+                Nominators { stash, nominations } => { expected_nominators.insert(stash, nominations); },
+                VirtualStakers(staker) => { expected_virtual_stakers.insert(staker); },
+    //             ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
+                ErasStakersOverview { era, validator, exposure } => { expected_eras_stakers_overview.insert((era, validator.clone()), exposure); },
+                ErasStakersPaged { era, validator, page, exposure } => { expected_eras_stakers_paged.insert((era, validator.clone(), page), exposure.into()); },
+                ClaimedRewards { era, validator, rewards } => { expected_claimed_rewards.insert((era, validator.clone()), rewards); },
+                ErasValidatorPrefs { era, validator, prefs } => { expected_eras_validator_prefs.insert((era, validator.clone()), prefs); },
+                ErasValidatorReward { era, reward } => { expected_eras_validator_reward.insert(era, reward); },
+                ErasRewardPoints { era, points } => { expected_eras_reward_points.insert(era, points); },
+                ErasTotalStake { era, total_stake } => { expected_eras_total_stake.insert(era, total_stake); },
+                UnappliedSlashes { era, slash } => {
+                    let slash_map_key_tuple = (slash.validator.clone(), Perbill::from_percent(99), 9999u32);
+                    expected_unapplied_slashes.insert((era, slash_map_key_tuple), slash);
+                },
+                BondedEras(be) => expected_bonded_eras = be,
+                ValidatorSlashInEra { era, validator, slash } => { expected_validator_slash_in_era.insert((era, validator.clone()), slash); },
+                NominatorSlashInEra { era, validator, slash } => { expected_nominator_slash_in_era.insert((era, validator.clone()), slash); },
+                SlashingSpans { account, spans } => { expected_slashing_spans.insert(account, spans); },
+    //            SpanSlash { account, span, slash } => { expected_span_slash.insert((account, span), slash); },
+                _ => todo!(), // Spanslash removed from master branch, remove for now
+            }
+        }
 
     //     if let Some(values) = expected_values_opt {
     //         // "Assert storage 'StakingAsync::ValidatorCount::ah_post::correct'"

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -156,451 +156,723 @@ impl<T: Config> Pallet<T> {
 
 #[cfg(all(feature = "std", feature = "ahm-staking-migration"))]
 impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::StakingMigrator<T> {
-	
 	type RcPrePayload = Vec<T::RcStakingMessage>;
 	type AhPrePayload = ();
 
 	fn pre_check(_rc_pre_payload: Self::RcPrePayload) -> Self::AhPrePayload {
-        // Assert storage 'StakingAsync::ValidatorCount::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::ValidatorCount::<T>::get(),
-            0,
-            "pallet_staking_async::ValidatorCount should be 0 on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ValidatorCount::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::ValidatorCount::<T>::get(),
+			0,
+			"pallet_staking_async::ValidatorCount should be 0 on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::MinNominatorBond::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::MinNominatorBond::<T>::get(),
-            Default::default(),
-            "pallet_staking_async::MinNominatorBond should be default on AH before migration"
-        );
+		// Assert storage 'StakingAsync::MinNominatorBond::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::MinNominatorBond::<T>::get(),
+			Default::default(),
+			"pallet_staking_async::MinNominatorBond should be default on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::MinValidatorBond::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::MinValidatorBond::<T>::get(),
-            Default::default(),
-            "pallet_staking_async::MinValidatorBond should be default on AH before migration"
-        );
+		// Assert storage 'StakingAsync::MinValidatorBond::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::MinValidatorBond::<T>::get(),
+			Default::default(),
+			"pallet_staking_async::MinValidatorBond should be default on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::MinimumActiveStake::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::MinimumActiveStake::<T>::get(),
-            Default::default(),
-            "pallet_staking_async::MinimumActiveStake should be default on AH before migration"
-        );
+		// Assert storage 'StakingAsync::MinimumActiveStake::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::MinimumActiveStake::<T>::get(),
+			Default::default(),
+			"pallet_staking_async::MinimumActiveStake should be default on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::MinCommission::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::MinCommission::<T>::get(),
-            Default::default(),
-            "pallet_staking_async::MinCommission should be default on AH before migration"
-        );
+		// Assert storage 'StakingAsync::MinCommission::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::MinCommission::<T>::get(),
+			Default::default(),
+			"pallet_staking_async::MinCommission should be default on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::MaxValidatorsCount::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::MaxValidatorsCount::<T>::get(),
-            None,
-            "pallet_staking_async::MaxValidatorsCount should be None on AH before migration"
-        );
+		// Assert storage 'StakingAsync::MaxValidatorsCount::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::MaxValidatorsCount::<T>::get(),
+			None,
+			"pallet_staking_async::MaxValidatorsCount should be None on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::MaxNominatorsCount::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::MaxNominatorsCount::<T>::get(),
-            None,
-            "pallet_staking_async::MaxNominatorsCount should be None on AH before migration"
-        );
+		// Assert storage 'StakingAsync::MaxNominatorsCount::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::MaxNominatorsCount::<T>::get(),
+			None,
+			"pallet_staking_async::MaxNominatorsCount should be None on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::CurrentEra::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::CurrentEra::<T>::get(),
-            None,
-            "pallet_staking_async::CurrentEra should be None on AH before migration"
-        );
+		// Assert storage 'StakingAsync::CurrentEra::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::CurrentEra::<T>::get(),
+			None,
+			"pallet_staking_async::CurrentEra should be None on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ActiveEra::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::ActiveEra::<T>::get(),
-            None,
-            "pallet_staking_async::ActiveEra should be None on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ActiveEra::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::ActiveEra::<T>::get(),
+			None,
+			"pallet_staking_async::ActiveEra should be None on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ForceEra::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::ForceEra::<T>::get(),
-            Default::default(), // Assumes Forcing::NotForcing or similar is default
-            "pallet_staking_async::ForceEra should be default on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ForceEra::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::ForceEra::<T>::get(),
+			Default::default(), // Assumes Forcing::NotForcing or similar is default
+			"pallet_staking_async::ForceEra should be default on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::MaxStakedRewards::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::MaxStakedRewards::<T>::get(),
-            None,
-            "pallet_staking_async::MaxStakedRewards should be None on AH before migration"
-        );
+		// Assert storage 'StakingAsync::MaxStakedRewards::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::MaxStakedRewards::<T>::get(),
+			None,
+			"pallet_staking_async::MaxStakedRewards should be None on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::SlashRewardFraction::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::SlashRewardFraction::<T>::get(),
-            Default::default(),
-            "pallet_staking_async::SlashRewardFraction should be default on AH before migration"
-        );
+		// Assert storage 'StakingAsync::SlashRewardFraction::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::SlashRewardFraction::<T>::get(),
+			Default::default(),
+			"pallet_staking_async::SlashRewardFraction should be default on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::CanceledSlashPayout::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::CanceledSlashPayout::<T>::get(),
-            Default::default(),
-            "pallet_staking_async::CanceledSlashPayout should be default on AH before migration"
-        );
+		// Assert storage 'StakingAsync::CanceledSlashPayout::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::CanceledSlashPayout::<T>::get(),
+			Default::default(),
+			"pallet_staking_async::CanceledSlashPayout should be default on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ChillThreshold::ah_pre::empty'
-        assert_eq!(
-            pallet_staking_async::ChillThreshold::<T>::get(),
-            None,
-            "pallet_staking_async::ChillThreshold should be None on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ChillThreshold::ah_pre::empty'
+		assert_eq!(
+			pallet_staking_async::ChillThreshold::<T>::get(),
+			None,
+			"pallet_staking_async::ChillThreshold should be None on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::Invulnerables::ah_pre::empty'
-        assert!(
-            pallet_staking_async::Invulnerables::<T>::get().is_empty(),
-            "pallet_staking_async::Invulnerables should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::Invulnerables::ah_pre::empty'
+		assert!(
+			pallet_staking_async::Invulnerables::<T>::get().is_empty(),
+			"pallet_staking_async::Invulnerables should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::BondedEras::ah_pre::empty'
-        assert!(
-            pallet_staking_async::BondedEras::<T>::get().is_empty(),
-            "pallet_staking_async::BondedEras should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::BondedEras::ah_pre::empty'
+		assert!(
+			pallet_staking_async::BondedEras::<T>::get().is_empty(),
+			"pallet_staking_async::BondedEras should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::Bonded::ah_pre::empty'
-        assert!(
-            pallet_staking_async::Bonded::<T>::iter().next().is_none(),
-            "pallet_staking_async::Bonded map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::Bonded::ah_pre::empty'
+		assert!(
+			pallet_staking_async::Bonded::<T>::iter().next().is_none(),
+			"pallet_staking_async::Bonded map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::Ledger::ah_pre::empty'
-        assert!(
-            pallet_staking_async::Ledger::<T>::iter().next().is_none(),
-            "pallet_staking_async::Ledger map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::Ledger::ah_pre::empty'
+		assert!(
+			pallet_staking_async::Ledger::<T>::iter().next().is_none(),
+			"pallet_staking_async::Ledger map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::Payee::ah_pre::empty'
-        assert!(
-            pallet_staking_async::Payee::<T>::iter().next().is_none(),
-            "pallet_staking_async::Payee map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::Payee::ah_pre::empty'
+		assert!(
+			pallet_staking_async::Payee::<T>::iter().next().is_none(),
+			"pallet_staking_async::Payee map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::Validators::ah_pre::empty'
-        assert!(
-            pallet_staking_async::Validators::<T>::iter().next().is_none(),
-            "pallet_staking_async::Validators map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::Validators::ah_pre::empty'
+		assert!(
+			pallet_staking_async::Validators::<T>::iter().next().is_none(),
+			"pallet_staking_async::Validators map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::Nominators::ah_pre::empty'
-        assert!(
-            pallet_staking_async::Nominators::<T>::iter().next().is_none(),
-            "pallet_staking_async::Nominators map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::Nominators::ah_pre::empty'
+		assert!(
+			pallet_staking_async::Nominators::<T>::iter().next().is_none(),
+			"pallet_staking_async::Nominators map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::VirtualStakers::ah_pre::empty'
-        assert!(
-            pallet_staking_async::VirtualStakers::<T>::iter().next().is_none(),
-            "pallet_staking_async::VirtualStakers map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::VirtualStakers::ah_pre::empty'
+		assert!(
+			pallet_staking_async::VirtualStakers::<T>::iter().next().is_none(),
+			"pallet_staking_async::VirtualStakers map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasStakersOverview::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ErasStakersOverview::<T>::iter().next().is_none(),
-            "pallet_staking_async::ErasStakersOverview map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ErasStakersOverview::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ErasStakersOverview::<T>::iter().next().is_none(),
+			"pallet_staking_async::ErasStakersOverview map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasStakersPaged::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ErasStakersPaged::<T>::iter().next().is_none(),
-            "pallet_staking_async::ErasStakersPaged map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ErasStakersPaged::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ErasStakersPaged::<T>::iter().next().is_none(),
+			"pallet_staking_async::ErasStakersPaged map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasClaimedRewards::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ErasClaimedRewards::<T>::iter().next().is_none(),
-            "pallet_staking_async::ErasClaimedRewards map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ErasClaimedRewards::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ErasClaimedRewards::<T>::iter().next().is_none(),
+			"pallet_staking_async::ErasClaimedRewards map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasValidatorPrefs::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ErasValidatorPrefs::<T>::iter().next().is_none(),
-            "pallet_staking_async::ErasValidatorPrefs map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ErasValidatorPrefs::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ErasValidatorPrefs::<T>::iter().next().is_none(),
+			"pallet_staking_async::ErasValidatorPrefs map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasValidatorReward::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ErasValidatorReward::<T>::iter().next().is_none(),
-            "pallet_staking_async::ErasValidatorReward map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ErasValidatorReward::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ErasValidatorReward::<T>::iter().next().is_none(),
+			"pallet_staking_async::ErasValidatorReward map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasRewardPoints::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ErasRewardPoints::<T>::iter().next().is_none(),
-            "pallet_staking_async::ErasRewardPoints map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ErasRewardPoints::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ErasRewardPoints::<T>::iter().next().is_none(),
+			"pallet_staking_async::ErasRewardPoints map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasTotalStake::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ErasTotalStake::<T>::iter().next().is_none(),
-            "pallet_staking_async::ErasTotalStake map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ErasTotalStake::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ErasTotalStake::<T>::iter().next().is_none(),
+			"pallet_staking_async::ErasTotalStake map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::UnappliedSlashes::ah_pre::empty'
-        assert!(
-            pallet_staking_async::UnappliedSlashes::<T>::iter().next().is_none(),
-            "pallet_staking_async::UnappliedSlashes map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::UnappliedSlashes::ah_pre::empty'
+		assert!(
+			pallet_staking_async::UnappliedSlashes::<T>::iter().next().is_none(),
+			"pallet_staking_async::UnappliedSlashes map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::ValidatorSlashInEra::ah_pre::empty'
-        assert!(
-            pallet_staking_async::ValidatorSlashInEra::<T>::iter().next().is_none(),
-            "pallet_staking_async::ValidatorSlashInEra map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::ValidatorSlashInEra::ah_pre::empty'
+		assert!(
+			pallet_staking_async::ValidatorSlashInEra::<T>::iter().next().is_none(),
+			"pallet_staking_async::ValidatorSlashInEra map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::NominatorSlashInEra::ah_pre::empty'
-        assert!(
-            pallet_staking_async::NominatorSlashInEra::<T>::iter().next().is_none(),
-            "pallet_staking_async::NominatorSlashInEra map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::NominatorSlashInEra::ah_pre::empty'
+		assert!(
+			pallet_staking_async::NominatorSlashInEra::<T>::iter().next().is_none(),
+			"pallet_staking_async::NominatorSlashInEra map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::SlashingSpans::ah_pre::empty'
-        assert!(
-            pallet_staking_async::SlashingSpans::<T>::iter().next().is_none(),
-            "pallet_staking_async::SlashingSpans map should be empty on AH before migration"
-        );
+		// Assert storage 'StakingAsync::SlashingSpans::ah_pre::empty'
+		assert!(
+			pallet_staking_async::SlashingSpans::<T>::iter().next().is_none(),
+			"pallet_staking_async::SlashingSpans map should be empty on AH before migration"
+		);
 
-        // Assert storage 'StakingAsync::SpanSlash::ah_pre::empty'
-        assert!(
-            pallet_staking_async::SpanSlash::<T>::iter().next().is_none(),
-            "pallet_staking_async::SpanSlash map should be empty on AH before migration"
-        );
-    }
+		// Assert storage 'StakingAsync::SpanSlash::ah_pre::empty'
+		assert!(
+			pallet_staking_async::SpanSlash::<T>::iter().next().is_none(),
+			"pallet_staking_async::SpanSlash map should be empty on AH before migration"
+		);
+	}
 
 	fn post_check(rc_pre_payload: Self::RcPrePayload, _ah_pre_payload: Self::AhPrePayload) {
-        use sp_staking::{EraIndex, Page, SessionIndex};
-        use sp_runtime::Perbill;
-        use std::collections::{BTreeMap, HashSet};
-        use frame_support::BoundedVec;
+		use frame_support::BoundedVec;
+		use sp_runtime::Perbill;
+		use sp_staking::{EraIndex, Page, SessionIndex};
+		use std::collections::{BTreeMap, HashSet};
 
-        type AccountId<T> = <T as frame_system::Config>::AccountId;
-        type Balance<T> = <T as pallet_staking_async::Config>::CurrencyBalance;
-        type StakingLedgerAsync<T> = pallet_staking_async::StakingLedger<T>;
-        type NominationsAsync<T> = pallet_staking_async::Nominations<T>;
-        type SpanRecordAsync<T> = pallet_staking_async::slashing::SpanRecord<Balance<T>>;
-        type EraRewardPointsAsync<T> = pallet_staking_async::EraRewardPoints<T>;
-        type RewardDestinationAsync<T> = pallet_staking_async::RewardDestination<AccountId<T>>;
-        type ValidatorPrefsAsync = pallet_staking_async::ValidatorPrefs;
-        type UnappliedSlashAsync<T> = pallet_staking_async::UnappliedSlash<T>;
-        type SlashingSpansAsync = pallet_staking_async::slashing::SlashingSpans;
-        type PagedExposureMetadataAsync<T> = sp_staking::PagedExposureMetadata<Balance<T>>;
-        type ExposurePageAsync<T> = pallet_staking_async::BoundedExposurePage<T>;
-        type AhStakingValues<T> = pallet_rc_migrator::staking::message::AhStakingValuesOf<T>;
-        type ActiveEraInfoAsync = pallet_staking_async::ActiveEraInfo;
-        type ForcingAsync = pallet_staking_async::Forcing;
-        type SpanIndex = u32;
+		type AccountId<T> = <T as frame_system::Config>::AccountId;
+		type Balance<T> = <T as pallet_staking_async::Config>::CurrencyBalance;
+		type StakingLedgerAsync<T> = pallet_staking_async::StakingLedger<T>;
+		type NominationsAsync<T> = pallet_staking_async::Nominations<T>;
+		type SpanRecordAsync<T> = pallet_staking_async::slashing::SpanRecord<Balance<T>>;
+		type EraRewardPointsAsync<T> = pallet_staking_async::EraRewardPoints<T>;
+		type RewardDestinationAsync<T> = pallet_staking_async::RewardDestination<AccountId<T>>;
+		type ValidatorPrefsAsync = pallet_staking_async::ValidatorPrefs;
+		type UnappliedSlashAsync<T> = pallet_staking_async::UnappliedSlash<T>;
+		type SlashingSpansAsync = pallet_staking_async::slashing::SlashingSpans;
+		type PagedExposureMetadataAsync<T> = sp_staking::PagedExposureMetadata<Balance<T>>;
+		type ExposurePageAsync<T> = pallet_staking_async::BoundedExposurePage<T>;
+		type AhStakingValues<T> = pallet_rc_migrator::staking::message::AhStakingValuesOf<T>;
+		type ActiveEraInfoAsync = pallet_staking_async::ActiveEraInfo;
+		type ForcingAsync = pallet_staking_async::Forcing;
+		type SpanIndex = u32;
 
-        let mut expected_values_opt: Option<AhStakingValues<T>> = None;
-        let mut expected_active_era_opt: Option<ActiveEraInfoAsync> = None;
-        let mut expected_force_era_opt: Option<ForcingAsync> = None;
-        let mut expected_invulnerables: Vec<AccountId<T>> = Vec::new();
-        let mut expected_bonded: BTreeMap<AccountId<T>, AccountId<T>> = BTreeMap::new();
-        let mut expected_ledger: BTreeMap<AccountId<T>, StakingLedgerAsync<T>> = BTreeMap::new();
-        let mut expected_payee: BTreeMap<AccountId<T>, RewardDestinationAsync<T>> = BTreeMap::new();
-        let mut expected_validators: BTreeMap<AccountId<T>, ValidatorPrefsAsync> = BTreeMap::new();
-        let mut expected_nominators: BTreeMap<AccountId<T>, NominationsAsync<T>> = BTreeMap::new();
-        let mut expected_virtual_stakers: HashSet<AccountId<T>> = HashSet::new();
-        let mut expected_eras_stakers_overview: BTreeMap<(EraIndex, AccountId<T>), PagedExposureMetadataAsync<T>> = BTreeMap::new();
-        let mut expected_eras_stakers_paged: BTreeMap<(EraIndex, AccountId<T>, Page), ExposurePageAsync<T>> = BTreeMap::new();
-        let mut expected_claimed_rewards: BTreeMap<(EraIndex, AccountId<T>), Vec<Page>> = BTreeMap::new();
-        let mut expected_eras_validator_prefs: BTreeMap<(EraIndex, AccountId<T>), ValidatorPrefsAsync> = BTreeMap::new();
-        let mut expected_eras_validator_reward: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
-        let mut expected_eras_reward_points: BTreeMap<EraIndex, EraRewardPointsAsync<T>> = BTreeMap::new();
-        let mut expected_eras_total_stake: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
-        let mut expected_unapplied_slashes: BTreeMap<(EraIndex, (AccountId<T>, Perbill, u32)), UnappliedSlashAsync<T>> = BTreeMap::new();
-        let mut expected_bonded_eras: Vec<(EraIndex, SessionIndex)> = Vec::new();
-        let mut expected_validator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), (Perbill, Balance<T>)> = BTreeMap::new();
-        let mut expected_nominator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), Balance<T>> = BTreeMap::new();
-        let mut expected_slashing_spans: BTreeMap<AccountId<T>, SlashingSpansAsync> = BTreeMap::new();
-        let mut expected_span_slash: BTreeMap<(AccountId<T>, SpanIndex), SpanRecordAsync<T>> = BTreeMap::new();
+		let mut expected_values_opt: Option<AhStakingValues<T>> = None;
+		let mut expected_active_era_opt: Option<ActiveEraInfoAsync> = None;
+		let mut expected_force_era_opt: Option<ForcingAsync> = None;
+		let mut expected_invulnerables: Vec<AccountId<T>> = Vec::new();
+		let mut expected_bonded: BTreeMap<AccountId<T>, AccountId<T>> = BTreeMap::new();
+		let mut expected_ledger: BTreeMap<AccountId<T>, StakingLedgerAsync<T>> = BTreeMap::new();
+		let mut expected_payee: BTreeMap<AccountId<T>, RewardDestinationAsync<T>> = BTreeMap::new();
+		let mut expected_validators: BTreeMap<AccountId<T>, ValidatorPrefsAsync> = BTreeMap::new();
+		let mut expected_nominators: BTreeMap<AccountId<T>, NominationsAsync<T>> = BTreeMap::new();
+		let mut expected_virtual_stakers: HashSet<AccountId<T>> = HashSet::new();
+		let mut expected_eras_stakers_overview: BTreeMap<
+			(EraIndex, AccountId<T>),
+			PagedExposureMetadataAsync<T>,
+		> = BTreeMap::new();
+		let mut expected_eras_stakers_paged: BTreeMap<
+			(EraIndex, AccountId<T>, Page),
+			ExposurePageAsync<T>,
+		> = BTreeMap::new();
+		let mut expected_claimed_rewards: BTreeMap<(EraIndex, AccountId<T>), Vec<Page>> =
+			BTreeMap::new();
+		let mut expected_eras_validator_prefs: BTreeMap<
+			(EraIndex, AccountId<T>),
+			ValidatorPrefsAsync,
+		> = BTreeMap::new();
+		let mut expected_eras_validator_reward: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
+		let mut expected_eras_reward_points: BTreeMap<EraIndex, EraRewardPointsAsync<T>> =
+			BTreeMap::new();
+		let mut expected_eras_total_stake: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
+		let mut expected_unapplied_slashes: BTreeMap<
+			(EraIndex, (AccountId<T>, Perbill, u32)),
+			UnappliedSlashAsync<T>,
+		> = BTreeMap::new();
+		let mut expected_bonded_eras: Vec<(EraIndex, SessionIndex)> = Vec::new();
+		let mut expected_validator_slash_in_era: BTreeMap<
+			(EraIndex, AccountId<T>),
+			(Perbill, Balance<T>),
+		> = BTreeMap::new();
+		let mut expected_nominator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), Balance<T>> =
+			BTreeMap::new();
+		let mut expected_slashing_spans: BTreeMap<AccountId<T>, SlashingSpansAsync> =
+			BTreeMap::new();
+		let mut expected_span_slash: BTreeMap<(AccountId<T>, SpanIndex), SpanRecordAsync<T>> =
+			BTreeMap::new();
 
-        for rc_message in rc_pre_payload {
-            let ah_message = T::RcStakingMessage::intoAh(rc_message);
-            use pallet_rc_migrator::staking::message::RcStakingMessage::*;
-            match ah_message {
-                Values(v) => {
-                    expected_active_era_opt = v.clone().active_era.map(pallet_staking::ActiveEraInfo::intoAh);
-                    expected_force_era_opt = Some(pallet_staking::Forcing::intoAh(v.clone().force_era));
-                    expected_values_opt = Some(v)
-                },
-                Invulnerables(inv) => expected_invulnerables = inv,
-                Bonded { stash, controller } => { expected_bonded.insert(stash, controller); },
-                Ledger { controller, ledger } => { expected_ledger.insert(controller, ledger); },
-                Payee { stash, payment } => { expected_payee.insert(stash, payment); },
-                Validators { stash, validators } => { expected_validators.insert(stash, validators); },
-                Nominators { stash, nominations } => { expected_nominators.insert(stash, nominations); },
-                VirtualStakers(staker) => { expected_virtual_stakers.insert(staker); },
-                ErasStakersOverview { era, validator, exposure } => { expected_eras_stakers_overview.insert((era, validator.clone()), exposure); },
-                ErasStakersPaged { era, validator, page, exposure } => { expected_eras_stakers_paged.insert((era, validator.clone(), page), exposure.into()); },
-                ClaimedRewards { era, validator, rewards } => { 
-                    let bounded = BoundedVec::<Page, pallet_staking_async::ErasClaimedRewardsBound<T>>::truncate_from(rewards);
-                    expected_claimed_rewards.insert((era, validator.clone()), bounded.into_inner()); 
-                },
-                ErasValidatorPrefs { era, validator, prefs } => { expected_eras_validator_prefs.insert((era, validator.clone()), prefs); },
-                ErasValidatorReward { era, reward } => { expected_eras_validator_reward.insert(era, reward); },
-                ErasRewardPoints { era, points } => { expected_eras_reward_points.insert(era, points); },
-                ErasTotalStake { era, total_stake } => { expected_eras_total_stake.insert(era, total_stake); },
-                UnappliedSlashes { era, slash } => {
-                    let slash_map_key_tuple = (slash.validator.clone(), Perbill::from_percent(99), 9999u32);
-                    expected_unapplied_slashes.insert((era, slash_map_key_tuple), slash);
-                },
-                BondedEras(be) => expected_bonded_eras = be,
-                ValidatorSlashInEra { era, validator, slash } => { expected_validator_slash_in_era.insert((era, validator.clone()), slash); },
-                NominatorSlashInEra { era, validator, slash } => { expected_nominator_slash_in_era.insert((era, validator.clone()), slash); },
-                SlashingSpans { account, spans } => { expected_slashing_spans.insert(account, spans); },
-                SpanSlash { account, span, slash } => { expected_span_slash.insert((account, span), slash); },
-            }
-        }
+		for rc_message in rc_pre_payload {
+			let ah_message = T::RcStakingMessage::intoAh(rc_message);
+			use pallet_rc_migrator::staking::message::RcStakingMessage::*;
+			match ah_message {
+				Values(v) => {
+					expected_active_era_opt =
+						v.clone().active_era.map(pallet_staking::ActiveEraInfo::intoAh);
+					expected_force_era_opt =
+						Some(pallet_staking::Forcing::intoAh(v.clone().force_era));
+					expected_values_opt = Some(v)
+				},
+				Invulnerables(inv) => expected_invulnerables = inv,
+				Bonded { stash, controller } => {
+					expected_bonded.insert(stash, controller);
+				},
+				Ledger { controller, ledger } => {
+					expected_ledger.insert(controller, ledger);
+				},
+				Payee { stash, payment } => {
+					expected_payee.insert(stash, payment);
+				},
+				Validators { stash, validators } => {
+					expected_validators.insert(stash, validators);
+				},
+				Nominators { stash, nominations } => {
+					expected_nominators.insert(stash, nominations);
+				},
+				VirtualStakers(staker) => {
+					expected_virtual_stakers.insert(staker);
+				},
+				ErasStakersOverview { era, validator, exposure } => {
+					expected_eras_stakers_overview.insert((era, validator.clone()), exposure);
+				},
+				ErasStakersPaged { era, validator, page, exposure } => {
+					expected_eras_stakers_paged
+						.insert((era, validator.clone(), page), exposure.into());
+				},
+				ClaimedRewards { era, validator, rewards } => {
+					let bounded = BoundedVec::<
+						Page,
+						pallet_staking_async::ErasClaimedRewardsBound<T>,
+					>::truncate_from(rewards);
+					expected_claimed_rewards.insert((era, validator.clone()), bounded.into_inner());
+				},
+				ErasValidatorPrefs { era, validator, prefs } => {
+					expected_eras_validator_prefs.insert((era, validator.clone()), prefs);
+				},
+				ErasValidatorReward { era, reward } => {
+					expected_eras_validator_reward.insert(era, reward);
+				},
+				ErasRewardPoints { era, points } => {
+					expected_eras_reward_points.insert(era, points);
+				},
+				ErasTotalStake { era, total_stake } => {
+					expected_eras_total_stake.insert(era, total_stake);
+				},
+				UnappliedSlashes { era, slash } => {
+					let slash_map_key_tuple =
+						(slash.validator.clone(), Perbill::from_percent(99), 9999u32);
+					expected_unapplied_slashes.insert((era, slash_map_key_tuple), slash);
+				},
+				BondedEras(be) => expected_bonded_eras = be,
+				ValidatorSlashInEra { era, validator, slash } => {
+					expected_validator_slash_in_era.insert((era, validator.clone()), slash);
+				},
+				NominatorSlashInEra { era, validator, slash } => {
+					expected_nominator_slash_in_era.insert((era, validator.clone()), slash);
+				},
+				SlashingSpans { account, spans } => {
+					expected_slashing_spans.insert(account, spans);
+				},
+				SpanSlash { account, span, slash } => {
+					expected_span_slash.insert((account, span), slash);
+				},
+			}
+		}
 
-        if let Some(values) = expected_values_opt {
-            let expected_force_era = expected_force_era_opt.expect("Bundled with values");
+		if let Some(values) = expected_values_opt {
+			let expected_force_era = expected_force_era_opt.expect("Bundled with values");
 
-            // Assert storage 'StakingAsync::ValidatorCount::ah_post::consistent'
-            assert_eq!(pallet_staking_async::ValidatorCount::<T>::get(), values.validator_count, "pallet_staking_async::ValidatorCount mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::MinNominatorBond::ah_post::consistent'
-            assert_eq!(pallet_staking_async::MinNominatorBond::<T>::get(), values.min_nominator_bond, "pallet_staking_async::MinNominatorBond mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::MinValidatorBond::ah_post::consistent'
-            assert_eq!(pallet_staking_async::MinValidatorBond::<T>::get(), values.min_validator_bond, "pallet_staking_async::MinValidatorBond mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::MinimumActiveStake::ah_post::consistent'
-            assert_eq!(pallet_staking_async::MinimumActiveStake::<T>::get(), values.min_active_stake, "pallet_staking_async::MinimumActiveStake mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::MinCommission::ah_post::consistent'
-            assert_eq!(pallet_staking_async::MinCommission::<T>::get(), values.min_commission, "pallet_staking_async::MinCommission mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::MaxValidatorsCount::ah_post::consistent'
-            assert_eq!(pallet_staking_async::MaxValidatorsCount::<T>::get(), values.max_validators_count, "pallet_staking_async::MaxValidatorsCount mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::MaxNominatorsCount::ah_post::consistent'
-            assert_eq!(pallet_staking_async::MaxNominatorsCount::<T>::get(), values.max_nominators_count, "pallet_staking_async::MaxNominatorsCount mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::CurrentEra::ah_post::consistent'
-            assert_eq!(pallet_staking_async::CurrentEra::<T>::get(), expected_active_era_opt.clone().map(|a| a.index), "pallet_staking_async::CurrentEra mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::ActiveEra::ah_post::consistent'
-            assert_eq!(pallet_staking_async::ActiveEra::<T>::get(), expected_active_era_opt, "pallet_staking_async::ActiveEra mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::ForceEra::ah_post::consistent'
-            assert_eq!(pallet_staking_async::ForceEra::<T>::get(), expected_force_era, "pallet_staking_async::ForceEra mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::MaxStakedRewards::ah_post::consistent'
-            assert_eq!(pallet_staking_async::MaxStakedRewards::<T>::get(), values.max_staked_rewards, "pallet_staking_async::MaxStakedRewards mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::SlashRewardFraction::ah_post::consistent'
-            assert_eq!(pallet_staking_async::SlashRewardFraction::<T>::get(), values.slash_reward_fraction, "pallet_staking_async::SlashRewardFraction mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::CanceledSlashPayout::ah_post::consistent'
-            assert_eq!(pallet_staking_async::CanceledSlashPayout::<T>::get(), values.canceled_slash_payout, "pallet_staking_async::CanceledSlashPayout mismatch on AH post-migration");
-            // Assert storage 'StakingAsync::ChillThreshold::ah_post::consistent'
-            assert_eq!(pallet_staking_async::ChillThreshold::<T>::get(), values.chill_threshold, "pallet_staking_async::ChillThreshold mismatch on AH post-migration");
-        }
+			// Assert storage 'StakingAsync::ValidatorCount::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::ValidatorCount::<T>::get(),
+				values.validator_count,
+				"pallet_staking_async::ValidatorCount mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::MinNominatorBond::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::MinNominatorBond::<T>::get(),
+				values.min_nominator_bond,
+				"pallet_staking_async::MinNominatorBond mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::MinValidatorBond::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::MinValidatorBond::<T>::get(),
+				values.min_validator_bond,
+				"pallet_staking_async::MinValidatorBond mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::MinimumActiveStake::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::MinimumActiveStake::<T>::get(),
+				values.min_active_stake,
+				"pallet_staking_async::MinimumActiveStake mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::MinCommission::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::MinCommission::<T>::get(),
+				values.min_commission,
+				"pallet_staking_async::MinCommission mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::MaxValidatorsCount::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::MaxValidatorsCount::<T>::get(),
+				values.max_validators_count,
+				"pallet_staking_async::MaxValidatorsCount mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::MaxNominatorsCount::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::MaxNominatorsCount::<T>::get(),
+				values.max_nominators_count,
+				"pallet_staking_async::MaxNominatorsCount mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::CurrentEra::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::CurrentEra::<T>::get(),
+				expected_active_era_opt.clone().map(|a| a.index),
+				"pallet_staking_async::CurrentEra mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::ActiveEra::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::ActiveEra::<T>::get(),
+				expected_active_era_opt,
+				"pallet_staking_async::ActiveEra mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::ForceEra::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::ForceEra::<T>::get(),
+				expected_force_era,
+				"pallet_staking_async::ForceEra mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::MaxStakedRewards::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::MaxStakedRewards::<T>::get(),
+				values.max_staked_rewards,
+				"pallet_staking_async::MaxStakedRewards mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::SlashRewardFraction::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::SlashRewardFraction::<T>::get(),
+				values.slash_reward_fraction,
+				"pallet_staking_async::SlashRewardFraction mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::CanceledSlashPayout::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::CanceledSlashPayout::<T>::get(),
+				values.canceled_slash_payout,
+				"pallet_staking_async::CanceledSlashPayout mismatch on AH post-migration"
+			);
+			// Assert storage 'StakingAsync::ChillThreshold::ah_post::consistent'
+			assert_eq!(
+				pallet_staking_async::ChillThreshold::<T>::get(),
+				values.chill_threshold,
+				"pallet_staking_async::ChillThreshold mismatch on AH post-migration"
+			);
+		}
 
-        // Assert storage 'StakingAsync::Invulnerables::ah_post::consistent'
-        assert_eq!(pallet_staking_async::Invulnerables::<T>::get().into_inner(), expected_invulnerables, "pallet_staking_async::Invulnerables mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::Invulnerables::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::Invulnerables::<T>::get().into_inner(),
+			expected_invulnerables,
+			"pallet_staking_async::Invulnerables mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::BondedEras::ah_post::consistent'
-        assert_eq!(pallet_staking_async::BondedEras::<T>::get().into_inner(), expected_bonded_eras, "pallet_staking_async::BondedEras mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::BondedEras::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::BondedEras::<T>::get().into_inner(),
+			expected_bonded_eras,
+			"pallet_staking_async::BondedEras mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::Bonded::ah_post::length'
-        assert_eq!(pallet_staking_async::Bonded::<T>::iter_keys().count(), expected_bonded.len(), "pallet_staking_async::Bonded map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::Bonded::ah_post::consistent'
-        assert_eq!(pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_,_>>(), expected_bonded, "pallet_staking_async::Bonded map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::Bonded::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::Bonded::<T>::iter_keys().count(),
+			expected_bonded.len(),
+			"pallet_staking_async::Bonded map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::Bonded::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_bonded,
+			"pallet_staking_async::Bonded map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::Ledger::ah_post::length'
-        assert_eq!(pallet_staking_async::Ledger::<T>::iter_keys().count(), expected_ledger.len(), "pallet_staking_async::Ledger map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::Ledger::ah_post::consistent'
-        assert_eq!(pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_,_>>(), expected_ledger, "pallet_staking_async::Ledger map content mismatch on AH post-migration");
-        
-        // Assert storage 'StakingAsync::Payee::ah_post::length'
-        assert_eq!(pallet_staking_async::Payee::<T>::iter_keys().count(), expected_payee.len(), "pallet_staking_async::Payee map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::Payee::ah_post::consistent'
-        assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "pallet_staking_async::Payee map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::Ledger::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::Ledger::<T>::iter_keys().count(),
+			expected_ledger.len(),
+			"pallet_staking_async::Ledger map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::Ledger::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_ledger,
+			"pallet_staking_async::Ledger map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::Validators::ah_post::length'
-        assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "pallet_staking_async::Validators map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::Validators::ah_post::consistent'
-        assert_eq!(pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validators, "pallet_staking_async::Validators map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::Payee::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::Payee::<T>::iter_keys().count(),
+			expected_payee.len(),
+			"pallet_staking_async::Payee map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::Payee::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_payee,
+			"pallet_staking_async::Payee map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::Nominators::ah_post::length'
-        assert_eq!(pallet_staking_async::Nominators::<T>::iter_keys().count(), expected_nominators.len(), "pallet_staking_async::Nominators map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::Nominators::ah_post::consistent'
-        assert_eq!(pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominators, "pallet_staking_async::Nominators map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::Validators::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::Validators::<T>::iter_keys().count(),
+			expected_validators.len(),
+			"pallet_staking_async::Validators map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::Validators::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_validators,
+			"pallet_staking_async::Validators map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::VirtualStakers::ah_post::length'
-        assert_eq!(pallet_staking_async::VirtualStakers::<T>::iter_keys().count(), expected_virtual_stakers.len(), "pallet_staking_async::VirtualStakers length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::VirtualStakers::ah_post::consistent'
-        let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
-        assert_eq!(current_virtual_stakers, expected_virtual_stakers, "pallet_staking_async::VirtualStakers content mismatch on AH post-migration");
-        
-        // Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'
-        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "pallet_staking_async::ErasStakersOverview map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ErasStakersOverview::ah_post::consistent'
-        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().map(|(era, account_id, metadata)| ((era, account_id), metadata)).collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "pallet_staking_async::ErasStakersOverview map content mismatch on AH post-migration");
-        
-        // Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'
-        assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "pallet_staking_async::ErasStakersPaged map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ErasStakersPaged::ah_post::consistent'
-        let current_eras_stakers_paged = pallet_staking_async::ErasStakersPaged::<T>::iter().collect::<BTreeMap<_,_>>();
-        assert_eq!(current_eras_stakers_paged, expected_eras_stakers_paged, "pallet_staking_async::ErasStakersPaged map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::Nominators::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::Nominators::<T>::iter_keys().count(),
+			expected_nominators.len(),
+			"pallet_staking_async::Nominators map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::Nominators::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_nominators,
+			"pallet_staking_async::Nominators map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'
-        assert_eq!(pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(), expected_claimed_rewards.len(), "pallet_staking_async::ErasClaimedRewards map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::consistent'
-        let current_claimed_rewards = pallet_staking_async::ErasClaimedRewards::<T>::iter()
-            .map(|(k1, k2, v_weak_bounded)| ((k1, k2), v_weak_bounded.into_inner()))
-            .collect::<BTreeMap<_,_>>();
-        assert_eq!(current_claimed_rewards, expected_claimed_rewards, "pallet_staking_async::ErasClaimedRewards map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::VirtualStakers::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::VirtualStakers::<T>::iter_keys().count(),
+			expected_virtual_stakers.len(),
+			"pallet_staking_async::VirtualStakers length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::VirtualStakers::ah_post::consistent'
+		let current_virtual_stakers =
+			pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
+		assert_eq!(
+			current_virtual_stakers, expected_virtual_stakers,
+			"pallet_staking_async::VirtualStakers content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'
-        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(), expected_eras_validator_prefs.len(), "pallet_staking_async::ErasValidatorPrefs map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::consistent'
-        assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter().map(|(era, account, prefs)| ((era, account), prefs)).collect::<BTreeMap<_,_>>(), expected_eras_validator_prefs, "pallet_staking_async::ErasValidatorPrefs map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(),
+			expected_eras_stakers_overview.len(),
+			"pallet_staking_async::ErasStakersOverview map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ErasStakersOverview::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::ErasStakersOverview::<T>::iter()
+				.map(|(era, account_id, metadata)| ((era, account_id), metadata))
+				.collect::<BTreeMap<_, _>>(),
+			expected_eras_stakers_overview,
+			"pallet_staking_async::ErasStakersOverview map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'
-        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(), expected_eras_validator_reward.len(), "pallet_staking_async::ErasValidatorReward map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ErasValidatorReward::ah_post::consistent'
-        assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_reward, "pallet_staking_async::ErasValidatorReward map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(),
+			expected_eras_stakers_paged.len(),
+			"pallet_staking_async::ErasStakersPaged map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ErasStakersPaged::ah_post::consistent'
+		let current_eras_stakers_paged =
+			pallet_staking_async::ErasStakersPaged::<T>::iter().collect::<BTreeMap<_, _>>();
+		assert_eq!(
+			current_eras_stakers_paged, expected_eras_stakers_paged,
+			"pallet_staking_async::ErasStakersPaged map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'
-        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(), expected_eras_reward_points.len(), "pallet_staking_async::ErasRewardPoints map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ErasRewardPoints::ah_post::consistent'
-        assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_reward_points, "pallet_staking_async::ErasRewardPoints map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(),
+			expected_claimed_rewards.len(),
+			"pallet_staking_async::ErasClaimedRewards map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::consistent'
+		let current_claimed_rewards = pallet_staking_async::ErasClaimedRewards::<T>::iter()
+			.map(|(k1, k2, v_weak_bounded)| ((k1, k2), v_weak_bounded.into_inner()))
+			.collect::<BTreeMap<_, _>>();
+		assert_eq!(
+			current_claimed_rewards, expected_claimed_rewards,
+			"pallet_staking_async::ErasClaimedRewards map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::ErasTotalStake::ah_post::length'
-        assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter_keys().count(), expected_eras_total_stake.len(), "pallet_staking_async::ErasTotalStake map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ErasTotalStake::ah_post::consistent'
-        assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_total_stake, "pallet_staking_async::ErasTotalStake map content mismatch on AH post-migration");
-        
-        // Assert storage 'StakingAsync::UnappliedSlashes::ah_post::length'
-        assert_eq!(pallet_staking_async::UnappliedSlashes::<T>::iter_keys().count(), expected_unapplied_slashes.len(), "pallet_staking_async::UnappliedSlashes map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::UnappliedSlashes::ah_post::consistent'
-        let current_unapplied_slashes = pallet_staking_async::UnappliedSlashes::<T>::iter()
-            .map(|(k1_era, k2_tuple, v_slash)| ((k1_era, k2_tuple), v_slash))
-            .collect::<BTreeMap<_,_>>();
-        assert_eq!(current_unapplied_slashes, expected_unapplied_slashes, "pallet_staking_async::UnappliedSlashes map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(),
+			expected_eras_validator_prefs.len(),
+			"pallet_staking_async::ErasValidatorPrefs map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::ErasValidatorPrefs::<T>::iter()
+				.map(|(era, account, prefs)| ((era, account), prefs))
+				.collect::<BTreeMap<_, _>>(),
+			expected_eras_validator_prefs,
+			"pallet_staking_async::ErasValidatorPrefs map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::length'
-        assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter_keys().count(), expected_validator_slash_in_era.len(), "pallet_staking_async::ValidatorSlashInEra map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::consistent'
-        assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter().map(|(era, account, slash)| ((era, account), slash)).collect::<BTreeMap<_,_>>(), expected_validator_slash_in_era, "pallet_staking_async::ValidatorSlashInEra map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(),
+			expected_eras_validator_reward.len(),
+			"pallet_staking_async::ErasValidatorReward map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ErasValidatorReward::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_eras_validator_reward,
+			"pallet_staking_async::ErasValidatorReward map content mismatch on AH post-migration"
+		);
 
-        // Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::length'
-        assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter_keys().count(), expected_nominator_slash_in_era.len(), "pallet_staking_async::NominatorSlashInEra map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::consistent'
-        assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter().map(|(era, account, balance)| ((era, account), balance)).collect::<BTreeMap<_,_>>(), expected_nominator_slash_in_era, "pallet_staking_async::NominatorSlashInEra map content mismatch on AH post-migration");
+		// Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(),
+			expected_eras_reward_points.len(),
+			"pallet_staking_async::ErasRewardPoints map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ErasRewardPoints::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_eras_reward_points,
+			"pallet_staking_async::ErasRewardPoints map content mismatch on AH post-migration"
+		);
 
-        // SlashSpans gone in latest polkadot-sdk master branch
-        // Assert storage 'StakingAsync::SlashingSpans::ah_post::length'
-        assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter_keys().count(), expected_slashing_spans.len(), "pallet_staking_async::SlashingSpans map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::SlashingSpans::ah_post::consistent'
-        assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter().collect::<BTreeMap<_,_>>(), expected_slashing_spans, "pallet_staking_async::SlashingSpans map content mismatch on AH post-migration");
-        
-        // Assert storage 'StakingAsync::SpanSlash::ah_post::length'
-        assert_eq!(pallet_staking_async::SpanSlash::<T>::iter_keys().count(), expected_span_slash.len(), "pallet_staking_async::SpanSlash map length mismatch on AH post-migration");
-        // Assert storage 'StakingAsync::SpanSlash::ah_post::consistent'
-        assert_eq!(pallet_staking_async::SpanSlash::<T>::iter().collect::<BTreeMap<_,_>>(), expected_span_slash, "pallet_staking_async::SpanSlash map content mismatch on AH post-migration");
-    }
+		// Assert storage 'StakingAsync::ErasTotalStake::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ErasTotalStake::<T>::iter_keys().count(),
+			expected_eras_total_stake.len(),
+			"pallet_staking_async::ErasTotalStake map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ErasTotalStake::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::ErasTotalStake::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_eras_total_stake,
+			"pallet_staking_async::ErasTotalStake map content mismatch on AH post-migration"
+		);
+
+		// Assert storage 'StakingAsync::UnappliedSlashes::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::UnappliedSlashes::<T>::iter_keys().count(),
+			expected_unapplied_slashes.len(),
+			"pallet_staking_async::UnappliedSlashes map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::UnappliedSlashes::ah_post::consistent'
+		let current_unapplied_slashes = pallet_staking_async::UnappliedSlashes::<T>::iter()
+			.map(|(k1_era, k2_tuple, v_slash)| ((k1_era, k2_tuple), v_slash))
+			.collect::<BTreeMap<_, _>>();
+		assert_eq!(
+			current_unapplied_slashes, expected_unapplied_slashes,
+			"pallet_staking_async::UnappliedSlashes map content mismatch on AH post-migration"
+		);
+
+		// Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::ValidatorSlashInEra::<T>::iter_keys().count(),
+			expected_validator_slash_in_era.len(),
+			"pallet_staking_async::ValidatorSlashInEra map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::ValidatorSlashInEra::<T>::iter()
+				.map(|(era, account, slash)| ((era, account), slash))
+				.collect::<BTreeMap<_, _>>(),
+			expected_validator_slash_in_era,
+			"pallet_staking_async::ValidatorSlashInEra map content mismatch on AH post-migration"
+		);
+
+		// Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::NominatorSlashInEra::<T>::iter_keys().count(),
+			expected_nominator_slash_in_era.len(),
+			"pallet_staking_async::NominatorSlashInEra map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::NominatorSlashInEra::<T>::iter()
+				.map(|(era, account, balance)| ((era, account), balance))
+				.collect::<BTreeMap<_, _>>(),
+			expected_nominator_slash_in_era,
+			"pallet_staking_async::NominatorSlashInEra map content mismatch on AH post-migration"
+		);
+
+		// SlashSpans gone in latest polkadot-sdk master branch
+		// Assert storage 'StakingAsync::SlashingSpans::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::SlashingSpans::<T>::iter_keys().count(),
+			expected_slashing_spans.len(),
+			"pallet_staking_async::SlashingSpans map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::SlashingSpans::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::SlashingSpans::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_slashing_spans,
+			"pallet_staking_async::SlashingSpans map content mismatch on AH post-migration"
+		);
+
+		// Assert storage 'StakingAsync::SpanSlash::ah_post::length'
+		assert_eq!(
+			pallet_staking_async::SpanSlash::<T>::iter_keys().count(),
+			expected_span_slash.len(),
+			"pallet_staking_async::SpanSlash map length mismatch on AH post-migration"
+		);
+		// Assert storage 'StakingAsync::SpanSlash::ah_post::consistent'
+		assert_eq!(
+			pallet_staking_async::SpanSlash::<T>::iter().collect::<BTreeMap<_, _>>(),
+			expected_span_slash,
+			"pallet_staking_async::SpanSlash map content mismatch on AH post-migration"
+		);
+	}
 }

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -158,27 +158,456 @@ impl<T: Config> Pallet<T> {
 
 #[cfg(all(feature = "std", feature = "ahm-staking-migration"))]
 impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::StakingMigrator<T> {
-	// use pallet_rc_migrator::staking::RcPrePayload;
 	
 	type RcPrePayload = Vec<T::RcStakingMessage>;
 	type AhPrePayload = ();
 
 	fn pre_check(_rc_pre_payload: Self::RcPrePayload) -> Self::AhPrePayload {
+        // "Assert storage 'StakingAsync::ValidatorCount::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::ValidatorCount::<T>::get(),
+            0,
+            "StakingAsync::ValidatorCount should be 0 on AH before migration"
+        );
 
-	}
+        // "Assert storage 'StakingAsync::MinNominatorBond::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::MinNominatorBond::<T>::get(),
+            Default::default(),
+            "StakingAsync::MinNominatorBond should be default on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::MinValidatorBond::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::MinValidatorBond::<T>::get(),
+            Default::default(),
+            "StakingAsync::MinValidatorBond should be default on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::MinimumActiveStake::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::MinimumActiveStake::<T>::get(),
+            Default::default(),
+            "StakingAsync::MinimumActiveStake should be default on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::MinCommission::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::MinCommission::<T>::get(),
+            Default::default(),
+            "StakingAsync::MinCommission should be default on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::MaxValidatorsCount::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::MaxValidatorsCount::<T>::get(),
+            None,
+            "StakingAsync::MaxValidatorsCount should be None on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::MaxNominatorsCount::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::MaxNominatorsCount::<T>::get(),
+            None,
+            "StakingAsync::MaxNominatorsCount should be None on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::CurrentEra::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::CurrentEra::<T>::get(),
+            None,
+            "StakingAsync::CurrentEra should be None on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ActiveEra::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::ActiveEra::<T>::get(),
+            None,
+            "StakingAsync::ActiveEra should be None on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ForceEra::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::ForceEra::<T>::get(),
+            Default::default(), // Assumes Forcing::NotForcing or similar is default
+            "StakingAsync::ForceEra should be default on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::MaxStakedRewards::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::MaxStakedRewards::<T>::get(),
+            None,
+            "StakingAsync::MaxStakedRewards should be None on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::SlashRewardFraction::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::SlashRewardFraction::<T>::get(),
+            Default::default(),
+            "StakingAsync::SlashRewardFraction should be default on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::CanceledSlashPayout::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::CanceledSlashPayout::<T>::get(),
+            Default::default(),
+            "StakingAsync::CanceledSlashPayout should be default on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ChillThreshold::ah_pre::empty'"
+        assert_eq!(
+            pallet_staking_async::ChillThreshold::<T>::get(),
+            None,
+            "StakingAsync::ChillThreshold should be None on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::Invulnerables::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::Invulnerables::<T>::get().is_empty(),
+            "StakingAsync::Invulnerables should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::BondedEras::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::BondedEras::<T>::get().is_empty(),
+            "StakingAsync::BondedEras should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::Bonded::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::Bonded::<T>::iter().next().is_none(),
+            "StakingAsync::Bonded map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::Ledger::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::Ledger::<T>::iter().next().is_none(),
+            "StakingAsync::Ledger map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::Payee::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::Payee::<T>::iter().next().is_none(),
+            "StakingAsync::Payee map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::Validators::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::Validators::<T>::iter().next().is_none(),
+            "StakingAsync::Validators map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::Nominators::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::Nominators::<T>::iter().next().is_none(),
+            "StakingAsync::Nominators map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::VirtualStakers::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::VirtualStakers::<T>::iter().next().is_none(),
+            "StakingAsync::VirtualStakers map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasStartSessionIndex::<T>::iter().next().is_none(),
+            "StakingAsync::ErasStartSessionIndex map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasStakersOverview::<T>::iter().next().is_none(),
+            "StakingAsync::ErasStakersOverview map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasStakersPaged::<T>::iter().next().is_none(),
+            "StakingAsync::ErasStakersPaged map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasClaimedRewards::<T>::iter().next().is_none(),
+            "StakingAsync::ErasClaimedRewards map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasValidatorPrefs::<T>::iter().next().is_none(),
+            "StakingAsync::ErasValidatorPrefs map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasValidatorReward::<T>::iter().next().is_none(),
+            "StakingAsync::ErasValidatorReward map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasRewardPoints::<T>::iter().next().is_none(),
+            "StakingAsync::ErasRewardPoints map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ErasTotalStake::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ErasTotalStake::<T>::iter().next().is_none(),
+            "StakingAsync::ErasTotalStake map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::UnappliedSlashes::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::UnappliedSlashes::<T>::iter().next().is_none(),
+            "StakingAsync::UnappliedSlashes map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::ValidatorSlashInEra::<T>::iter().next().is_none(),
+            "StakingAsync::ValidatorSlashInEra map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::NominatorSlashInEra::<T>::iter().next().is_none(),
+            "StakingAsync::NominatorSlashInEra map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::SlashingSpans::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::SlashingSpans::<T>::iter().next().is_none(),
+            "StakingAsync::SlashingSpans map should be empty on AH before migration"
+        );
+
+        // "Assert storage 'StakingAsync::SpanSlash::ah_pre::empty'"
+        assert!(
+            pallet_staking_async::SpanSlash::<T>::iter().next().is_none(),
+            "StakingAsync::SpanSlash map should be empty on AH before migration"
+        );
+    }
 
 	fn post_check(rc_pre_payload: Self::RcPrePayload, _ah_pre_payload: Self::AhPrePayload) {
-		use RcStakingMessage::*;
+        use sp_staking::{EraIndex, Page, SessionIndex, 
+            // SpanIndex,
+        };
+        use sp_runtime::{Perbill, Percent};
+        use std::collections::{BTreeMap, HashSet};
+        use frame_support::BoundedVec;
 
-		let ledgers: Vec<_> = rc_pre_payload.into_iter().map(|message| match T::RcStakingMessage::intoAh(message) {
-			Ledger { controller, ledger } => {
-				(controller, ledger)
-			},
-			_ => todo!(),
-		}).collect();
+        type AccountId<T> = <T as frame_system::Config>::AccountId;
+        type Balance<T> = <T as pallet_staking_async::Config>::CurrencyBalance;
+        type StakingLedgerAsync<T> = pallet_staking_async::StakingLedger<T>;
+        type NominationsAsync<T> = pallet_staking_async::Nominations<T>;
+        type SpanRecordAsync<T> = pallet_staking_async::slashing::SpanRecord<Balance<T>>;
+        type EraRewardPointsAsync<T> = pallet_staking_async::EraRewardPoints<T>;
+        type RewardDestinationAsync<T> = pallet_staking_async::RewardDestination<AccountId<T>>;
+        type ValidatorPrefsAsync = pallet_staking_async::ValidatorPrefs;
+        type UnappliedSlashAsync<T> = pallet_staking_async::UnappliedSlash<T>;
+        type SlashingSpansAsync = pallet_staking_async::slashing::SlashingSpans;
+        type PagedExposureMetadataAsync<T> = sp_staking::PagedExposureMetadata<Balance<T>>;
+        type ExposurePageAsync<T> = pallet_staking_async::BoundedExposurePage<T>;
+        type AhStakingValues<T> = pallet_rc_migrator::staking::message::AhStakingValuesOf<T>;
+        type ActiveEraInfoAsync = pallet_staking_async::ActiveEraInfo;
+        type ForcingAsync = pallet_staking_async::Forcing;
 
-		let x = pallet_staking_async::Ledger::<T>::iter().collect::<Vec<_>>().len();
+    //     let mut expected_values_opt: Option<AhStakingValues<T>> = None;
+    //     let mut expected_invulnerables: Vec<AccountId<T>> = Vec::new();
+    //     let mut expected_bonded: BTreeMap<AccountId<T>, AccountId<T>> = BTreeMap::new();
+    //     let mut expected_ledger: BTreeMap<AccountId<T>, StakingLedgerAsync<T>> = BTreeMap::new();
+    //     let mut expected_payee: BTreeMap<AccountId<T>, RewardDestinationAsync<T>> = BTreeMap::new();
+    //     let mut expected_validators: BTreeMap<AccountId<T>, ValidatorPrefsAsync> = BTreeMap::new();
+    //     let mut expected_nominators: BTreeMap<AccountId<T>, NominationsAsync<T>> = BTreeMap::new();
+    //     let mut expected_virtual_stakers: HashSet<AccountId<T>> = HashSet::new();
+    //     let mut expected_eras_start_session_index: BTreeMap<EraIndex, SessionIndex> = BTreeMap::new();
+    //     let mut expected_eras_stakers_overview: BTreeMap<(EraIndex, AccountId<T>), PagedExposureMetadataAsync<T>> = BTreeMap::new();
+    //     let mut expected_eras_stakers_paged: BTreeMap<(EraIndex, AccountId<T>, Page), ExposurePageAsync<T>> = BTreeMap::new();
+    //     let mut expected_claimed_rewards: BTreeMap<(EraIndex, AccountId<T>), Vec<Page>> = BTreeMap::new();
+    //     let mut expected_eras_validator_prefs: BTreeMap<(EraIndex, AccountId<T>), ValidatorPrefsAsync> = BTreeMap::new();
+    //     let mut expected_eras_validator_reward: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
+    //     let mut expected_eras_reward_points: BTreeMap<EraIndex, EraRewardPointsAsync<T>> = BTreeMap::new();
+    //     let mut expected_eras_total_stake: BTreeMap<EraIndex, Balance<T>> = BTreeMap::new();
+    //     let mut expected_unapplied_slashes: BTreeMap<(EraIndex, (AccountId<T>, Perbill, u32)), UnappliedSlashAsync<T>> = BTreeMap::new();
+    //     let mut expected_bonded_eras: Vec<(EraIndex, SessionIndex)> = Vec::new();
+    //     let mut expected_validator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), (Perbill, Balance<T>)> = BTreeMap::new();
+    //     let mut expected_nominator_slash_in_era: BTreeMap<(EraIndex, AccountId<T>), Balance<T>> = BTreeMap::new();
+    //     let mut expected_slashing_spans: BTreeMap<AccountId<T>, SlashingSpansAsync> = BTreeMap::new();
+    // //     let mut expected_span_slash: BTreeMap<(AccountId<T>, SpanIndex), SpanRecordAsync<T>> = BTreeMap::new();
 
-		assert_eq!(x as u32, ledgers.len() as u32);
-	}
+    //     for rc_message in rc_pre_payload {
+    //         let ah_message = T::RcStakingMessage::intoAh(rc_message);
+    //         use pallet_rc_migrator::staking::message::RcStakingMessage::*;
+    //         match ah_message {
+    //             Values(v) => expected_values_opt = Some(v),
+    //             Invulnerables(inv) => expected_invulnerables = inv,
+    //             Bonded { stash, controller } => { expected_bonded.insert(stash, controller); },
+    //             Ledger { controller, ledger } => { expected_ledger.insert(controller, ledger); },
+    //             Payee { stash, payment } => { expected_payee.insert(stash, payment); },
+    //             Validators { stash, validators } => { expected_validators.insert(stash, validators); },
+    //             Nominators { stash, nominations } => { expected_nominators.insert(stash, nominations); },
+    //             VirtualStakers(staker) => { expected_virtual_stakers.insert(staker); },
+    //             ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
+    //             ErasStakersOverview { era, validator, exposure } => { expected_eras_stakers_overview.insert((era, validator.clone()), exposure); },
+    //             ErasStakersPaged { era, validator, page, exposure } => { expected_eras_stakers_paged.insert((era, validator.clone(), page), exposure.into()); },
+    //             ClaimedRewards { era, validator, rewards } => { expected_claimed_rewards.insert((era, validator.clone()), rewards); },
+    //             ErasValidatorPrefs { era, validator, prefs } => { expected_eras_validator_prefs.insert((era, validator.clone()), prefs); },
+    //             ErasValidatorReward { era, reward } => { expected_eras_validator_reward.insert(era, reward); },
+    //             ErasRewardPoints { era, points } => { expected_eras_reward_points.insert(era, points); },
+    //             ErasTotalStake { era, total_stake } => { expected_eras_total_stake.insert(era, total_stake); },
+    //             UnappliedSlashes { era, slash } => {
+    //                 let slash_map_key_tuple = (slash.validator.clone(), Perbill::from_percent(99), 9999u32);
+    //                 expected_unapplied_slashes.insert((era, slash_map_key_tuple), slash);
+    //             },
+    //             BondedEras(be) => expected_bonded_eras = be,
+    //             ValidatorSlashInEra { era, validator, slash } => { expected_validator_slash_in_era.insert((era, validator.clone()), slash); },
+    //             NominatorSlashInEra { era, validator, slash } => { expected_nominator_slash_in_era.insert((era, validator.clone()), slash); },
+    //             SlashingSpans { account, spans } => { expected_slashing_spans.insert(account, spans); },
+    // //            SpanSlash { account, span, slash } => { expected_span_slash.insert((account, span), slash); },
+    //             _ => todo!(), // Spanslash removes from master branch
+    //         }
+    //     }
+
+    //     if let Some(values) = expected_values_opt {
+    //         // "Assert storage 'StakingAsync::ValidatorCount::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::ValidatorCount::<T>::get(), values.validator_count, "StakingAsync::ValidatorCount mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::MinNominatorBond::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::MinNominatorBond::<T>::get(), values.min_nominator_bond, "StakingAsync::MinNominatorBond mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::MinValidatorBond::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::MinValidatorBond::<T>::get(), values.min_validator_bond, "StakingAsync::MinValidatorBond mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::MinimumActiveStake::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::MinimumActiveStake::<T>::get(), values.min_active_stake, "StakingAsync::MinimumActiveStake mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::MinCommission::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::MinCommission::<T>::get(), values.min_commission, "StakingAsync::MinCommission mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::MaxValidatorsCount::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::MaxValidatorsCount::<T>::get(), values.max_validators_count, "StakingAsync::MaxValidatorsCount mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::MaxNominatorsCount::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::MaxNominatorsCount::<T>::get(), values.max_nominators_count, "StakingAsync::MaxNominatorsCount mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::CurrentEra::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::CurrentEra::<T>::get(), values.current_era, "StakingAsync::CurrentEra mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::ActiveEra::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::ActiveEra::<T>::get(), values.active_era, "StakingAsync::ActiveEra mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::ForceEra::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::ForceEra::<T>::get(), values.force_era, "StakingAsync::ForceEra mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::MaxStakedRewards::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::MaxStakedRewards::<T>::get(), values.max_staked_rewards, "StakingAsync::MaxStakedRewards mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::SlashRewardFraction::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::SlashRewardFraction::<T>::get(), values.slash_reward_fraction, "StakingAsync::SlashRewardFraction mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::CanceledSlashPayout::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::CanceledSlashPayout::<T>::get(), values.canceled_slash_payout, "StakingAsync::CanceledSlashPayout mismatch on AH post-migration");
+    //         // "Assert storage 'StakingAsync::ChillThreshold::ah_post::correct'"
+    //         assert_eq!(pallet_staking_async::ChillThreshold::<T>::get(), values.chill_threshold, "StakingAsync::ChillThreshold mismatch on AH post-migration");
+    //     }
+
+    //     // "Assert storage 'StakingAsync::Invulnerables::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::Invulnerables::<T>::get().into_inner(), expected_invulnerables, "StakingAsync::Invulnerables mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::BondedEras::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::BondedEras::<T>::get().into_inner(), expected_bonded_eras, "StakingAsync::BondedEras mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::Bonded::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::Bonded::<T>::iter_keys().count(), expected_bonded.len(), "StakingAsync::Bonded map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::Bonded::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_,_>>(), expected_bonded, "StakingAsync::Bonded map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::Ledger::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::Ledger::<T>::iter_keys().count(), expected_ledger.len(), "StakingAsync::Ledger map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::Ledger::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_,_>>(), expected_ledger, "StakingAsync::Ledger map content mismatch on AH post-migration");
+        
+    //     // "Assert storage 'StakingAsync::Payee::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::Payee::<T>::iter_keys().count(), expected_payee.len(), "StakingAsync::Payee map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::Payee::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "StakingAsync::Payee map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::Validators::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "StakingAsync::Validators map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::Validators::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validators, "StakingAsync::Validators map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::Nominators::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::Nominators::<T>::iter_keys().count(), expected_nominators.len(), "StakingAsync::Nominators map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::Nominators::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominators, "StakingAsync::Nominators map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::VirtualStakers::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::VirtualStakers::<T>::iter_keys().count(), expected_virtual_stakers.len(), "StakingAsync::VirtualStakers length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::VirtualStakers::ah_post::correct'"
+    //     let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
+    //     assert_eq!(current_virtual_stakers, expected_virtual_stakers, "StakingAsync::VirtualStakers content mismatch on AH post-migration");
+        
+    //     // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter_keys().count(), expected_eras_start_session_index.len(), "StakingAsync::ErasStartSessionIndex map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_start_session_index, "StakingAsync::ErasStartSessionIndex map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "StakingAsync::ErasStakersOverview map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "StakingAsync::ErasStakersOverview map content mismatch on AH post-migration");
+        
+    //     // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "StakingAsync::ErasStakersPaged map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::correct'"
+    //     let current_eras_stakers_paged = pallet_staking_async::ErasStakersPaged::<T>::iter()
+    //         .map(|(k, v_bounded)| (k, v_bounded.0))
+    //         .collect::<BTreeMap<_,_>>();
+    //     assert_eq!(current_eras_stakers_paged, expected_eras_stakers_paged, "StakingAsync::ErasStakersPaged map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(), expected_claimed_rewards.len(), "StakingAsync::ErasClaimedRewards map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::correct'"
+    //     let current_claimed_rewards = pallet_staking_async::ErasClaimedRewards::<T>::iter()
+    //         .map(|(k1, k2, v_weak_bounded)| ((k1, k2), v_weak_bounded.into_inner()))
+    //         .collect::<BTreeMap<_,_>>();
+    //     assert_eq!(current_claimed_rewards, expected_claimed_rewards, "StakingAsync::ErasClaimedRewards map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(), expected_eras_validator_prefs.len(), "StakingAsync::ErasValidatorPrefs map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_prefs, "StakingAsync::ErasValidatorPrefs map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(), expected_eras_validator_reward.len(), "StakingAsync::ErasValidatorReward map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_reward, "StakingAsync::ErasValidatorReward map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(), expected_eras_reward_points.len(), "StakingAsync::ErasRewardPoints map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_reward_points, "StakingAsync::ErasRewardPoints map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter_keys().count(), expected_eras_total_stake.len(), "StakingAsync::ErasTotalStake map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_total_stake, "StakingAsync::ErasTotalStake map content mismatch on AH post-migration");
+        
+    //     // "Assert storage 'StakingAsync::UnappliedSlashes::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::UnappliedSlashes::<T>::iter_keys().count(), expected_unapplied_slashes.len(), "StakingAsync::UnappliedSlashes map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::UnappliedSlashes::ah_post::correct'"
+    //     let current_unapplied_slashes = pallet_staking_async::UnappliedSlashes::<T>::iter()
+    //         .map(|(k1_era, k2_tuple, v_slash)| ((k1_era, k2_tuple), v_slash))
+    //         .collect::<BTreeMap<_,_>>();
+    //     assert_eq!(current_unapplied_slashes, expected_unapplied_slashes, "StakingAsync::UnappliedSlashes map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter_keys().count(), expected_validator_slash_in_era.len(), "StakingAsync::ValidatorSlashInEra map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validator_slash_in_era, "StakingAsync::ValidatorSlashInEra map content mismatch on AH post-migration");
+
+    //     // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter_keys().count(), expected_nominator_slash_in_era.len(), "StakingAsync::NominatorSlashInEra map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominator_slash_in_era, "StakingAsync::NominatorSlashInEra map content mismatch on AH post-migration");
+
+    // //     // "Assert storage 'StakingAsync::SlashingSpans::ah_post::length'"
+    // //     assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter_keys().count(), expected_slashing_spans.len(), "StakingAsync::SlashingSpans map length mismatch on AH post-migration");
+    // //     // "Assert storage 'StakingAsync::SlashingSpans::ah_post::correct'"
+    // //     assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter().collect::<BTreeMap<_,_>>(), expected_slashing_spans, "StakingAsync::SlashingSpans map content mismatch on AH post-migration");
+        
+    //     // "Assert storage 'StakingAsync::SpanSlash::ah_post::length'"
+    //     assert_eq!(pallet_staking_async::SpanSlash::<T>::iter_keys().count(), expected_span_slash.len(), "StakingAsync::SpanSlash map length mismatch on AH post-migration");
+    //     // "Assert storage 'StakingAsync::SpanSlash::ah_post::correct'"
+    //     assert_eq!(pallet_staking_async::SpanSlash::<T>::iter().collect::<BTreeMap<_,_>>(), expected_span_slash, "StakingAsync::SpanSlash map content mismatch on AH post-migration");
+    }
 }

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -17,7 +17,6 @@
 //! Pallet staking migration.
 
 use crate::*;
-use frame_support::traits::DefensiveTruncateInto;
 use sp_runtime::Perbill;
 
 impl<T: Config> Pallet<T> {
@@ -383,7 +382,7 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
 
 	fn post_check(rc_pre_payload: Self::RcPrePayload, _ah_pre_payload: Self::AhPrePayload) {
         use sp_staking::{EraIndex, Page, SessionIndex};
-        use sp_runtime::{Perbill, Percent};
+        use sp_runtime::Perbill;
         use std::collections::{BTreeMap, HashSet};
         use frame_support::BoundedVec;
 
@@ -405,8 +404,8 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         type SpanIndex = u32;
 
         let mut expected_values_opt: Option<AhStakingValues<T>> = None;
-        let mut expected_active_era_opt: Option<pallet_staking_async::ActiveEraInfo> = None;
-        let mut expected_force_era_opt: Option<pallet_staking_async::Forcing> = None;
+        let mut expected_active_era_opt: Option<ActiveEraInfoAsync> = None;
+        let mut expected_force_era_opt: Option<ForcingAsync> = None;
         let mut expected_invulnerables: Vec<AccountId<T>> = Vec::new();
         let mut expected_bonded: BTreeMap<AccountId<T>, AccountId<T>> = BTreeMap::new();
         let mut expected_ledger: BTreeMap<AccountId<T>, StakingLedgerAsync<T>> = BTreeMap::new();
@@ -414,7 +413,6 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         let mut expected_validators: BTreeMap<AccountId<T>, ValidatorPrefsAsync> = BTreeMap::new();
         let mut expected_nominators: BTreeMap<AccountId<T>, NominationsAsync<T>> = BTreeMap::new();
         let mut expected_virtual_stakers: HashSet<AccountId<T>> = HashSet::new();
-        let mut expected_eras_start_session_index: BTreeMap<EraIndex, SessionIndex> = BTreeMap::new();
         let mut expected_eras_stakers_overview: BTreeMap<(EraIndex, AccountId<T>), PagedExposureMetadataAsync<T>> = BTreeMap::new();
         let mut expected_eras_stakers_paged: BTreeMap<(EraIndex, AccountId<T>, Page), ExposurePageAsync<T>> = BTreeMap::new();
         let mut expected_claimed_rewards: BTreeMap<(EraIndex, AccountId<T>), Vec<Page>> = BTreeMap::new();

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -521,31 +521,32 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         // "Assert storage 'StakingAsync::Payee::ah_post::correct'"
         assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "StakingAsync::Payee map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::Validators::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "StakingAsync::Validators map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::Validators::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validators, "StakingAsync::Validators map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Validators::ah_post::length'"
+        assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "StakingAsync::Validators map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Validators::ah_post::correct'"
+        assert_eq!(pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validators, "StakingAsync::Validators map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::Nominators::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::Nominators::<T>::iter_keys().count(), expected_nominators.len(), "StakingAsync::Nominators map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::Nominators::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominators, "StakingAsync::Nominators map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Nominators::ah_post::length'"
+        assert_eq!(pallet_staking_async::Nominators::<T>::iter_keys().count(), expected_nominators.len(), "StakingAsync::Nominators map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Nominators::ah_post::correct'"
+        assert_eq!(pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominators, "StakingAsync::Nominators map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::VirtualStakers::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::VirtualStakers::<T>::iter_keys().count(), expected_virtual_stakers.len(), "StakingAsync::VirtualStakers length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::VirtualStakers::ah_post::correct'"
-    //     let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
-    //     assert_eq!(current_virtual_stakers, expected_virtual_stakers, "StakingAsync::VirtualStakers content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::VirtualStakers::ah_post::length'"
+        assert_eq!(pallet_staking_async::VirtualStakers::<T>::iter_keys().count(), expected_virtual_stakers.len(), "StakingAsync::VirtualStakers length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::VirtualStakers::ah_post::correct'"
+        let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
+        assert_eq!(current_virtual_stakers, expected_virtual_stakers, "StakingAsync::VirtualStakers content mismatch on AH post-migration");
         
-    // //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::length'"
-    // //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter_keys().count(), expected_eras_start_session_index.len(), "StakingAsync::ErasStartSessionIndex map length mismatch on AH post-migration");
-    // //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::correct'"
-    // //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_start_session_index, "StakingAsync::ErasStartSessionIndex map content mismatch on AH post-migration");
+        // No longer migrated
+    //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::length'"
+    //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter_keys().count(), expected_eras_start_session_index.len(), "StakingAsync::ErasStartSessionIndex map length mismatch on AH post-migration");
+    //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::correct'"
+    //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_start_session_index, "StakingAsync::ErasStartSessionIndex map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "StakingAsync::ErasStakersOverview map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "StakingAsync::ErasStakersOverview map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'"
+        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "StakingAsync::ErasStakersOverview map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::correct'"
+        assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().map(|(era, account_id, metadata)| ((era, account_id), metadata)).collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "StakingAsync::ErasStakersOverview map content mismatch on AH post-migration");
         
     //     // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'"
     //     assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "StakingAsync::ErasStakersPaged map length mismatch on AH post-migration");
@@ -601,6 +602,7 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
     //     // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::correct'"
     //     assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominator_slash_in_era, "StakingAsync::NominatorSlashInEra map content mismatch on AH post-migration");
 
+    // SlashSpans gone in latest polkadot-sdk master branch
     // //     // "Assert storage 'StakingAsync::SlashingSpans::ah_post::length'"
     // //     assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter_keys().count(), expected_slashing_spans.len(), "StakingAsync::SlashingSpans map length mismatch on AH post-migration");
     // //     // "Assert storage 'StakingAsync::SlashingSpans::ah_post::correct'"

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -308,12 +308,6 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
             "StakingAsync::VirtualStakers map should be empty on AH before migration"
         );
 
-        // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_pre::empty'"
-        assert!(
-            pallet_staking_async::ErasStartSessionIndex::<T>::iter().next().is_none(),
-            "StakingAsync::ErasStartSessionIndex map should be empty on AH before migration"
-        );
-
         // "Assert storage 'StakingAsync::ErasStakersOverview::ah_pre::empty'"
         assert!(
             pallet_staking_async::ErasStakersOverview::<T>::iter().next().is_none(),
@@ -446,7 +440,7 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
     //             Validators { stash, validators } => { expected_validators.insert(stash, validators); },
     //             Nominators { stash, nominations } => { expected_nominators.insert(stash, nominations); },
     //             VirtualStakers(staker) => { expected_virtual_stakers.insert(staker); },
-    //             ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
+    // //             ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
     //             ErasStakersOverview { era, validator, exposure } => { expected_eras_stakers_overview.insert((era, validator.clone()), exposure); },
     //             ErasStakersPaged { era, validator, page, exposure } => { expected_eras_stakers_paged.insert((era, validator.clone(), page), exposure.into()); },
     //             ClaimedRewards { era, validator, rewards } => { expected_claimed_rewards.insert((era, validator.clone()), rewards); },
@@ -535,10 +529,10 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
     //     let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
     //     assert_eq!(current_virtual_stakers, expected_virtual_stakers, "StakingAsync::VirtualStakers content mismatch on AH post-migration");
         
-    //     // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter_keys().count(), expected_eras_start_session_index.len(), "StakingAsync::ErasStartSessionIndex map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_start_session_index, "StakingAsync::ErasStartSessionIndex map content mismatch on AH post-migration");
+    // //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::length'"
+    // //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter_keys().count(), expected_eras_start_session_index.len(), "StakingAsync::ErasStartSessionIndex map length mismatch on AH post-migration");
+    // //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::correct'"
+    // //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_start_session_index, "StakingAsync::ErasStartSessionIndex map content mismatch on AH post-migration");
 
     //     // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'"
     //     assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "StakingAsync::ErasStakersOverview map length mismatch on AH post-migration");

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -468,7 +468,7 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         }
 
         if let Some(values) = expected_values_opt {
-            let expected_force_era = expected_force_era_opt.expect("Bundled with values above");
+            let expected_force_era = expected_force_era_opt.expect("Bundled with values");
 
             // "Assert storage 'StakingAsync::ValidatorCount::ah_post::correct'"
             assert_eq!(pallet_staking_async::ValidatorCount::<T>::get(), values.validator_count, "StakingAsync::ValidatorCount mismatch on AH post-migration");
@@ -500,26 +500,26 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
             assert_eq!(pallet_staking_async::ChillThreshold::<T>::get(), values.chill_threshold, "StakingAsync::ChillThreshold mismatch on AH post-migration");
         }
 
-    //     // "Assert storage 'StakingAsync::Invulnerables::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::Invulnerables::<T>::get().into_inner(), expected_invulnerables, "StakingAsync::Invulnerables mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Invulnerables::ah_post::correct'"
+        assert_eq!(pallet_staking_async::Invulnerables::<T>::get().into_inner(), expected_invulnerables, "StakingAsync::Invulnerables mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::BondedEras::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::BondedEras::<T>::get().into_inner(), expected_bonded_eras, "StakingAsync::BondedEras mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::BondedEras::ah_post::correct'"
+        assert_eq!(pallet_staking_async::BondedEras::<T>::get().into_inner(), expected_bonded_eras, "StakingAsync::BondedEras mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::Bonded::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::Bonded::<T>::iter_keys().count(), expected_bonded.len(), "StakingAsync::Bonded map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::Bonded::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_,_>>(), expected_bonded, "StakingAsync::Bonded map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Bonded::ah_post::length'"
+        assert_eq!(pallet_staking_async::Bonded::<T>::iter_keys().count(), expected_bonded.len(), "StakingAsync::Bonded map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Bonded::ah_post::correct'"
+        assert_eq!(pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_,_>>(), expected_bonded, "StakingAsync::Bonded map content mismatch on AH post-migration");
 
-    //     // "Assert storage 'StakingAsync::Ledger::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::Ledger::<T>::iter_keys().count(), expected_ledger.len(), "StakingAsync::Ledger map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::Ledger::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_,_>>(), expected_ledger, "StakingAsync::Ledger map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Ledger::ah_post::length'"
+        assert_eq!(pallet_staking_async::Ledger::<T>::iter_keys().count(), expected_ledger.len(), "StakingAsync::Ledger map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Ledger::ah_post::correct'"
+        assert_eq!(pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_,_>>(), expected_ledger, "StakingAsync::Ledger map content mismatch on AH post-migration");
         
-    //     // "Assert storage 'StakingAsync::Payee::ah_post::length'"
-    //     assert_eq!(pallet_staking_async::Payee::<T>::iter_keys().count(), expected_payee.len(), "StakingAsync::Payee map length mismatch on AH post-migration");
-    //     // "Assert storage 'StakingAsync::Payee::ah_post::correct'"
-    //     assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "StakingAsync::Payee map content mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Payee::ah_post::length'"
+        assert_eq!(pallet_staking_async::Payee::<T>::iter_keys().count(), expected_payee.len(), "StakingAsync::Payee map length mismatch on AH post-migration");
+        // "Assert storage 'StakingAsync::Payee::ah_post::correct'"
+        assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "StakingAsync::Payee map content mismatch on AH post-migration");
 
     //     // "Assert storage 'StakingAsync::Validators::ah_post::length'"
     //     assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "StakingAsync::Validators map length mismatch on AH post-migration");

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -445,10 +445,13 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
                 Validators { stash, validators } => { expected_validators.insert(stash, validators); },
                 Nominators { stash, nominations } => { expected_nominators.insert(stash, nominations); },
                 VirtualStakers(staker) => { expected_virtual_stakers.insert(staker); },
-    //             ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
+    //          ErasStartSessionIndex { era, session } => { expected_eras_start_session_index.insert(era, session); },
                 ErasStakersOverview { era, validator, exposure } => { expected_eras_stakers_overview.insert((era, validator.clone()), exposure); },
                 ErasStakersPaged { era, validator, page, exposure } => { expected_eras_stakers_paged.insert((era, validator.clone(), page), exposure.into()); },
-                ClaimedRewards { era, validator, rewards } => { expected_claimed_rewards.insert((era, validator.clone()), rewards); },
+                ClaimedRewards { era, validator, rewards } => { 
+                    let bounded = BoundedVec::<Page, pallet_staking_async::ErasClaimedRewardsBound<T>>::truncate_from(rewards);
+                    expected_claimed_rewards.insert((era, validator.clone()), bounded.into_inner()); 
+                },
                 ErasValidatorPrefs { era, validator, prefs } => { expected_eras_validator_prefs.insert((era, validator.clone()), prefs); },
                 ErasValidatorReward { era, reward } => { expected_eras_validator_reward.insert(era, reward); },
                 ErasRewardPoints { era, points } => { expected_eras_reward_points.insert(era, points); },
@@ -469,93 +472,93 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
         if let Some(values) = expected_values_opt {
             let expected_force_era = expected_force_era_opt.expect("Bundled with values");
 
-            // "Assert storage 'StakingAsync::ValidatorCount::ah_post::correct'"
+            // "Assert storage 'StakingAsync::ValidatorCount::ah_post::consistent'"
             assert_eq!(pallet_staking_async::ValidatorCount::<T>::get(), values.validator_count, "StakingAsync::ValidatorCount mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinNominatorBond::ah_post::correct'"
+            // "Assert storage 'StakingAsync::MinNominatorBond::ah_post::consistent'"
             assert_eq!(pallet_staking_async::MinNominatorBond::<T>::get(), values.min_nominator_bond, "StakingAsync::MinNominatorBond mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinValidatorBond::ah_post::correct'"
+            // "Assert storage 'StakingAsync::MinValidatorBond::ah_post::consistent'"
             assert_eq!(pallet_staking_async::MinValidatorBond::<T>::get(), values.min_validator_bond, "StakingAsync::MinValidatorBond mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinimumActiveStake::ah_post::correct'"
+            // "Assert storage 'StakingAsync::MinimumActiveStake::ah_post::consistent'"
             assert_eq!(pallet_staking_async::MinimumActiveStake::<T>::get(), values.min_active_stake, "StakingAsync::MinimumActiveStake mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MinCommission::ah_post::correct'"
+            // "Assert storage 'StakingAsync::MinCommission::ah_post::consistent'"
             assert_eq!(pallet_staking_async::MinCommission::<T>::get(), values.min_commission, "StakingAsync::MinCommission mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MaxValidatorsCount::ah_post::correct'"
+            // "Assert storage 'StakingAsync::MaxValidatorsCount::ah_post::consistent'"
             assert_eq!(pallet_staking_async::MaxValidatorsCount::<T>::get(), values.max_validators_count, "StakingAsync::MaxValidatorsCount mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MaxNominatorsCount::ah_post::correct'"
+            // "Assert storage 'StakingAsync::MaxNominatorsCount::ah_post::consistent'"
             assert_eq!(pallet_staking_async::MaxNominatorsCount::<T>::get(), values.max_nominators_count, "StakingAsync::MaxNominatorsCount mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::CurrentEra::ah_post::correct'"
+            // "Assert storage 'StakingAsync::CurrentEra::ah_post::consistent'"
             assert_eq!(pallet_staking_async::CurrentEra::<T>::get(), expected_active_era_opt.clone().map(|a| a.index), "StakingAsync::CurrentEra mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::ActiveEra::ah_post::correct'"
+            // "Assert storage 'StakingAsync::ActiveEra::ah_post::consistent'"
             assert_eq!(pallet_staking_async::ActiveEra::<T>::get(), expected_active_era_opt, "StakingAsync::ActiveEra mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::ForceEra::ah_post::correct'"
+            // "Assert storage 'StakingAsync::ForceEra::ah_post::consistent'"
             assert_eq!(pallet_staking_async::ForceEra::<T>::get(), expected_force_era, "StakingAsync::ForceEra mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::MaxStakedRewards::ah_post::correct'"
+            // "Assert storage 'StakingAsync::MaxStakedRewards::ah_post::consistent'"
             assert_eq!(pallet_staking_async::MaxStakedRewards::<T>::get(), values.max_staked_rewards, "StakingAsync::MaxStakedRewards mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::SlashRewardFraction::ah_post::correct'"
+            // "Assert storage 'StakingAsync::SlashRewardFraction::ah_post::consistent'"
             assert_eq!(pallet_staking_async::SlashRewardFraction::<T>::get(), values.slash_reward_fraction, "StakingAsync::SlashRewardFraction mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::CanceledSlashPayout::ah_post::correct'"
+            // "Assert storage 'StakingAsync::CanceledSlashPayout::ah_post::consistent'"
             assert_eq!(pallet_staking_async::CanceledSlashPayout::<T>::get(), values.canceled_slash_payout, "StakingAsync::CanceledSlashPayout mismatch on AH post-migration");
-            // "Assert storage 'StakingAsync::ChillThreshold::ah_post::correct'"
+            // "Assert storage 'StakingAsync::ChillThreshold::ah_post::consistent'"
             assert_eq!(pallet_staking_async::ChillThreshold::<T>::get(), values.chill_threshold, "StakingAsync::ChillThreshold mismatch on AH post-migration");
         }
 
-        // "Assert storage 'StakingAsync::Invulnerables::ah_post::correct'"
+        // "Assert storage 'StakingAsync::Invulnerables::ah_post::consistent'"
         assert_eq!(pallet_staking_async::Invulnerables::<T>::get().into_inner(), expected_invulnerables, "StakingAsync::Invulnerables mismatch on AH post-migration");
 
-        // "Assert storage 'StakingAsync::BondedEras::ah_post::correct'"
+        // "Assert storage 'StakingAsync::BondedEras::ah_post::consistent'"
         assert_eq!(pallet_staking_async::BondedEras::<T>::get().into_inner(), expected_bonded_eras, "StakingAsync::BondedEras mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::Bonded::ah_post::length'"
         assert_eq!(pallet_staking_async::Bonded::<T>::iter_keys().count(), expected_bonded.len(), "StakingAsync::Bonded map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Bonded::ah_post::correct'"
+        // "Assert storage 'StakingAsync::Bonded::ah_post::consistent'"
         assert_eq!(pallet_staking_async::Bonded::<T>::iter().collect::<BTreeMap<_,_>>(), expected_bonded, "StakingAsync::Bonded map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::Ledger::ah_post::length'"
         assert_eq!(pallet_staking_async::Ledger::<T>::iter_keys().count(), expected_ledger.len(), "StakingAsync::Ledger map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Ledger::ah_post::correct'"
+        // "Assert storage 'StakingAsync::Ledger::ah_post::consistent'"
         assert_eq!(pallet_staking_async::Ledger::<T>::iter().collect::<BTreeMap<_,_>>(), expected_ledger, "StakingAsync::Ledger map content mismatch on AH post-migration");
         
         // "Assert storage 'StakingAsync::Payee::ah_post::length'"
         assert_eq!(pallet_staking_async::Payee::<T>::iter_keys().count(), expected_payee.len(), "StakingAsync::Payee map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Payee::ah_post::correct'"
+        // "Assert storage 'StakingAsync::Payee::ah_post::consistent'"
         assert_eq!(pallet_staking_async::Payee::<T>::iter().collect::<BTreeMap<_,_>>(), expected_payee, "StakingAsync::Payee map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::Validators::ah_post::length'"
         assert_eq!(pallet_staking_async::Validators::<T>::iter_keys().count(), expected_validators.len(), "StakingAsync::Validators map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Validators::ah_post::correct'"
+        // "Assert storage 'StakingAsync::Validators::ah_post::consistent'"
         assert_eq!(pallet_staking_async::Validators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_validators, "StakingAsync::Validators map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::Nominators::ah_post::length'"
         assert_eq!(pallet_staking_async::Nominators::<T>::iter_keys().count(), expected_nominators.len(), "StakingAsync::Nominators map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::Nominators::ah_post::correct'"
+        // "Assert storage 'StakingAsync::Nominators::ah_post::consistent'"
         assert_eq!(pallet_staking_async::Nominators::<T>::iter().collect::<BTreeMap<_,_>>(), expected_nominators, "StakingAsync::Nominators map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::VirtualStakers::ah_post::length'"
         assert_eq!(pallet_staking_async::VirtualStakers::<T>::iter_keys().count(), expected_virtual_stakers.len(), "StakingAsync::VirtualStakers length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::VirtualStakers::ah_post::correct'"
+        // "Assert storage 'StakingAsync::VirtualStakers::ah_post::consistent'"
         let current_virtual_stakers = pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<HashSet<_>>();
         assert_eq!(current_virtual_stakers, expected_virtual_stakers, "StakingAsync::VirtualStakers content mismatch on AH post-migration");
         
         // No longer migrated
     //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::length'"
     //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter_keys().count(), expected_eras_start_session_index.len(), "StakingAsync::ErasStartSessionIndex map length mismatch on AH post-migration");
-    //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::correct'"
+    //    // "Assert storage 'StakingAsync::ErasStartSessionIndex::ah_post::consistent'"
     //    assert_eq!(pallet_staking_async::ErasStartSessionIndex::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_start_session_index, "StakingAsync::ErasStartSessionIndex map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter_keys().count(), expected_eras_stakers_overview.len(), "StakingAsync::ErasStakersOverview map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ErasStakersOverview::ah_post::consistent'"
         assert_eq!(pallet_staking_async::ErasStakersOverview::<T>::iter().map(|(era, account_id, metadata)| ((era, account_id), metadata)).collect::<BTreeMap<_,_>>(), expected_eras_stakers_overview, "StakingAsync::ErasStakersOverview map content mismatch on AH post-migration");
         
         // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasStakersPaged::<T>::iter_keys().count(), expected_eras_stakers_paged.len(), "StakingAsync::ErasStakersPaged map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ErasStakersPaged::ah_post::consistent'"
         let current_eras_stakers_paged = pallet_staking_async::ErasStakersPaged::<T>::iter().collect::<BTreeMap<_,_>>();
         assert_eq!(current_eras_stakers_paged, expected_eras_stakers_paged, "StakingAsync::ErasStakersPaged map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasClaimedRewards::<T>::iter_keys().count(), expected_claimed_rewards.len(), "StakingAsync::ErasClaimedRewards map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ErasClaimedRewards::ah_post::consistent'"
         let current_claimed_rewards = pallet_staking_async::ErasClaimedRewards::<T>::iter()
             .map(|(k1, k2, v_weak_bounded)| ((k1, k2), v_weak_bounded.into_inner()))
             .collect::<BTreeMap<_,_>>();
@@ -563,27 +566,27 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
 
         // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter_keys().count(), expected_eras_validator_prefs.len(), "StakingAsync::ErasValidatorPrefs map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ErasValidatorPrefs::ah_post::consistent'"
         assert_eq!(pallet_staking_async::ErasValidatorPrefs::<T>::iter().map(|(era, account, prefs)| ((era, account), prefs)).collect::<BTreeMap<_,_>>(), expected_eras_validator_prefs, "StakingAsync::ErasValidatorPrefs map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter_keys().count(), expected_eras_validator_reward.len(), "StakingAsync::ErasValidatorReward map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ErasValidatorReward::ah_post::consistent'"
         assert_eq!(pallet_staking_async::ErasValidatorReward::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_validator_reward, "StakingAsync::ErasValidatorReward map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter_keys().count(), expected_eras_reward_points.len(), "StakingAsync::ErasRewardPoints map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ErasRewardPoints::ah_post::consistent'"
         assert_eq!(pallet_staking_async::ErasRewardPoints::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_reward_points, "StakingAsync::ErasRewardPoints map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::length'"
         assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter_keys().count(), expected_eras_total_stake.len(), "StakingAsync::ErasTotalStake map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ErasTotalStake::ah_post::consistent'"
         assert_eq!(pallet_staking_async::ErasTotalStake::<T>::iter().collect::<BTreeMap<_,_>>(), expected_eras_total_stake, "StakingAsync::ErasTotalStake map content mismatch on AH post-migration");
         
         // "Assert storage 'StakingAsync::UnappliedSlashes::ah_post::length'"
         assert_eq!(pallet_staking_async::UnappliedSlashes::<T>::iter_keys().count(), expected_unapplied_slashes.len(), "StakingAsync::UnappliedSlashes map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::UnappliedSlashes::ah_post::correct'"
+        // "Assert storage 'StakingAsync::UnappliedSlashes::ah_post::consistent'"
         let current_unapplied_slashes = pallet_staking_async::UnappliedSlashes::<T>::iter()
             .map(|(k1_era, k2_tuple, v_slash)| ((k1_era, k2_tuple), v_slash))
             .collect::<BTreeMap<_,_>>();
@@ -591,23 +594,23 @@ impl<T: Config> crate::types::AhMigrationCheck for pallet_rc_migrator::staking::
 
         // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::length'"
         assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter_keys().count(), expected_validator_slash_in_era.len(), "StakingAsync::ValidatorSlashInEra map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::correct'"
+        // "Assert storage 'StakingAsync::ValidatorSlashInEra::ah_post::consistent'"
         assert_eq!(pallet_staking_async::ValidatorSlashInEra::<T>::iter().map(|(era, account, slash)| ((era, account), slash)).collect::<BTreeMap<_,_>>(), expected_validator_slash_in_era, "StakingAsync::ValidatorSlashInEra map content mismatch on AH post-migration");
 
         // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::length'"
         assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter_keys().count(), expected_nominator_slash_in_era.len(), "StakingAsync::NominatorSlashInEra map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::correct'"
+        // "Assert storage 'StakingAsync::NominatorSlashInEra::ah_post::consistent'"
         assert_eq!(pallet_staking_async::NominatorSlashInEra::<T>::iter().map(|(era, account, balance)| ((era, account), balance)).collect::<BTreeMap<_,_>>(), expected_nominator_slash_in_era, "StakingAsync::NominatorSlashInEra map content mismatch on AH post-migration");
 
         // SlashSpans gone in latest polkadot-sdk master branch
         // "Assert storage 'StakingAsync::SlashingSpans::ah_post::length'"
         assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter_keys().count(), expected_slashing_spans.len(), "StakingAsync::SlashingSpans map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::SlashingSpans::ah_post::correct'"
+        // "Assert storage 'StakingAsync::SlashingSpans::ah_post::consistent'"
         assert_eq!(pallet_staking_async::SlashingSpans::<T>::iter().collect::<BTreeMap<_,_>>(), expected_slashing_spans, "StakingAsync::SlashingSpans map content mismatch on AH post-migration");
         
         // "Assert storage 'StakingAsync::SpanSlash::ah_post::length'"
         assert_eq!(pallet_staking_async::SpanSlash::<T>::iter_keys().count(), expected_span_slash.len(), "StakingAsync::SpanSlash map length mismatch on AH post-migration");
-        // "Assert storage 'StakingAsync::SpanSlash::ah_post::correct'"
+        // "Assert storage 'StakingAsync::SpanSlash::ah_post::consistent'"
         assert_eq!(pallet_staking_async::SpanSlash::<T>::iter().collect::<BTreeMap<_,_>>(), expected_span_slash, "StakingAsync::SpanSlash map content mismatch on AH post-migration");
     }
 }

--- a/pallets/ah-migrator/src/types.rs
+++ b/pallets/ah-migrator/src/types.rs
@@ -65,7 +65,7 @@ pub trait AhMigrationCheck {
 	fn post_check(rc_pre_payload: Self::RcPrePayload, ah_pre_payload: Self::AhPrePayload);
 }
 
-#[impl_trait_for_tuples::impl_for_tuples(16)]
+#[impl_trait_for_tuples::impl_for_tuples(24)]
 impl AhMigrationCheck for Tuple {
 	for_tuples! { type RcPrePayload = (#( Tuple::RcPrePayload ),* ); }
 	for_tuples! { type AhPrePayload = (#( Tuple::AhPrePayload ),* ); }

--- a/pallets/rc-migrator/src/staking/message.rs
+++ b/pallets/rc-migrator/src/staking/message.rs
@@ -27,10 +27,7 @@ use codec::HasCompact;
 use core::fmt::Debug;
 pub use frame_election_provider_support::PageIndex;
 use frame_support::traits::DefensiveTruncateInto;
-use pallet_staking::{
-	slashing::SpanIndex,
-	ActiveEraInfo, Forcing,
-};
+use pallet_staking::{slashing::SpanIndex, ActiveEraInfo, Forcing};
 use sp_runtime::{Perbill, Percent};
 use sp_staking::{EraIndex, ExposurePage, Page, PagedExposureMetadata, SessionIndex};
 

--- a/pallets/rc-migrator/src/staking/message.rs
+++ b/pallets/rc-migrator/src/staking/message.rs
@@ -23,14 +23,13 @@ use crate::{
 	*,
 };
 use alloc::collections::BTreeMap;
-use codec::{EncodeLike, HasCompact};
+use codec::HasCompact;
 use core::fmt::Debug;
 pub use frame_election_provider_support::PageIndex;
 use frame_support::traits::DefensiveTruncateInto;
 use pallet_staking::{
-	slashing::{SlashingSpans, SpanIndex, SpanRecord},
-	ActiveEraInfo, EraRewardPoints, Forcing, Nominations, RewardDestination, StakingLedger,
-	ValidatorPrefs,
+	slashing::SpanIndex,
+	ActiveEraInfo, Forcing,
 };
 use sp_runtime::{Perbill, Percent};
 use sp_staking::{EraIndex, ExposurePage, Page, PagedExposureMetadata, SessionIndex};

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -601,17 +601,6 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
             .collect();
         messages.extend(virtual_stakers_messages);
 
-        // StakingStage::ErasStartSessionIndex
-        let eras_ssi_items: Vec<_> = pallet_staking::ErasStartSessionIndex::<T>::iter().collect();
-        let eras_ssi_messages: Vec<_> = eras_ssi_items
-            .into_iter()
-            .map(|(era, session)| RcStakingMessage::ErasStartSessionIndex {
-                era,     
-                session, 
-            })
-            .collect();
-        messages.extend(eras_ssi_messages);
-
         // StakingStage::ErasStakersOverview
         let eras_so_items: Vec<_> = pallet_staking::ErasStakersOverview::<T>::iter().collect();
         let eras_so_messages: Vec<_> = eras_so_items
@@ -899,11 +888,6 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
             pallet_staking::VirtualStakers::<T>::iter().next().is_none(),
             "VirtualStakers map should be empty on RC after migration"
         );
-        // Assert storage 'Staking::ErasStartSessionIndex::rc_post::empty'
-        assert!(
-            pallet_staking::ErasStartSessionIndex::<T>::iter().next().is_none(),
-            "ErasStartSessionIndex map should be empty on RC after migration"
-        );
         // Assert storage 'Staking::ErasStakersOverview::rc_post::empty'
         assert!(
             pallet_staking::ErasStakersOverview::<T>::iter().next().is_none(),
@@ -965,7 +949,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
             "SpanSlash map should be empty on RC after migration"
         );
 
-		// -- Ensure deprecated storage items empty as well --
+		// -- Ensure deprecated storage or not migrated items are empty as well --
 
 		// Assert storage 'Staking::ErasStakers::rc_post::empty'
         assert!(
@@ -976,6 +960,11 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         assert!(
             pallet_staking::ErasStakersClipped::<T>::iter().next().is_none(),
             "ErasStakersClipped map should be empty on RC after migration (deprecated item)"
+        );
+		// Assert storage 'Staking::ErasStartSessionIndex::rc_post::empty'
+        assert!(
+            pallet_staking::ErasStartSessionIndex::<T>::iter().next().is_none(),
+            "ErasStartSessionIndex map should be empty on RC after migration"
         );
     }
 }

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -708,19 +708,19 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::MinNominatorBond::rc_post::empty'
         assert_eq!(
             pallet_staking::MinNominatorBond::<T>::get(),
-            0,
+            Default::default(),
             "MinNominatorBond should be default on RC after migration"
         );
         // Assert storage 'Staking::MinValidatorBond::rc_post::empty'
         assert_eq!(
             pallet_staking::MinValidatorBond::<T>::get(),
-            0,
+            Default::default(),
             "MinValidatorBond should be default on RC after migration"
         );
         // Assert storage 'Staking::MinimumActiveStake::rc_post::empty'
         assert_eq!(
             pallet_staking::MinimumActiveStake::<T>::get(),
-            0,
+            Default::default(),
             "MinimumActiveStake should be default on RC after migration"
         );
         // Assert storage 'Staking::MinCommission::rc_post::empty'
@@ -774,7 +774,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::CanceledSlashPayout::rc_post::empty'
         assert_eq!(
             pallet_staking::CanceledSlashPayout::<T>::get(),
-            0,
+            Default::default(),
             "CanceledSlashPayout should be default on RC after migration"
         );
         // Assert storage 'Staking::CurrentPlannedSession::rc_post::empty'

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -19,18 +19,12 @@
 pub use crate::staking::message::{
 	AhEquivalentStakingMessageOf, RcStakingMessage, RcStakingMessageOf,
 };
-use crate::{staking::IntoAh, *};
-use codec::{EncodeLike, HasCompact};
-use core::fmt::Debug;
+use crate::*;
 pub use frame_election_provider_support::PageIndex;
-use frame_support::traits::DefensiveTruncateInto;
 use pallet_staking::{
-	slashing::{SlashingSpans, SpanIndex, SpanRecord},
-	ActiveEraInfo, EraRewardPoints, Forcing, Nominations, RewardDestination, StakingLedger,
-	ValidatorPrefs,
+	slashing::SpanIndex,
 };
-use sp_runtime::{Perbill, Percent};
-use sp_staking::{EraIndex, ExposurePage, Page, PagedExposureMetadata, SessionIndex};
+use sp_staking::{EraIndex, Page};
 
 pub struct StakingMigrator<T> {
 	_phantom: PhantomData<T>,

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -962,7 +962,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
             "ErasStakersClipped map should be empty on RC after migration (deprecated item)"
         );
 
-		// Fails - should we remove during migration?
+		// Fails - should we remove state during migration?
 		// Assert storage 'Staking::ErasStartSessionIndex::rc_post::empty'
         // assert!(
         //     pallet_staking::ErasStartSessionIndex::<T>::iter().next().is_none(),

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -523,7 +523,7 @@ fn resume<Map: frame_support::IterableStorageMap<K, V>, K: FullEncode, V: FullCo
 }
 
 // The payload that will be passed between pre and post migration checks
-pub type RcPrePayload = (
+pub type RcPrePayload<T> = (
 	// Values captured by `StakingMigrator::take_values()`.
 	crate::staking::message::RcStakingValuesOf<T>,
 	// Invulnerables.

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -525,55 +525,55 @@ fn resume<Map: frame_support::IterableStorageMap<K, V>, K: FullEncode, V: FullCo
 // The payload that will be passed between pre and post migration checks
 type RcPrePayload = (
 	// Values captured by `StakingMigrator::take_values()`.
-	crate::staking::message::RcStakingValuesOf<T>, //16
+	crate::staking::message::RcStakingValuesOf<T>,
 	// Invulnerables.
 	Vec<<T as frame_system::Config>::AccountId>,
-	// Bonded (stash, controller) pairs.
+	// Bonded map.
 	Vec<(<T as frame_system::Config>::AccountId, <T as frame_system::Config>::AccountId)>,
-	// Ledgers (controller, ledger).
+	// Ledger map.
 	Vec<(<T as frame_system::Config>::AccountId, pallet_staking::StakingLedger<T>)>,
-	// Payees (stash, payment_destination).
+	// Payee map.
 	Vec<(
 		<T as frame_system::Config>::AccountId,
 		pallet_staking::RewardDestination<<T as frame_system::Config>::AccountId>,
 	)>,
-	// Validators (stash, prefs).
+	// Validators map.
 	Vec<(<T as frame_system::Config>::AccountId, pallet_staking::ValidatorPrefs)>,
-	// Nominators (stash, nominations).
+	// Nominators map.
 	Vec<(<T as frame_system::Config>::AccountId, pallet_staking::Nominations<T>)>,
-	// VirtualStakers (staker_id).
+	// VirtualStakers map.
 	Vec<<T as frame_system::Config>::AccountId>,
-	// ErasStartSessionIndex (era, session_index).
+	// ErasStartSessionIndex map.
 	Vec<(sp_staking::EraIndex, sp_staking::SessionIndex)>,
-	// ErasStakersOverview (era, validator_stash, overview_metadata).
+	// ErasStakersOverview double map.
 	Vec<(
 		sp_staking::EraIndex,
 		<T as frame_system::Config>::AccountId,
 		sp_staking::PagedExposureMetadata<pallet_staking::BalanceOf<T>>,
 	)>,
-	// ErasStakersPaged ((era, validator_stash, page_index), page_data).
+	// ErasStakersPaged n map.
 	Vec<(
 		(sp_staking::EraIndex, <T as frame_system::Config>::AccountId, sp_staking::Page),
 		sp_staking::ExposurePage<<T as frame_system::Config>::AccountId, pallet_staking::BalanceOf<T>>,
 	)>,
-	// ClaimedRewards (era, validator_stash, Vec<page_index>).
+	// ClaimedRewards double map.
 	Vec<(sp_staking::EraIndex, <T as frame_system::Config>::AccountId, Vec<sp_staking::Page>)>,
-	// ErasValidatorPrefs (era, validator_stash, prefs).
+	// ErasValidatorPrefs double map.
 	Vec<(
 		sp_staking::EraIndex,
 		<T as frame_system::Config>::AccountId,
 		pallet_staking::ValidatorPrefs,
 	)>,
-	// ErasValidatorReward (era, reward_balance).
+	// ErasValidatorReward map.
 	Vec<(sp_staking::EraIndex, pallet_staking::BalanceOf<T>)>,
-	// ErasRewardPoints (era, points_data).
+	// ErasRewardPoints map.
 	Vec<(
 		sp_staking::EraIndex,
 		pallet_staking::EraRewardPoints<<T as frame_system::Config>::AccountId>,
 	)>,
-	// ErasTotalStake (era, total_stake_balance).
+	// ErasTotalStake map.
 	Vec<(sp_staking::EraIndex, pallet_staking::BalanceOf<T>)>,
-	// UnappliedSlashes (era, Vec<slash_details>).
+	// UnappliedSlashes map.
 	Vec<(
 		sp_staking::EraIndex,
 		Vec<
@@ -583,23 +583,23 @@ type RcPrePayload = (
 			>,
 		>,
 	)>,
-	// BondedEras (Vec<(era, session_index)>).
+	// BondedEras.
 	Vec<(sp_staking::EraIndex, sp_staking::SessionIndex)>,
-	// ValidatorSlashInEra (era, validator_stash, (slash_perbill, slash_amount)).
+	// ValidatorSlashInEra double map.
 	Vec<(
 		sp_staking::EraIndex,
 		<T as frame_system::Config>::AccountId,
 		(sp_runtime::Perbill, pallet_staking::BalanceOf<T>),
 	)>,
-	// NominatorSlashInEra (era, nominator_stash, slash_amount).
+	// NominatorSlashInEra double map.
 	Vec<(
 		sp_staking::EraIndex,
 		<T as frame_system::Config>::AccountId,
 		pallet_staking::BalanceOf<T>,
 	)>,
-	// SlashingSpans (account_id, spans_data).
+	// SlashingSpans map.
 	Vec<(<T as frame_system::Config>::AccountId, pallet_staking::slashing::SlashingSpans)>,
-	// SpanSlash ((account_id, span_index), record_data).
+	// SpanSlash map.
 	Vec<(
 		(<T as frame_system::Config>::AccountId, pallet_staking::slashing::SpanIndex),
 		pallet_staking::slashing::SpanRecord<pallet_staking::BalanceOf<T>>,

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -523,7 +523,7 @@ fn resume<Map: frame_support::IterableStorageMap<K, V>, K: FullEncode, V: FullCo
 }
 
 // The payload that will be passed between pre and post migration checks
-type RcPrePayload = (
+pub type RcPrePayload = (
 	// Values captured by `StakingMigrator::take_values()`.
 	crate::staking::message::RcStakingValuesOf<T>,
 	// Invulnerables.
@@ -606,7 +606,7 @@ type RcPrePayload = (
 	)>,
 );
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", feature = "ahm-staking-migration"))]
 impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
 	type RcPrePayload = RcPrePayload<T>;
 

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -726,7 +726,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::MinCommission::rc_post::empty'
         assert_eq!(
             pallet_staking::MinCommission::<T>::get(),
-            <Perbill as Default>::default(),
+            Default::default(),
             "MinCommission should be default on RC after migration"
         );
         // Assert storage 'Staking::MaxValidatorsCount::rc_post::empty'
@@ -756,7 +756,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::ForceEra::rc_post::empty'
         assert_eq!(
             pallet_staking::ForceEra::<T>::get(),
-            <Forcing as Default>::default(),
+            Default::default(),
             "ForceEra should be default on RC after migration"
         );
         // Assert storage 'Staking::MaxStakedRewards::rc_post::empty'
@@ -768,7 +768,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::SlashRewardFraction::rc_post::empty'
         assert_eq!(
             pallet_staking::SlashRewardFraction::<T>::get(),
-            <Perbill as Default>::default(),
+            Default::default(),
             "SlashRewardFraction should be default on RC after migration"
         );
         // Assert storage 'Staking::CanceledSlashPayout::rc_post::empty'

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -720,13 +720,13 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::MinimumActiveStake::rc_post::empty'
         assert_eq!(
             pallet_staking::MinimumActiveStake::<T>::get(),
-            Default::default(), // Assuming BalanceOf<T> defaults to zero
+            Default::default(),
             "MinimumActiveStake should be default on RC after migration"
         );
         // Assert storage 'Staking::MinCommission::rc_post::empty'
         assert_eq!(
             pallet_staking::MinCommission::<T>::get(),
-            Default::default(), // Perbill::zero()
+            Default::default(),
             "MinCommission should be default on RC after migration"
         );
         // Assert storage 'Staking::MaxValidatorsCount::rc_post::empty'
@@ -756,7 +756,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::ForceEra::rc_post::empty'
         assert_eq!(
             pallet_staking::ForceEra::<T>::get(),
-            Default::default(), // Forcing::NotForcing
+            Default::default(),
             "ForceEra should be default on RC after migration"
         );
         // Assert storage 'Staking::MaxStakedRewards::rc_post::empty'
@@ -768,19 +768,19 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::SlashRewardFraction::rc_post::empty'
         assert_eq!(
             pallet_staking::SlashRewardFraction::<T>::get(),
-            Default::default(), // Perbill::zero()
+            Default::default(),
             "SlashRewardFraction should be default on RC after migration"
         );
         // Assert storage 'Staking::CanceledSlashPayout::rc_post::empty'
         assert_eq!(
             pallet_staking::CanceledSlashPayout::<T>::get(),
-            Default::default(), // Assuming BalanceOf<T> defaults to zero
+            Default::default(),
             "CanceledSlashPayout should be default on RC after migration"
         );
         // Assert storage 'Staking::CurrentPlannedSession::rc_post::empty'
         assert_eq!(
             pallet_staking::CurrentPlannedSession::<T>::get(),
-            Default::default(), // SessionIndex 0
+            Default::default(),
             "CurrentPlannedSession should be default on RC after migration"
         );
         // Assert storage 'Staking::ChillThreshold::rc_post::empty'

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -21,9 +21,7 @@ pub use crate::staking::message::{
 };
 use crate::*;
 pub use frame_election_provider_support::PageIndex;
-use pallet_staking::{
-	slashing::SpanIndex,
-};
+use pallet_staking::slashing::SpanIndex;
 use sp_staking::{EraIndex, Page};
 
 pub struct StakingMigrator<T> {
@@ -503,464 +501,438 @@ fn resume<Map: frame_support::IterableStorageMap<K, V>, K: FullEncode, V: FullCo
 impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
 	type RcPrePayload = Vec<RcStakingMessageOf<T>>;
 
-    fn pre_check() -> Self::RcPrePayload {
-        let mut messages = Vec::new();
+	fn pre_check() -> Self::RcPrePayload {
+		let mut messages = Vec::new();
 
-        // StakingStage::Values
-        let staking_values = crate::staking::message::RcStakingValuesOf::<T> {
-            validator_count: pallet_staking::ValidatorCount::<T>::get(),
-            min_validator_count: pallet_staking::MinimumValidatorCount::<T>::get(),
-            min_nominator_bond: pallet_staking::MinNominatorBond::<T>::get(),
-            min_validator_bond: pallet_staking::MinValidatorBond::<T>::get(),
-            min_active_stake: pallet_staking::MinimumActiveStake::<T>::get(),
-            min_commission: pallet_staking::MinCommission::<T>::get(),
-            max_validators_count: pallet_staking::MaxValidatorsCount::<T>::get(),
-            max_nominators_count: pallet_staking::MaxNominatorsCount::<T>::get(),
-            current_era: pallet_staking::CurrentEra::<T>::get(),
-            active_era: pallet_staking::ActiveEra::<T>::get(),
-            force_era: pallet_staking::ForceEra::<T>::get(),
-            max_staked_rewards: pallet_staking::MaxStakedRewards::<T>::get(),
-            slash_reward_fraction: pallet_staking::SlashRewardFraction::<T>::get(),
-            canceled_slash_payout: pallet_staking::CanceledSlashPayout::<T>::get(),
-            current_planned_session: pallet_staking::CurrentPlannedSession::<T>::get(),
-            chill_threshold: pallet_staking::ChillThreshold::<T>::get(),
-        };
-        messages.push(RcStakingMessage::Values(staking_values));
+		// StakingStage::Values
+		let staking_values = crate::staking::message::RcStakingValuesOf::<T> {
+			validator_count: pallet_staking::ValidatorCount::<T>::get(),
+			min_validator_count: pallet_staking::MinimumValidatorCount::<T>::get(),
+			min_nominator_bond: pallet_staking::MinNominatorBond::<T>::get(),
+			min_validator_bond: pallet_staking::MinValidatorBond::<T>::get(),
+			min_active_stake: pallet_staking::MinimumActiveStake::<T>::get(),
+			min_commission: pallet_staking::MinCommission::<T>::get(),
+			max_validators_count: pallet_staking::MaxValidatorsCount::<T>::get(),
+			max_nominators_count: pallet_staking::MaxNominatorsCount::<T>::get(),
+			current_era: pallet_staking::CurrentEra::<T>::get(),
+			active_era: pallet_staking::ActiveEra::<T>::get(),
+			force_era: pallet_staking::ForceEra::<T>::get(),
+			max_staked_rewards: pallet_staking::MaxStakedRewards::<T>::get(),
+			slash_reward_fraction: pallet_staking::SlashRewardFraction::<T>::get(),
+			canceled_slash_payout: pallet_staking::CanceledSlashPayout::<T>::get(),
+			current_planned_session: pallet_staking::CurrentPlannedSession::<T>::get(),
+			chill_threshold: pallet_staking::ChillThreshold::<T>::get(),
+		};
+		messages.push(RcStakingMessage::Values(staking_values));
 
-        // StakingStage::Invulnerables
-        let invulnerables = pallet_staking::Invulnerables::<T>::get();
-        messages.push(RcStakingMessage::Invulnerables(invulnerables));
+		// StakingStage::Invulnerables
+		let invulnerables = pallet_staking::Invulnerables::<T>::get();
+		messages.push(RcStakingMessage::Invulnerables(invulnerables));
 
-        // StakingStage::Bonded
-        let bonded_items: Vec<_> = pallet_staking::Bonded::<T>::iter().collect();
-        let bonded_messages: Vec<_> = bonded_items
-            .into_iter()
-            .map(|(stash, controller)| RcStakingMessage::Bonded {
-                stash,
-                controller,
-            })
-            .collect();
-        messages.extend(bonded_messages);
+		// StakingStage::Bonded
+		let bonded_items: Vec<_> = pallet_staking::Bonded::<T>::iter().collect();
+		let bonded_messages: Vec<_> = bonded_items
+			.into_iter()
+			.map(|(stash, controller)| RcStakingMessage::Bonded { stash, controller })
+			.collect();
+		messages.extend(bonded_messages);
 
-        // StakingStage::Ledger
-        let ledgers: Vec<_> = pallet_staking::Ledger::<T>::iter().collect();
-        let ledger_messages: Vec<_> = ledgers
-            .into_iter()
-            .map(|(controller, ledger)| RcStakingMessage::Ledger {
-                controller: controller.clone(),
-                ledger,
-            })
-            .collect();
-        messages.extend(ledger_messages);
+		// StakingStage::Ledger
+		let ledgers: Vec<_> = pallet_staking::Ledger::<T>::iter().collect();
+		let ledger_messages: Vec<_> = ledgers
+			.into_iter()
+			.map(|(controller, ledger)| RcStakingMessage::Ledger {
+				controller: controller.clone(),
+				ledger,
+			})
+			.collect();
+		messages.extend(ledger_messages);
 
-        // StakingStage::Payee
-        let payees: Vec<_> = pallet_staking::Payee::<T>::iter().collect();
-        let payee_messages: Vec<_> = payees
-            .into_iter()
-            .map(|(stash, payment)| RcStakingMessage::Payee {
-                stash,    
-                payment,  
-            })
-            .collect();
-        messages.extend(payee_messages);
+		// StakingStage::Payee
+		let payees: Vec<_> = pallet_staking::Payee::<T>::iter().collect();
+		let payee_messages: Vec<_> = payees
+			.into_iter()
+			.map(|(stash, payment)| RcStakingMessage::Payee { stash, payment })
+			.collect();
+		messages.extend(payee_messages);
 
-        // StakingStage::Validators
-        let validators_items: Vec<_> = pallet_staking::Validators::<T>::iter().collect();
-        let validators_messages: Vec<_> = validators_items
-            .into_iter()
-            .map(|(stash, validators_prefs)| RcStakingMessage::Validators {
-                stash, 
-                validators: validators_prefs, 
-            })
-            .collect();
-        messages.extend(validators_messages);
+		// StakingStage::Validators
+		let validators_items: Vec<_> = pallet_staking::Validators::<T>::iter().collect();
+		let validators_messages: Vec<_> = validators_items
+			.into_iter()
+			.map(|(stash, validators_prefs)| RcStakingMessage::Validators {
+				stash,
+				validators: validators_prefs,
+			})
+			.collect();
+		messages.extend(validators_messages);
 
-        // StakingStage::Nominators
-        let nominators_items: Vec<_> = pallet_staking::Nominators::<T>::iter().collect();
-        let nominators_messages: Vec<_> = nominators_items
-            .into_iter()
-            .map(|(stash, nominations)| RcStakingMessage::Nominators {
-                stash, 
-                nominations, 
-            })
-            .collect();
-        messages.extend(nominators_messages);
+		// StakingStage::Nominators
+		let nominators_items: Vec<_> = pallet_staking::Nominators::<T>::iter().collect();
+		let nominators_messages: Vec<_> = nominators_items
+			.into_iter()
+			.map(|(stash, nominations)| RcStakingMessage::Nominators { stash, nominations })
+			.collect();
+		messages.extend(nominators_messages);
 
-        // StakingStage::VirtualStakers
-        let virtual_stakers_keys: Vec<_> =
-            pallet_staking::VirtualStakers::<T>::iter().map(|(k, _)| k).collect();
-        let virtual_stakers_messages: Vec<_> = virtual_stakers_keys
-            .into_iter()
-            .map(|staker| RcStakingMessage::VirtualStakers(staker)) 
-            .collect();
-        messages.extend(virtual_stakers_messages);
+		// StakingStage::VirtualStakers
+		let virtual_stakers_keys: Vec<_> =
+			pallet_staking::VirtualStakers::<T>::iter().map(|(k, _)| k).collect();
+		let virtual_stakers_messages: Vec<_> = virtual_stakers_keys
+			.into_iter()
+			.map(|staker| RcStakingMessage::VirtualStakers(staker))
+			.collect();
+		messages.extend(virtual_stakers_messages);
 
-        // StakingStage::ErasStakersOverview
-        let eras_so_items: Vec<_> = pallet_staking::ErasStakersOverview::<T>::iter().collect();
-        let eras_so_messages: Vec<_> = eras_so_items
-            .into_iter()
-            .map(|(era, validator, exposure)| RcStakingMessage::ErasStakersOverview {
-                era,       
-                validator, 
-                exposure,  
-            })
-            .collect();
-        messages.extend(eras_so_messages);
+		// StakingStage::ErasStakersOverview
+		let eras_so_items: Vec<_> = pallet_staking::ErasStakersOverview::<T>::iter().collect();
+		let eras_so_messages: Vec<_> = eras_so_items
+			.into_iter()
+			.map(|(era, validator, exposure)| RcStakingMessage::ErasStakersOverview {
+				era,
+				validator,
+				exposure,
+			})
+			.collect();
+		messages.extend(eras_so_messages);
 
-        // StakingStage::ErasStakersPaged
-        let eras_sp_items: Vec<_> = pallet_staking::ErasStakersPaged::<T>::iter().collect();
-        let eras_sp_messages: Vec<_> = eras_sp_items
-            .into_iter()
-            .map(|((era, validator, page), exposure)| RcStakingMessage::ErasStakersPaged {
-                era,       
-                validator, 
-                page,      
-                exposure,  
-            })
-            .collect();
-        messages.extend(eras_sp_messages);
+		// StakingStage::ErasStakersPaged
+		let eras_sp_items: Vec<_> = pallet_staking::ErasStakersPaged::<T>::iter().collect();
+		let eras_sp_messages: Vec<_> = eras_sp_items
+			.into_iter()
+			.map(|((era, validator, page), exposure)| RcStakingMessage::ErasStakersPaged {
+				era,
+				validator,
+				page,
+				exposure,
+			})
+			.collect();
+		messages.extend(eras_sp_messages);
 
-        // StakingStage::ClaimedRewards
-        let claimed_rewards_items: Vec<_> = pallet_staking::ClaimedRewards::<T>::iter().collect();
-        let claimed_rewards_messages: Vec<_> = claimed_rewards_items
-            .into_iter()
-            .map(|(era, validator, rewards)| RcStakingMessage::ClaimedRewards {
-                era,       
-                validator, 
-                rewards,   
-            })
-            .collect();
-        messages.extend(claimed_rewards_messages);
+		// StakingStage::ClaimedRewards
+		let claimed_rewards_items: Vec<_> = pallet_staking::ClaimedRewards::<T>::iter().collect();
+		let claimed_rewards_messages: Vec<_> = claimed_rewards_items
+			.into_iter()
+			.map(|(era, validator, rewards)| RcStakingMessage::ClaimedRewards {
+				era,
+				validator,
+				rewards,
+			})
+			.collect();
+		messages.extend(claimed_rewards_messages);
 
-        // StakingStage::ErasValidatorPrefs
-        let eras_vp_items: Vec<_> = pallet_staking::ErasValidatorPrefs::<T>::iter().collect();
-        let eras_vp_messages: Vec<_> = eras_vp_items
-            .into_iter()
-            .map(|(era, validator, prefs)| RcStakingMessage::ErasValidatorPrefs {
-                era,       
-                validator, 
-                prefs,     
-            })
-            .collect();
-        messages.extend(eras_vp_messages);
+		// StakingStage::ErasValidatorPrefs
+		let eras_vp_items: Vec<_> = pallet_staking::ErasValidatorPrefs::<T>::iter().collect();
+		let eras_vp_messages: Vec<_> = eras_vp_items
+			.into_iter()
+			.map(|(era, validator, prefs)| RcStakingMessage::ErasValidatorPrefs {
+				era,
+				validator,
+				prefs,
+			})
+			.collect();
+		messages.extend(eras_vp_messages);
 
-        // StakingStage::ErasValidatorReward
-        let eras_vr_items: Vec<_> = pallet_staking::ErasValidatorReward::<T>::iter().collect();
-        let eras_vr_messages: Vec<_> = eras_vr_items
-            .into_iter()
-            .map(|(era, reward)| RcStakingMessage::ErasValidatorReward {
-                era,    
-                reward, 
-            })
-            .collect();
-        messages.extend(eras_vr_messages);
+		// StakingStage::ErasValidatorReward
+		let eras_vr_items: Vec<_> = pallet_staking::ErasValidatorReward::<T>::iter().collect();
+		let eras_vr_messages: Vec<_> = eras_vr_items
+			.into_iter()
+			.map(|(era, reward)| RcStakingMessage::ErasValidatorReward { era, reward })
+			.collect();
+		messages.extend(eras_vr_messages);
 
-        // StakingStage::ErasRewardPoints
-        let eras_rp_items: Vec<_> = pallet_staking::ErasRewardPoints::<T>::iter().collect();
-        let eras_rp_messages: Vec<_> = eras_rp_items
-            .into_iter()
-            .map(|(era, points)| RcStakingMessage::ErasRewardPoints {
-                era,    
-                points, 
-            })
-            .collect();
-        messages.extend(eras_rp_messages);
+		// StakingStage::ErasRewardPoints
+		let eras_rp_items: Vec<_> = pallet_staking::ErasRewardPoints::<T>::iter().collect();
+		let eras_rp_messages: Vec<_> = eras_rp_items
+			.into_iter()
+			.map(|(era, points)| RcStakingMessage::ErasRewardPoints { era, points })
+			.collect();
+		messages.extend(eras_rp_messages);
 
-        // StakingStage::ErasTotalStake
-        let eras_ts_items: Vec<_> = pallet_staking::ErasTotalStake::<T>::iter().collect();
-        let eras_ts_messages: Vec<_> = eras_ts_items
-            .into_iter()
-            .map(|(era, total_stake)| RcStakingMessage::ErasTotalStake {
-                era,         
-                total_stake, 
-            })
-            .collect();
-        messages.extend(eras_ts_messages);
+		// StakingStage::ErasTotalStake
+		let eras_ts_items: Vec<_> = pallet_staking::ErasTotalStake::<T>::iter().collect();
+		let eras_ts_messages: Vec<_> = eras_ts_items
+			.into_iter()
+			.map(|(era, total_stake)| RcStakingMessage::ErasTotalStake { era, total_stake })
+			.collect();
+		messages.extend(eras_ts_messages);
 
-        // StakingStage::UnappliedSlashes
-        let unapplied_slashes_items: Vec<_> =
-            pallet_staking::UnappliedSlashes::<T>::iter().collect();
-        for (era, slashes_vec) in unapplied_slashes_items {
-            for slash_item in slashes_vec {
-                messages.push(RcStakingMessage::UnappliedSlashes {
-                    era, 
-                    slash: slash_item,
-                });
-            }
-        }
+		// StakingStage::UnappliedSlashes
+		let unapplied_slashes_items: Vec<_> =
+			pallet_staking::UnappliedSlashes::<T>::iter().collect();
+		for (era, slashes_vec) in unapplied_slashes_items {
+			for slash_item in slashes_vec {
+				messages.push(RcStakingMessage::UnappliedSlashes { era, slash: slash_item });
+			}
+		}
 
-        // StakingStage::BondedEras
-        let bonded_eras = pallet_staking::BondedEras::<T>::get(); 
-        messages.push(RcStakingMessage::BondedEras(bonded_eras));
+		// StakingStage::BondedEras
+		let bonded_eras = pallet_staking::BondedEras::<T>::get();
+		messages.push(RcStakingMessage::BondedEras(bonded_eras));
 
-        // StakingStage::ValidatorSlashInEra
-        let val_slash_items: Vec<_> =
-            pallet_staking::ValidatorSlashInEra::<T>::iter().collect();
-        let val_slash_messages: Vec<_> = val_slash_items
-            .into_iter()
-            .map(|(era, validator, slash)| RcStakingMessage::ValidatorSlashInEra {
-                era,       
-                validator, 
-                slash,     
-            })
-            .collect();
-        messages.extend(val_slash_messages);
+		// StakingStage::ValidatorSlashInEra
+		let val_slash_items: Vec<_> = pallet_staking::ValidatorSlashInEra::<T>::iter().collect();
+		let val_slash_messages: Vec<_> = val_slash_items
+			.into_iter()
+			.map(|(era, validator, slash)| RcStakingMessage::ValidatorSlashInEra {
+				era,
+				validator,
+				slash,
+			})
+			.collect();
+		messages.extend(val_slash_messages);
 
-        // StakingStage::NominatorSlashInEra
-        let nom_slash_items: Vec<_> =
-            pallet_staking::NominatorSlashInEra::<T>::iter().collect();
-        let nom_slash_messages: Vec<_> = nom_slash_items
-            .into_iter()
-            .map(|(era, validator, slash)| RcStakingMessage::NominatorSlashInEra {
-                era,       
-                validator, 
-                slash,     
-            })
-            .collect();
-        messages.extend(nom_slash_messages);
+		// StakingStage::NominatorSlashInEra
+		let nom_slash_items: Vec<_> = pallet_staking::NominatorSlashInEra::<T>::iter().collect();
+		let nom_slash_messages: Vec<_> = nom_slash_items
+			.into_iter()
+			.map(|(era, validator, slash)| RcStakingMessage::NominatorSlashInEra {
+				era,
+				validator,
+				slash,
+			})
+			.collect();
+		messages.extend(nom_slash_messages);
 
-        // StakingStage::SlashingSpans
-        let slashing_spans_items: Vec<_> = pallet_staking::SlashingSpans::<T>::iter().collect();
-        let slashing_spans_messages: Vec<_> = slashing_spans_items
-            .into_iter()
-            .map(|(account, spans)| RcStakingMessage::SlashingSpans {
-                account, 
-                spans,   
-            })
-            .collect();
-        messages.extend(slashing_spans_messages);
+		// StakingStage::SlashingSpans
+		let slashing_spans_items: Vec<_> = pallet_staking::SlashingSpans::<T>::iter().collect();
+		let slashing_spans_messages: Vec<_> = slashing_spans_items
+			.into_iter()
+			.map(|(account, spans)| RcStakingMessage::SlashingSpans { account, spans })
+			.collect();
+		messages.extend(slashing_spans_messages);
 
-        // StakingStage::SpanSlash
-        let span_slash_items: Vec<_> = pallet_staking::SpanSlash::<T>::iter().collect();
-        let span_slash_messages: Vec<_> = span_slash_items
-            .into_iter()
-            .map(|((account, span_idx), slash_record)| RcStakingMessage::SpanSlash {
-                account,      
-                span: span_idx, 
-                slash: slash_record, 
-            })
-            .collect();
-        messages.extend(span_slash_messages);
+		// StakingStage::SpanSlash
+		let span_slash_items: Vec<_> = pallet_staking::SpanSlash::<T>::iter().collect();
+		let span_slash_messages: Vec<_> = span_slash_items
+			.into_iter()
+			.map(|((account, span_idx), slash_record)| RcStakingMessage::SpanSlash {
+				account,
+				span: span_idx,
+				slash: slash_record,
+			})
+			.collect();
+		messages.extend(span_slash_messages);
 
-        messages
-    }
+		messages
+	}
 
-    fn post_check(_rc_pre_payload: Self::RcPrePayload) {
-        // Assert storage 'Staking::ValidatorCount::rc_post::empty'
-        assert_eq!(
-            pallet_staking::ValidatorCount::<T>::get(),
-            0,
-            "ValidatorCount should be default on RC after migration"
-        );
-        // Assert storage 'Staking::MinimumValidatorCount::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MinimumValidatorCount::<T>::get(),
-            0,
-            "MinimumValidatorCount should be default on RC after migration"
-        );
-        // Assert storage 'Staking::MinNominatorBond::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MinNominatorBond::<T>::get(),
-            Default::default(),
-            "MinNominatorBond should be default on RC after migration"
-        );
-        // Assert storage 'Staking::MinValidatorBond::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MinValidatorBond::<T>::get(),
-            Default::default(),
-            "MinValidatorBond should be default on RC after migration"
-        );
-        // Assert storage 'Staking::MinimumActiveStake::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MinimumActiveStake::<T>::get(),
-            Default::default(),
-            "MinimumActiveStake should be default on RC after migration"
-        );
-        // Assert storage 'Staking::MinCommission::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MinCommission::<T>::get(),
-            Default::default(),
-            "MinCommission should be default on RC after migration"
-        );
-        // Assert storage 'Staking::MaxValidatorsCount::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MaxValidatorsCount::<T>::get(),
-            None,
-            "MaxValidatorsCount should be None on RC after migration"
-        );
-        // Assert storage 'Staking::MaxNominatorsCount::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MaxNominatorsCount::<T>::get(),
-            None,
-            "MaxNominatorsCount should be None on RC after migration"
-        );
-        // Assert storage 'Staking::CurrentEra::rc_post::empty'
-        assert_eq!(
-            pallet_staking::CurrentEra::<T>::get(),
-            None,
-            "CurrentEra should be None on RC after migration"
-        );
-        // Assert storage 'Staking::ActiveEra::rc_post::empty'
-        assert_eq!(
-            pallet_staking::ActiveEra::<T>::get(),
-            None,
-            "ActiveEra should be None on RC after migration"
-        );
-        // Assert storage 'Staking::ForceEra::rc_post::empty'
-        assert_eq!(
-            pallet_staking::ForceEra::<T>::get(),
-            Default::default(),
-            "ForceEra should be default on RC after migration"
-        );
-        // Assert storage 'Staking::MaxStakedRewards::rc_post::empty'
-        assert_eq!(
-            pallet_staking::MaxStakedRewards::<T>::get(),
-            None,
-            "MaxStakedRewards should be None on RC after migration"
-        );
-        // Assert storage 'Staking::SlashRewardFraction::rc_post::empty'
-        assert_eq!(
-            pallet_staking::SlashRewardFraction::<T>::get(),
-            Default::default(),
-            "SlashRewardFraction should be default on RC after migration"
-        );
-        // Assert storage 'Staking::CanceledSlashPayout::rc_post::empty'
-        assert_eq!(
-            pallet_staking::CanceledSlashPayout::<T>::get(),
-            Default::default(),
-            "CanceledSlashPayout should be default on RC after migration"
-        );
-        // Assert storage 'Staking::CurrentPlannedSession::rc_post::empty'
-        assert_eq!(
-            pallet_staking::CurrentPlannedSession::<T>::get(),
-            0,
-            "CurrentPlannedSession should be default on RC after migration"
-        );
-        // Assert storage 'Staking::ChillThreshold::rc_post::empty'
-        assert_eq!(
-            pallet_staking::ChillThreshold::<T>::get(),
-            None,
-            "ChillThreshold should be None on RC after migration"
-        );
-        // Assert storage 'Staking::Invulnerables::rc_post::empty'
-        assert!(
-            pallet_staking::Invulnerables::<T>::get().is_empty(),
-            "Invulnerables should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::BondedEras::rc_post::empty'
-        assert!(
-            pallet_staking::BondedEras::<T>::get().is_empty(),
-            "BondedEras should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::Bonded::rc_post::empty'
-        assert!(
-            pallet_staking::Bonded::<T>::iter().next().is_none(),
-            "Bonded map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::Ledger::rc_post::empty'
-        assert!(
-            pallet_staking::Ledger::<T>::iter().next().is_none(),
-            "Ledger map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::Payee::rc_post::empty'
-        assert!(
-            pallet_staking::Payee::<T>::iter().next().is_none(),
-            "Payee map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::Validators::rc_post::empty'
-        assert!(
-            pallet_staking::Validators::<T>::iter().next().is_none(),
-            "Validators map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::Nominators::rc_post::empty'
-        assert!(
-            pallet_staking::Nominators::<T>::iter().next().is_none(),
-            "Nominators map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::VirtualStakers::rc_post::empty'
-        assert!(
-            pallet_staking::VirtualStakers::<T>::iter().next().is_none(),
-            "VirtualStakers map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ErasStakersOverview::rc_post::empty'
-        assert!(
-            pallet_staking::ErasStakersOverview::<T>::iter().next().is_none(),
-            "ErasStakersOverview map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ErasStakersPaged::rc_post::empty'
-        assert!(
-            pallet_staking::ErasStakersPaged::<T>::iter().next().is_none(),
-            "ErasStakersPaged map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ClaimedRewards::rc_post::empty'
-        assert!(
-            pallet_staking::ClaimedRewards::<T>::iter().next().is_none(),
-            "ClaimedRewards map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ErasValidatorPrefs::rc_post::empty'
-        assert!(
-            pallet_staking::ErasValidatorPrefs::<T>::iter().next().is_none(),
-            "ErasValidatorPrefs map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ErasValidatorReward::rc_post::empty'
-        assert!(
-            pallet_staking::ErasValidatorReward::<T>::iter().next().is_none(),
-            "ErasValidatorReward map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ErasRewardPoints::rc_post::empty'
-        assert!(
-            pallet_staking::ErasRewardPoints::<T>::iter().next().is_none(),
-            "ErasRewardPoints map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ErasTotalStake::rc_post::empty'
-        assert!(
-            pallet_staking::ErasTotalStake::<T>::iter().next().is_none(),
-            "ErasTotalStake map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::UnappliedSlashes::rc_post::empty'
-        assert!(
-            pallet_staking::UnappliedSlashes::<T>::iter().next().is_none(),
-            "UnappliedSlashes map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::ValidatorSlashInEra::rc_post::empty'
-        assert!(
-            pallet_staking::ValidatorSlashInEra::<T>::iter().next().is_none(),
-            "ValidatorSlashInEra map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::NominatorSlashInEra::rc_post::empty'
-        assert!(
-            pallet_staking::NominatorSlashInEra::<T>::iter().next().is_none(),
-            "NominatorSlashInEra map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::SlashingSpans::rc_post::empty'
-        assert!(
-            pallet_staking::SlashingSpans::<T>::iter().next().is_none(),
-            "SlashingSpans map should be empty on RC after migration"
-        );
-        // Assert storage 'Staking::SpanSlash::rc_post::empty'
-        assert!(
-            pallet_staking::SpanSlash::<T>::iter().next().is_none(),
-            "SpanSlash map should be empty on RC after migration"
-        );
+	fn post_check(_rc_pre_payload: Self::RcPrePayload) {
+		// Assert storage 'Staking::ValidatorCount::rc_post::empty'
+		assert_eq!(
+			pallet_staking::ValidatorCount::<T>::get(),
+			0,
+			"ValidatorCount should be default on RC after migration"
+		);
+		// Assert storage 'Staking::MinimumValidatorCount::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MinimumValidatorCount::<T>::get(),
+			0,
+			"MinimumValidatorCount should be default on RC after migration"
+		);
+		// Assert storage 'Staking::MinNominatorBond::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MinNominatorBond::<T>::get(),
+			Default::default(),
+			"MinNominatorBond should be default on RC after migration"
+		);
+		// Assert storage 'Staking::MinValidatorBond::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MinValidatorBond::<T>::get(),
+			Default::default(),
+			"MinValidatorBond should be default on RC after migration"
+		);
+		// Assert storage 'Staking::MinimumActiveStake::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MinimumActiveStake::<T>::get(),
+			Default::default(),
+			"MinimumActiveStake should be default on RC after migration"
+		);
+		// Assert storage 'Staking::MinCommission::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MinCommission::<T>::get(),
+			Default::default(),
+			"MinCommission should be default on RC after migration"
+		);
+		// Assert storage 'Staking::MaxValidatorsCount::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MaxValidatorsCount::<T>::get(),
+			None,
+			"MaxValidatorsCount should be None on RC after migration"
+		);
+		// Assert storage 'Staking::MaxNominatorsCount::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MaxNominatorsCount::<T>::get(),
+			None,
+			"MaxNominatorsCount should be None on RC after migration"
+		);
+		// Assert storage 'Staking::CurrentEra::rc_post::empty'
+		assert_eq!(
+			pallet_staking::CurrentEra::<T>::get(),
+			None,
+			"CurrentEra should be None on RC after migration"
+		);
+		// Assert storage 'Staking::ActiveEra::rc_post::empty'
+		assert_eq!(
+			pallet_staking::ActiveEra::<T>::get(),
+			None,
+			"ActiveEra should be None on RC after migration"
+		);
+		// Assert storage 'Staking::ForceEra::rc_post::empty'
+		assert_eq!(
+			pallet_staking::ForceEra::<T>::get(),
+			Default::default(),
+			"ForceEra should be default on RC after migration"
+		);
+		// Assert storage 'Staking::MaxStakedRewards::rc_post::empty'
+		assert_eq!(
+			pallet_staking::MaxStakedRewards::<T>::get(),
+			None,
+			"MaxStakedRewards should be None on RC after migration"
+		);
+		// Assert storage 'Staking::SlashRewardFraction::rc_post::empty'
+		assert_eq!(
+			pallet_staking::SlashRewardFraction::<T>::get(),
+			Default::default(),
+			"SlashRewardFraction should be default on RC after migration"
+		);
+		// Assert storage 'Staking::CanceledSlashPayout::rc_post::empty'
+		assert_eq!(
+			pallet_staking::CanceledSlashPayout::<T>::get(),
+			Default::default(),
+			"CanceledSlashPayout should be default on RC after migration"
+		);
+		// Assert storage 'Staking::CurrentPlannedSession::rc_post::empty'
+		assert_eq!(
+			pallet_staking::CurrentPlannedSession::<T>::get(),
+			0,
+			"CurrentPlannedSession should be default on RC after migration"
+		);
+		// Assert storage 'Staking::ChillThreshold::rc_post::empty'
+		assert_eq!(
+			pallet_staking::ChillThreshold::<T>::get(),
+			None,
+			"ChillThreshold should be None on RC after migration"
+		);
+		// Assert storage 'Staking::Invulnerables::rc_post::empty'
+		assert!(
+			pallet_staking::Invulnerables::<T>::get().is_empty(),
+			"Invulnerables should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::BondedEras::rc_post::empty'
+		assert!(
+			pallet_staking::BondedEras::<T>::get().is_empty(),
+			"BondedEras should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::Bonded::rc_post::empty'
+		assert!(
+			pallet_staking::Bonded::<T>::iter().next().is_none(),
+			"Bonded map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::Ledger::rc_post::empty'
+		assert!(
+			pallet_staking::Ledger::<T>::iter().next().is_none(),
+			"Ledger map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::Payee::rc_post::empty'
+		assert!(
+			pallet_staking::Payee::<T>::iter().next().is_none(),
+			"Payee map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::Validators::rc_post::empty'
+		assert!(
+			pallet_staking::Validators::<T>::iter().next().is_none(),
+			"Validators map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::Nominators::rc_post::empty'
+		assert!(
+			pallet_staking::Nominators::<T>::iter().next().is_none(),
+			"Nominators map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::VirtualStakers::rc_post::empty'
+		assert!(
+			pallet_staking::VirtualStakers::<T>::iter().next().is_none(),
+			"VirtualStakers map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ErasStakersOverview::rc_post::empty'
+		assert!(
+			pallet_staking::ErasStakersOverview::<T>::iter().next().is_none(),
+			"ErasStakersOverview map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ErasStakersPaged::rc_post::empty'
+		assert!(
+			pallet_staking::ErasStakersPaged::<T>::iter().next().is_none(),
+			"ErasStakersPaged map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ClaimedRewards::rc_post::empty'
+		assert!(
+			pallet_staking::ClaimedRewards::<T>::iter().next().is_none(),
+			"ClaimedRewards map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ErasValidatorPrefs::rc_post::empty'
+		assert!(
+			pallet_staking::ErasValidatorPrefs::<T>::iter().next().is_none(),
+			"ErasValidatorPrefs map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ErasValidatorReward::rc_post::empty'
+		assert!(
+			pallet_staking::ErasValidatorReward::<T>::iter().next().is_none(),
+			"ErasValidatorReward map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ErasRewardPoints::rc_post::empty'
+		assert!(
+			pallet_staking::ErasRewardPoints::<T>::iter().next().is_none(),
+			"ErasRewardPoints map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ErasTotalStake::rc_post::empty'
+		assert!(
+			pallet_staking::ErasTotalStake::<T>::iter().next().is_none(),
+			"ErasTotalStake map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::UnappliedSlashes::rc_post::empty'
+		assert!(
+			pallet_staking::UnappliedSlashes::<T>::iter().next().is_none(),
+			"UnappliedSlashes map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::ValidatorSlashInEra::rc_post::empty'
+		assert!(
+			pallet_staking::ValidatorSlashInEra::<T>::iter().next().is_none(),
+			"ValidatorSlashInEra map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::NominatorSlashInEra::rc_post::empty'
+		assert!(
+			pallet_staking::NominatorSlashInEra::<T>::iter().next().is_none(),
+			"NominatorSlashInEra map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::SlashingSpans::rc_post::empty'
+		assert!(
+			pallet_staking::SlashingSpans::<T>::iter().next().is_none(),
+			"SlashingSpans map should be empty on RC after migration"
+		);
+		// Assert storage 'Staking::SpanSlash::rc_post::empty'
+		assert!(
+			pallet_staking::SpanSlash::<T>::iter().next().is_none(),
+			"SpanSlash map should be empty on RC after migration"
+		);
 
 		// -- Ensure deprecated storage or not migrated items are empty as well --
 
 		// Assert storage 'Staking::ErasStakers::rc_post::empty'
-        assert!(
-            pallet_staking::ErasStakers::<T>::iter().next().is_none(),
-            "ErasStakers map should be empty on RC after migration (deprecated item)"
-        );
-        // Assert storage 'Staking::ErasStakersClipped::rc_post::empty'
-        assert!(
-            pallet_staking::ErasStakersClipped::<T>::iter().next().is_none(),
-            "ErasStakersClipped map should be empty on RC after migration (deprecated item)"
-        );
+		assert!(
+			pallet_staking::ErasStakers::<T>::iter().next().is_none(),
+			"ErasStakers map should be empty on RC after migration (deprecated item)"
+		);
+		// Assert storage 'Staking::ErasStakersClipped::rc_post::empty'
+		assert!(
+			pallet_staking::ErasStakersClipped::<T>::iter().next().is_none(),
+			"ErasStakersClipped map should be empty on RC after migration (deprecated item)"
+		);
 
 		// Fails - should we remove state during migration?
 		// Assert storage 'Staking::ErasStartSessionIndex::rc_post::empty'
-        // assert!(
-        //     pallet_staking::ErasStartSessionIndex::<T>::iter().next().is_none(),
-        //     "ErasStartSessionIndex map should be empty on RC after migration"
-        // );
-    }
+		// assert!(
+		//     pallet_staking::ErasStartSessionIndex::<T>::iter().next().is_none(),
+		//     "ErasStartSessionIndex map should be empty on RC after migration"
+		// );
+	}
 }

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -961,10 +961,12 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
             pallet_staking::ErasStakersClipped::<T>::iter().next().is_none(),
             "ErasStakersClipped map should be empty on RC after migration (deprecated item)"
         );
+
+		// Fails - should we remove during migration?
 		// Assert storage 'Staking::ErasStartSessionIndex::rc_post::empty'
-        assert!(
-            pallet_staking::ErasStartSessionIndex::<T>::iter().next().is_none(),
-            "ErasStartSessionIndex map should be empty on RC after migration"
-        );
+        // assert!(
+        //     pallet_staking::ErasStartSessionIndex::<T>::iter().next().is_none(),
+        //     "ErasStartSessionIndex map should be empty on RC after migration"
+        // );
     }
 }

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -696,37 +696,37 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::ValidatorCount::rc_post::empty'
         assert_eq!(
             pallet_staking::ValidatorCount::<T>::get(),
-            Default::default(),
+            0,
             "ValidatorCount should be default on RC after migration"
         );
         // Assert storage 'Staking::MinimumValidatorCount::rc_post::empty'
         assert_eq!(
             pallet_staking::MinimumValidatorCount::<T>::get(),
-            Default::default(),
+            0,
             "MinimumValidatorCount should be default on RC after migration"
         );
         // Assert storage 'Staking::MinNominatorBond::rc_post::empty'
         assert_eq!(
             pallet_staking::MinNominatorBond::<T>::get(),
-            Default::default(),
+            0,
             "MinNominatorBond should be default on RC after migration"
         );
         // Assert storage 'Staking::MinValidatorBond::rc_post::empty'
         assert_eq!(
             pallet_staking::MinValidatorBond::<T>::get(),
-            Default::default(),
+            0,
             "MinValidatorBond should be default on RC after migration"
         );
         // Assert storage 'Staking::MinimumActiveStake::rc_post::empty'
         assert_eq!(
             pallet_staking::MinimumActiveStake::<T>::get(),
-            Default::default(),
+            0,
             "MinimumActiveStake should be default on RC after migration"
         );
         // Assert storage 'Staking::MinCommission::rc_post::empty'
         assert_eq!(
             pallet_staking::MinCommission::<T>::get(),
-            Default::default(),
+            <Perbill as Default>::default(),
             "MinCommission should be default on RC after migration"
         );
         // Assert storage 'Staking::MaxValidatorsCount::rc_post::empty'
@@ -756,7 +756,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::ForceEra::rc_post::empty'
         assert_eq!(
             pallet_staking::ForceEra::<T>::get(),
-            Default::default(),
+            <Forcing as Default>::default(),
             "ForceEra should be default on RC after migration"
         );
         // Assert storage 'Staking::MaxStakedRewards::rc_post::empty'
@@ -768,19 +768,19 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         // Assert storage 'Staking::SlashRewardFraction::rc_post::empty'
         assert_eq!(
             pallet_staking::SlashRewardFraction::<T>::get(),
-            Default::default(),
+            <Perbill as Default>::default(),
             "SlashRewardFraction should be default on RC after migration"
         );
         // Assert storage 'Staking::CanceledSlashPayout::rc_post::empty'
         assert_eq!(
             pallet_staking::CanceledSlashPayout::<T>::get(),
-            Default::default(),
+            0,
             "CanceledSlashPayout should be default on RC after migration"
         );
         // Assert storage 'Staking::CurrentPlannedSession::rc_post::empty'
         assert_eq!(
             pallet_staking::CurrentPlannedSession::<T>::get(),
-            Default::default(),
+            0,
             "CurrentPlannedSession should be default on RC after migration"
         );
         // Assert storage 'Staking::ChillThreshold::rc_post::empty'

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -551,7 +551,7 @@ type RcPrePayload = (
 		<T as frame_system::Config>::AccountId,
 		sp_staking::PagedExposureMetadata<pallet_staking::BalanceOf<T>>,
 	)>,
-	// ErasStakersPaged n map.
+	// ErasStakersPaged N map.
 	Vec<(
 		(sp_staking::EraIndex, <T as frame_system::Config>::AccountId, sp_staking::Page),
 		sp_staking::ExposurePage<<T as frame_system::Config>::AccountId, pallet_staking::BalanceOf<T>>,
@@ -611,8 +611,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
 	type RcPrePayload = RcPrePayload<T>;
 
     fn pre_check() -> Self::RcPrePayload {
-        // To get the "before take" values for those covered by `take_values`, we re-fetch them here.
-        let pre_take_values = crate::staking::message::StakingValues {
+        let staking_values = crate::staking::message::StakingValues {
             validator_count: pallet_staking::ValidatorCount::<T>::get(),
             min_validator_count: pallet_staking::MinimumValidatorCount::<T>::get(),
             min_nominator_bond: pallet_staking::MinNominatorBond::<T>::get(),
@@ -631,7 +630,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
             chill_threshold: pallet_staking::ChillThreshold::<T>::get(),
         };
 
-        let invulnerables = pallet_staking::Invulnerables::<T>::get(); // .get() before take()
+        let invulnerables = pallet_staking::Invulnerables::<T>::get();
         let bonded: Vec<_> = pallet_staking::Bonded::<T>::iter().collect();
         let ledgers: Vec<_> = pallet_staking::Ledger::<T>::iter().collect();
         let payees: Vec<_> = pallet_staking::Payee::<T>::iter().collect();
@@ -655,7 +654,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         let eras_reward_points: Vec<_> = pallet_staking::ErasRewardPoints::<T>::iter().collect();
         let eras_total_stake: Vec<_> = pallet_staking::ErasTotalStake::<T>::iter().collect();
         let unapplied_slashes: Vec<_> = pallet_staking::UnappliedSlashes::<T>::iter().collect();
-        let bonded_eras = pallet_staking::BondedEras::<T>::get(); // .get() before take()
+        let bonded_eras = pallet_staking::BondedEras::<T>::get();
         let validator_slash_in_era: Vec<_> =
             pallet_staking::ValidatorSlashInEra::<T>::iter()
             .map(|(era, validator, slash)| (era, validator, slash))
@@ -668,7 +667,7 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
         let span_slashes: Vec<_> = pallet_staking::SpanSlash::<T>::iter().collect();
 
         (
-            pre_take_values,
+            staking_values,
             invulnerables,
             bonded,
             ledgers,
@@ -694,116 +693,112 @@ impl<T: Config> crate::types::RcMigrationCheck for StakingMigrator<T> {
     }
 
     fn post_check(_rc_pre_payload: Self::RcPrePayload) {
-        // Assertions for items handled by `take_values()`
-        // Assert storage 'Staking::ValidatorCount::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::ValidatorCount::rc_post::empty'
         assert_eq!(
             pallet_staking::ValidatorCount::<T>::get(),
             Default::default(),
             "ValidatorCount should be default on RC after migration"
         );
-        // Assert storage 'Staking::MinimumValidatorCount::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MinimumValidatorCount::rc_post::empty'
         assert_eq!(
             pallet_staking::MinimumValidatorCount::<T>::get(),
             Default::default(),
             "MinimumValidatorCount should be default on RC after migration"
         );
-        // Assert storage 'Staking::MinNominatorBond::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MinNominatorBond::rc_post::empty'
         assert_eq!(
             pallet_staking::MinNominatorBond::<T>::get(),
             Default::default(),
             "MinNominatorBond should be default on RC after migration"
         );
-        // Assert storage 'Staking::MinValidatorBond::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MinValidatorBond::rc_post::empty'
         assert_eq!(
             pallet_staking::MinValidatorBond::<T>::get(),
             Default::default(),
             "MinValidatorBond should be default on RC after migration"
         );
-        // Assert storage 'Staking::MinimumActiveStake::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MinimumActiveStake::rc_post::empty'
         assert_eq!(
             pallet_staking::MinimumActiveStake::<T>::get(),
             Default::default(), // Assuming BalanceOf<T> defaults to zero
             "MinimumActiveStake should be default on RC after migration"
         );
-        // Assert storage 'Staking::MinCommission::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MinCommission::rc_post::empty'
         assert_eq!(
             pallet_staking::MinCommission::<T>::get(),
             Default::default(), // Perbill::zero()
             "MinCommission should be default on RC after migration"
         );
-        // Assert storage 'Staking::MaxValidatorsCount::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MaxValidatorsCount::rc_post::empty'
         assert_eq!(
             pallet_staking::MaxValidatorsCount::<T>::get(),
             None,
             "MaxValidatorsCount should be None on RC after migration"
         );
-        // Assert storage 'Staking::MaxNominatorsCount::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MaxNominatorsCount::rc_post::empty'
         assert_eq!(
             pallet_staking::MaxNominatorsCount::<T>::get(),
             None,
             "MaxNominatorsCount should be None on RC after migration"
         );
-        // Assert storage 'Staking::CurrentEra::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::CurrentEra::rc_post::empty'
         assert_eq!(
             pallet_staking::CurrentEra::<T>::get(),
             None,
             "CurrentEra should be None on RC after migration"
         );
-        // Assert storage 'Staking::ActiveEra::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::ActiveEra::rc_post::empty'
         assert_eq!(
             pallet_staking::ActiveEra::<T>::get(),
             None,
             "ActiveEra should be None on RC after migration"
         );
-        // Assert storage 'Staking::ForceEra::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::ForceEra::rc_post::empty'
         assert_eq!(
             pallet_staking::ForceEra::<T>::get(),
             Default::default(), // Forcing::NotForcing
             "ForceEra should be default on RC after migration"
         );
-        // Assert storage 'Staking::MaxStakedRewards::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::MaxStakedRewards::rc_post::empty'
         assert_eq!(
             pallet_staking::MaxStakedRewards::<T>::get(),
             None,
             "MaxStakedRewards should be None on RC after migration"
         );
-        // Assert storage 'Staking::SlashRewardFraction::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::SlashRewardFraction::rc_post::empty'
         assert_eq!(
             pallet_staking::SlashRewardFraction::<T>::get(),
             Default::default(), // Perbill::zero()
             "SlashRewardFraction should be default on RC after migration"
         );
-        // Assert storage 'Staking::CanceledSlashPayout::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::CanceledSlashPayout::rc_post::empty'
         assert_eq!(
             pallet_staking::CanceledSlashPayout::<T>::get(),
             Default::default(), // Assuming BalanceOf<T> defaults to zero
             "CanceledSlashPayout should be default on RC after migration"
         );
-        // Assert storage 'Staking::CurrentPlannedSession::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::CurrentPlannedSession::rc_post::empty'
         assert_eq!(
             pallet_staking::CurrentPlannedSession::<T>::get(),
             Default::default(), // SessionIndex 0
             "CurrentPlannedSession should be default on RC after migration"
         );
-        // Assert storage 'Staking::ChillThreshold::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::ChillThreshold::rc_post::empty'
         assert_eq!(
             pallet_staking::ChillThreshold::<T>::get(),
             None,
             "ChillThreshold should be None on RC after migration"
         );
-
-        // Assert storage 'Staking::Invulnerables::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::Invulnerables::rc_post::empty'
         assert!(
             pallet_staking::Invulnerables::<T>::get().is_empty(),
             "Invulnerables should be empty on RC after migration"
         );
-        // Assert storage 'Staking::BondedEras::rc_post::empty_or_correct_default'
+        // Assert storage 'Staking::BondedEras::rc_post::empty'
         assert!(
             pallet_staking::BondedEras::<T>::get().is_empty(),
             "BondedEras should be empty on RC after migration"
         );
-
-        // Assertions for iterated and removed items
         // Assert storage 'Staking::Bonded::rc_post::empty'
         assert!(
             pallet_staking::Bonded::<T>::iter().next().is_none(),

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -171,7 +171,7 @@ pub trait RcMigrationCheck {
 	fn post_check(rc_pre_payload: Self::RcPrePayload);
 }
 
-#[impl_trait_for_tuples::impl_for_tuples(16)]
+#[impl_trait_for_tuples::impl_for_tuples(24)]
 impl RcMigrationCheck for Tuple {
 	for_tuples! { type RcPrePayload = (#( Tuple::RcPrePayload ),* ); }
 


### PR DESCRIPTION
Relay chain and AssetHub migration checks for the pallet-staking (to pallet-staking-async) storage items. Part of #644

Note: I used the existing rc-migrator staking/message.rs piping for sending the data over, this made the types easier to convert from pallet-staking to pallet-staking-async.
