### PR TITLE
Kusama runtime: remove released migrations

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1929,22 +1929,6 @@ pub type Migrations = (migrations::Unreleased, migrations::Permanent);
 pub mod migrations {
 	use super::*;
 	use pallet_balances::WeightInfo;
-	use polkadot_primitives::node_features::FeatureIndex;
-	use runtime_parachains::configuration::WeightInfo as ParachainsWeightInfo;
-	/// Enable RFC103 feature.
-	///
-	/// This will make the Kusama relay chain runtime accept v2 candidate receipts.
-	pub struct EnableRFC103Feature;
-	impl frame_support::traits::OnRuntimeUpgrade for EnableRFC103Feature {
-		fn on_runtime_upgrade() -> Weight {
-			let _ = Configuration::set_node_feature(
-				RawOrigin::Root.into(),
-				FeatureIndex::CandidateReceiptV2 as u8,
-				true,
-			);
-			weights::runtime_parachains_configuration::WeightInfo::<Runtime>::set_node_feature()
-		}
-	}
 
 	parameter_types! {
 		/// Weight for balance unreservations
@@ -1952,12 +1936,7 @@ pub mod migrations {
 	}
 
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = (
-		parachains_shared::migration::MigrateToV1<Runtime>,
-		parachains_scheduler::migration::MigrateV2ToV3<Runtime>,
-		pallet_child_bounties::migration::MigrateV0ToV1<Runtime, BalanceTransferAllowDeath>,
-		EnableRFC103Feature,
-	);
+	pub type Unreleased = ();
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);


### PR DESCRIPTION
These have been released on Kusama with 1.5.0 upgrade. 

- [x] Does not require a CHANGELOG entry
