### PR TITLE
Polkadot: Reintroduce parameters pallet & parameterize inflation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10566,6 +10566,7 @@ dependencies = [
  "pallet-nomination-pools-runtime-api",
  "pallet-offences",
  "pallet-offences-benchmarking",
+ "pallet-parameters",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-referenda",

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -60,6 +60,7 @@ pallet-mmr = { workspace = true }
 pallet-multisig = { workspace = true }
 pallet-nomination-pools = { workspace = true }
 pallet-nomination-pools-runtime-api = { workspace = true }
+pallet-parameters = { workspace = true }
 pallet-offences = { workspace = true }
 pallet-preimage = { workspace = true }
 pallet-proxy = { workspace = true }
@@ -146,6 +147,7 @@ std = [
 	"pallet-authority-discovery/std",
 	"pallet-authorship/std",
 	"pallet-babe/std",
+	"pallet-parameters/std",
 	"pallet-bags-list/std",
 	"pallet-balances/std",
 	"pallet-beefy-mmr/std",
@@ -242,6 +244,7 @@ runtime-benchmarks = [
 	"pallet-grandpa/runtime-benchmarks",
 	"pallet-indices/runtime-benchmarks",
 	"pallet-message-queue/runtime-benchmarks",
+	"pallet-parameters/runtime-benchmarks",
 	"pallet-mmr/runtime-benchmarks",
 	"pallet-multisig/runtime-benchmarks",
 	"pallet-nomination-pools-benchmarking/runtime-benchmarks",
@@ -299,6 +302,7 @@ try-runtime = [
 	"pallet-fast-unstake/try-runtime",
 	"pallet-grandpa/try-runtime",
 	"pallet-indices/try-runtime",
+	"pallet-parameters/try-runtime",
 	"pallet-message-queue/try-runtime",
 	"pallet-mmr/try-runtime",
 	"pallet-multisig/try-runtime",

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -662,34 +662,17 @@ impl frame_support::traits::EnsureOriginWithArg<RuntimeOrigin, RuntimeParameters
 {
 	type Success = ();
 
-	// fn try_origin(
-	// 	origin: RuntimeOrigin,
-	// 	key: &RuntimeParametersKey,
-	// ) -> Result<Self::Success, RuntimeOrigin> {
-	// 	use crate::RuntimeParametersKey::*;
-
-	// 	match key {
-	// 		Inflation(_) => frame_system::ensure_root(origin.clone()),
-	// 	}
-	// 	.map_err(|_| origin)
-	// }
-
 	fn try_origin(
-        origin: RuntimeOrigin,
-        key: &RuntimeParametersKey,
-    ) -> Result<Self::Success, RuntimeOrigin> {
-        use crate::RuntimeParametersKey::*;
-        use sp_runtime::traits::BadOrigin; // Add this use statement if needed
+		origin: RuntimeOrigin,
+		key: &RuntimeParametersKey,
+	) -> Result<Self::Success, RuntimeOrigin> {
+		use crate::RuntimeParametersKey::*;
 
-        match key {
-            Inflation(_) => Ok::<(), BadOrigin>(()), // Specify the error type here
-        }
-        .map_err(|_| origin)?;
-
-        // You'll need to define what Self::Success should be
-        // For example, if it's an empty tuple `()`
-        Ok(())
-    }
+		match key {
+			Inflation(_) => frame_system::ensure_root(origin.clone()),
+		}
+		.map_err(|_| origin)
+	}
 
 	#[cfg(feature = "runtime-benchmarks")]
 	fn try_successful_origin(_key: &RuntimeParametersKey) -> Result<RuntimeOrigin, ()> {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -636,8 +636,8 @@ pub mod dynamic_params {
 		#[codec(index = 0)]
 		pub static YearlyEmission: u128 = 1_200_932_591_245_300_186;
 
-		/// The percentage of inflation diverted to the federal treasury.
-		/// Default to 15%, as per ref 1139.
+		/// The percentage of inflation diverted to the treasury.
+		/// Default to 15%, as per [Referendum 1139](https://polkadot.subsquare.io/referenda/1139).
 		#[codec(index = 1)]
 		pub static PercentToTreasury: Perquintill = Perquintill::from_percent(15);
 	}
@@ -3113,15 +3113,6 @@ mod inflation_tests {
 	use pallet_staking::EraPayout;
 	use approx::assert_relative_eq;
 	const MILLISECONDS_PER_DAY: u64 = 24 * 60 * 60 * 1000;
-
-	#[test]
-	fn check_values() {
-		let mut ext = sp_io::TestExternalities::new_empty();
-		ext.execute_with(|| {
-		let yearly_emission = dynamic_params::inflation::YearlyEmission::get();
-		print!("{:?}", yearly_emission);
-		});
-	}
 
 	#[test]
 	fn staking_inflation_correct_single_era() {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -646,12 +646,10 @@ pub mod dynamic_params {
 #[cfg(feature = "runtime-benchmarks")]
 impl Default for RuntimeParameters {
 	fn default() -> Self {
-		RuntimeParameters::Inflation(
-			dynamic_params::inflation::Parameters::YearlyEmission(
-				dynamic_params::inflation::YearlyEmission,
-				Some(1_200_932_591_245_300_186u128),
-			)
-		)
+		RuntimeParameters::Inflation(dynamic_params::inflation::Parameters::YearlyEmission(
+			dynamic_params::inflation::YearlyEmission,
+			Some(1_200_932_591_245_300_186u128),
+		))
 	}
 }
 
@@ -3110,81 +3108,85 @@ mod multiplier_tests {
 #[cfg(test)]
 mod inflation_tests {
 	use super::*;
-	use pallet_staking::EraPayout;
 	use approx::assert_relative_eq;
+	use pallet_staking::EraPayout;
 	const MILLISECONDS_PER_DAY: u64 = 24 * 60 * 60 * 1000;
 
 	#[test]
 	fn staking_inflation_correct_single_era() {
 		let mut ext = sp_io::TestExternalities::new_empty();
 		ext.execute_with(|| {
-		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123, // ignored
-			456, // ignored
-			MILLISECONDS_PER_DAY,
-		);
+			let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+				123, // ignored
+				456, // ignored
+				MILLISECONDS_PER_DAY,
+			);
 
-		// Values are within 0.1%
-		assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64, max_relative = 0.001);
-		assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64, max_relative = 0.001);
-		// Total per day is ~328,797 DOT
-		assert_relative_eq!(
-			(to_stakers as f64 + to_treasury as f64),
-			(328_797 * UNITS) as f64,
-			max_relative = 0.001
-		);
-	});
+			// Values are within 0.1%
+			assert_relative_eq!(to_stakers as f64, (279_477 * UNITS) as f64, max_relative = 0.001);
+			assert_relative_eq!(to_treasury as f64, (49_320 * UNITS) as f64, max_relative = 0.001);
+			// Total per day is ~328,797 DOT
+			assert_relative_eq!(
+				(to_stakers as f64 + to_treasury as f64),
+				(328_797 * UNITS) as f64,
+				max_relative = 0.001
+			);
+		});
 	}
 
 	#[test]
 	fn staking_inflation_correct_longer_era() {
 		let mut ext = sp_io::TestExternalities::new_empty();
 		ext.execute_with(|| {
-		// Twice the era duration means twice the emission:
-		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123, // ignored
-			456, // ignored
-			2 * MILLISECONDS_PER_DAY,
-		);
+			// Twice the era duration means twice the emission:
+			let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+				123, // ignored
+				456, // ignored
+				2 * MILLISECONDS_PER_DAY,
+			);
 
-		assert_relative_eq!(
-			to_stakers as f64,
-			(279_477 * UNITS) as f64 * 2.0,
-			max_relative = 0.001
-		);
-		assert_relative_eq!(
-			to_treasury as f64,
-			(49_320 * UNITS) as f64 * 2.0,
-			max_relative = 0.001
-		);
-	});
+			assert_relative_eq!(
+				to_stakers as f64,
+				(279_477 * UNITS) as f64 * 2.0,
+				max_relative = 0.001
+			);
+			assert_relative_eq!(
+				to_treasury as f64,
+				(49_320 * UNITS) as f64 * 2.0,
+				max_relative = 0.001
+			);
+		});
 	}
 
 	#[test]
 	fn staking_inflation_correct_whole_year() {
 		let mut ext = sp_io::TestExternalities::new_empty();
 		ext.execute_with(|| {
-		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123,                                  // ignored
-			456,                                  // ignored
-			MILLISECONDS_PER_DAY * (36525 / 100), // 1 year
-		);
+			let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+				123,                                  // ignored
+				456,                                  // ignored
+				MILLISECONDS_PER_DAY * (36525 / 100), // 1 year
+			);
 
-		// Our yearly emissions is about 120M DOT:
-		let yearly_emission = 120_093_259 * UNITS;
-		assert_relative_eq!(
-			to_stakers as f64 + to_treasury as f64,
-			yearly_emission as f64,
-			max_relative = 0.001
-		);
+			// Our yearly emissions is about 120M DOT:
+			let yearly_emission = 120_093_259 * UNITS;
+			assert_relative_eq!(
+				to_stakers as f64 + to_treasury as f64,
+				yearly_emission as f64,
+				max_relative = 0.001
+			);
 
-		assert_relative_eq!(to_stakers as f64, yearly_emission as f64 * 0.85, max_relative = 0.001);
-		assert_relative_eq!(
-			to_treasury as f64,
-			yearly_emission as f64 * 0.15,
-			max_relative = 0.001
-		);
-	});
+			assert_relative_eq!(
+				to_stakers as f64,
+				yearly_emission as f64 * 0.85,
+				max_relative = 0.001
+			);
+			assert_relative_eq!(
+				to_treasury as f64,
+				yearly_emission as f64 * 0.15,
+				max_relative = 0.001
+			);
+		});
 	}
 
 	// 10 years into the future, our values do not overflow.
