### PR TITLE
Fetch upstream tags in verify changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      # We need to fetch the upstream tags, as they are used to determine the latest release
+      - name: “Fetch upstream tags”
+        run: |
+          git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
+          git fetch upstream --tags
+
       - name: Verify
         run: |
           sudo apt install python3

--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      # We need to fetch the upstream tags, as they are used to determine the latest release
+      - name: “Fetch upstream tags”
+        run: |
+          git remote add upstream https://github.com/${{ github.event.pull_request.base.repo.full_name }}.git
+          git fetch upstream --tags
+
       - name: Install updates and dependencies
         run: .github/install-deps.sh
 


### PR DESCRIPTION
This fetches the upstream tags, so that "verify changelog" can check those. This is important for pull requests opened by external people.

- [x] Does not require a CHANGELOG entry
