### PR TITLE
Set clippy to verify all features

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Clippy
         run: |
           cargo clippy --version
-          cargo clippy --all-targets --locked -q
+          cargo clippy --all-targets --locked --workspace --quiet
+          cargo clippy --all-targets --all-features --locked --workspace --quiet
         env:
           RUSTFLAGS: "-D warnings"
           SKIP_WASM_BUILD: 1

--- a/pallets/remote-proxy/src/tests.rs
+++ b/pallets/remote-proxy/src/tests.rs
@@ -174,7 +174,7 @@ impl crate::RemoteProxyInterface<u64, ProxyType, u64> for RemoteProxyImpl {
 			sp_trie::TrieDBMutBuilder::<sp_trie::LayoutV1<_>>::new(&mut db, &mut root).build();
 
 		let proxy_definition = vec![ProxyDefinition::<u64, ProxyType, u64> {
-			delegate: caller.clone(),
+			delegate: *caller,
 			proxy_type: ProxyType::default(),
 			delay: 0,
 		}];

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -3365,7 +3365,7 @@ mod remote_tests {
 			let (staking, leftover) = <Runtime as pallet_staking::Config>::EraPayout::era_payout(
 				total_staked,
 				total_issuance,
-				average_era_duration_millis.into(),
+				average_era_duration_millis,
 			);
 			use ss58_registry::TokenRegistry;
 			let token: ss58_registry::Token = TokenRegistry::Dot.into();

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -1149,7 +1149,7 @@ impl
 
 		assert_ok!(ForeignAssets::force_create(
 			RuntimeOrigin::root(),
-			asset_id.clone().into(),
+			asset_id.clone(),
 			account.clone().into(), /* owner */
 			true,                   /* is_sufficient */
 			1,
@@ -1159,7 +1159,7 @@ impl
 		use frame_support::traits::Currency;
 		let _ = Balances::deposit_creating(&lp_provider, u64::MAX.into());
 		assert_ok!(ForeignAssets::mint_into(
-			asset_id.clone().into(),
+			asset_id.clone(),
 			&lp_provider,
 			u64::MAX.into()
 		));
@@ -1398,7 +1398,7 @@ mod benches {
 				xcm_config::bridging::to_polkadot::AssetHubPolkadot::get(),
 				Asset::from((
 					xcm_config::bridging::to_polkadot::DotLocation::get(),
-					10000000000 as u128,
+					10000000000_u128,
 				))
 			)
 		);
@@ -1440,7 +1440,7 @@ mod benches {
 
 			assert_ok!(ForeignAssets::force_create(
 				RuntimeOrigin::root(),
-				asset_location.clone().into(),
+				asset_location.clone(),
 				account.clone().into(),
 				true,
 				1,
@@ -1448,7 +1448,7 @@ mod benches {
 
 			assert_ok!(ForeignAssets::mint(
 				origin.clone(),
-				asset_location.clone().into(),
+				asset_location.clone(),
 				account.clone().into(),
 				4_000 * UNITS,
 			));
@@ -1468,7 +1468,7 @@ mod benches {
 				2_000 * UNITS,
 				1,
 				1,
-				account.into(),
+				account,
 			));
 
 			let native_asset_id_latest: AssetId = native_asset_id.try_into().unwrap();
@@ -1537,7 +1537,7 @@ mod benches {
 				xcm_config::bridging::SiblingBridgeHubParaId::get().into(),
 			);
 			let bridged_asset_hub = xcm_config::bridging::to_polkadot::AssetHubPolkadot::get();
-			let _ = PolkadotXcm::force_xcm_version(
+			PolkadotXcm::force_xcm_version(
 				RuntimeOrigin::root(),
 				Box::new(bridged_asset_hub.clone()),
 				XCM_VERSION,

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1097,7 +1097,7 @@ impl
 
 		assert_ok!(ForeignAssets::force_create(
 			RuntimeOrigin::root(),
-			asset_id.clone().into(),
+			asset_id.clone(),
 			account.clone().into(), /* owner */
 			true,                   /* is_sufficient */
 			1,
@@ -1107,7 +1107,7 @@ impl
 		use frame_support::traits::Currency;
 		let _ = Balances::deposit_creating(&lp_provider, u64::MAX.into());
 		assert_ok!(ForeignAssets::mint_into(
-			asset_id.clone().into(),
+			asset_id.clone(),
 			&lp_provider,
 			u64::MAX.into()
 		));
@@ -1344,7 +1344,7 @@ mod benches {
 				xcm_config::bridging::to_kusama::AssetHubKusama::get(),
 				Asset::from((
 					xcm_config::bridging::to_kusama::KsmLocation::get(),
-					1000000000000 as u128
+					1000000000000_u128
 				))
 			)
 		);
@@ -1386,7 +1386,7 @@ mod benches {
 
 			assert_ok!(ForeignAssets::force_create(
 				RuntimeOrigin::root(),
-				asset_location.clone().into(),
+				asset_location.clone(),
 				account.clone().into(),
 				true,
 				1,
@@ -1394,7 +1394,7 @@ mod benches {
 
 			assert_ok!(ForeignAssets::mint(
 				origin.clone(),
-				asset_location.clone().into(),
+				asset_location.clone(),
 				account.clone().into(),
 				4_000 * UNITS,
 			));
@@ -1414,7 +1414,7 @@ mod benches {
 				2_000 * UNITS,
 				1,
 				1,
-				account.into(),
+				account,
 			));
 
 			let native_asset_id_latest: AssetId = native_asset_id.try_into().unwrap();
@@ -1483,7 +1483,7 @@ mod benches {
 				xcm_config::bridging::SiblingBridgeHubParaId::get().into(),
 			);
 			let bridged_asset_hub = xcm_config::bridging::to_kusama::AssetHubKusama::get();
-			let _ = PolkadotXcm::force_xcm_version(
+			PolkadotXcm::force_xcm_version(
 				RuntimeOrigin::root(),
 				Box::new(bridged_asset_hub.clone()),
 				XCM_VERSION,

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -768,7 +768,7 @@ mod benches {
 		fn export_message_origin_and_destination(
 		) -> Result<(Location, NetworkId, InteriorLocation), BenchmarkError> {
 			// save XCM version for remote bridge hub
-			let _ = PolkadotXcm::force_xcm_version(
+			PolkadotXcm::force_xcm_version(
 				RuntimeOrigin::root(),
 				Box::new(bridge_to_polkadot_config::BridgeHubPolkadotLocation::get()),
 				XCM_VERSION,
@@ -918,7 +918,7 @@ mod benches {
 			use cumulus_primitives_core::XcmpMessageSource;
 			assert!(XcmpQueue::take_outbound_messages(usize::MAX).is_empty());
 			ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(42.into());
-			let _ = PolkadotXcm::force_xcm_version(
+			PolkadotXcm::force_xcm_version(
 				RuntimeOrigin::root(),
 				Box::new(Location::new(1, Parachain(42))),
 				XCM_VERSION,

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -805,7 +805,7 @@ mod benches {
 		fn export_message_origin_and_destination(
 		) -> Result<(Location, NetworkId, InteriorLocation), BenchmarkError> {
 			// save XCM version for remote bridge hub
-			let _ = PolkadotXcm::force_xcm_version(
+			PolkadotXcm::force_xcm_version(
 				RuntimeOrigin::root(),
 				Box::new(bridge_to_kusama_config::BridgeHubKusamaLocation::get()),
 				XCM_VERSION,
@@ -953,7 +953,7 @@ mod benches {
 			use cumulus_primitives_core::XcmpMessageSource;
 			assert!(XcmpQueue::take_outbound_messages(usize::MAX).is_empty());
 			ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(42.into());
-			let _ = PolkadotXcm::force_xcm_version(
+			PolkadotXcm::force_xcm_version(
 				RuntimeOrigin::root(),
 				Box::new(Location::new(1, Parachain(42))),
 				XCM_VERSION,

--- a/system-parachains/encointer/src/lib.rs
+++ b/system-parachains/encointer/src/lib.rs
@@ -1371,7 +1371,7 @@ impl_runtime_apis! {
 			list_benchmarks!(list, extra);
 
 			let storage_info = AllPalletsWithSystem::storage_info();
-			return (list, storage_info)
+			(list, storage_info)
 		}
 
 		fn dispatch_benchmark(


### PR DESCRIPTION
The change follows  [polkadot-sdk's clippy usage](https://github.com/paritytech/polkadot-sdk/blob/4173aac8abc7e518d4048306c18d4f2176241206/.github/workflows/checks.yml#L39C1-L40C1) to also verify feature gated code like `test` or `runtime-benchmarks`

It also fixes current findings (only tests and benchmarks related code)

- [x] Does not require a CHANGELOG entry