@@ -3192,21 +3194,21 @@ mod inflation_tests {
 	fn staking_inflation_correct_not_overflow() {
 		let mut ext = sp_io::TestExternalities::new_empty();
 		ext.execute_with(|| {
-		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123,                                 // ignored
-			456,                                 // ignored
-			MILLISECONDS_PER_DAY * (36525 / 10), // 10 years
-		);
-		let initial_ti: i128 = 15_011_657_390_566_252_333;
-		let projected_total_issuance = (to_stakers as i128 + to_treasury as i128) + initial_ti;
+			let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+				123,                                 // ignored
+				456,                                 // ignored
+				MILLISECONDS_PER_DAY * (36525 / 10), // 10 years
+			);
+			let initial_ti: i128 = 15_011_657_390_566_252_333;
+			let projected_total_issuance = (to_stakers as i128 + to_treasury as i128) + initial_ti;
 
-		// In 2034, there will be about 2.7 billion DOT in existence.
-		assert_relative_eq!(
-			projected_total_issuance as f64,
-			(2_700_000_000 * UNITS) as f64,
-			max_relative = 0.001
-		);
-	});
+			// In 2034, there will be about 2.7 billion DOT in existence.
+			assert_relative_eq!(
+				projected_total_issuance as f64,
+				(2_700_000_000 * UNITS) as f64,
+				max_relative = 0.001
+			);
+		});
 	}
 
 	// Print percent per year, just as convenience.
@@ -3214,23 +3216,23 @@ mod inflation_tests {
 	fn staking_inflation_correct_print_percent() {
 		let mut ext = sp_io::TestExternalities::new_empty();
 		ext.execute_with(|| {
-		let (to_stakers, to_treasury) = super::EraPayout::era_payout(
-			123,                                  // ignored
-			456,                                  // ignored
-			(36525 * MILLISECONDS_PER_DAY) / 100, // 1 year
-		);
-		let yearly_emission = to_stakers + to_treasury;
-		let mut ti: i128 = 15_011_657_390_566_252_333;
+			let (to_stakers, to_treasury) = super::EraPayout::era_payout(
+				123,                                  // ignored
+				456,                                  // ignored
+				(36525 * MILLISECONDS_PER_DAY) / 100, // 1 year
+			);
+			let yearly_emission = to_stakers + to_treasury;
+			let mut ti: i128 = 15_011_657_390_566_252_333;
 
-		for y in 0..10 {
-			let new_ti = ti + yearly_emission as i128;
-			let inflation = 100.0 * (new_ti - ti) as f64 / ti as f64;
-			println!("Year {y} inflation: {inflation}%");
-			ti = new_ti;
+			for y in 0..10 {
+				let new_ti = ti + yearly_emission as i128;
+				let inflation = 100.0 * (new_ti - ti) as f64 / ti as f64;
+				println!("Year {y} inflation: {inflation}%");
+				ti = new_ti;
 
-			assert!(inflation <= 8.0 && inflation > 2.0, "sanity check");
-		}
-	});
+				assert!(inflation <= 8.0 && inflation > 2.0, "sanity check");
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
Intended to close out #715.

Introduces both YearlyEmission and PercentToTreasury as parameters that can be set at runtime. Parameterizing the amount of DOT minted per year and the percentage of that that's diverted to the treasury. It also wraps the inflation tests in an externality as that's now necessary.

@ggwpez 
[@jonasW3F](https://github.com/jonasW3F)