### PR TITLE
[AHM] Remove empty conviction voting filter

### DIFF
--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
@@ -21,6 +21,6 @@ xcm = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true }
 
 # Runtimes
-asset-hub-kusama-runtime = { workspace = true, default-features = true }
+asset-hub-kusama-runtime = { workspace = true }
 kusama-emulated-chain = { workspace = true }
 penpal-emulated-chain = { workspace = true }

--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
@@ -21,6 +21,6 @@ xcm = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true }
 
 # Runtimes
-asset-hub-polkadot-runtime = { workspace = true, default-features = true }
+asset-hub-polkadot-runtime = { workspace = true }
 polkadot-emulated-chain = { workspace = true }
 penpal-emulated-chain = { workspace = true }

--- a/integration-tests/emulated/chains/relays/kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/relays/kusama/Cargo.toml
@@ -25,4 +25,4 @@ emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 kusama-runtime-constants = { workspace = true, default-features = true }
-kusama-runtime = { workspace = true, default-features = true }
+kusama-runtime = { workspace = true }

--- a/integration-tests/emulated/chains/relays/polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/relays/polkadot/Cargo.toml
@@ -27,4 +27,4 @@ emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 polkadot-runtime-constants = { workspace = true, default-features = true }
-polkadot-runtime = { workspace = true, default-features = true }
+polkadot-runtime = { workspace = true }

--- a/pallets/rc-migrator/src/conviction_voting.rs
+++ b/pallets/rc-migrator/src/conviction_voting.rs
@@ -243,12 +243,10 @@ impl<T: Config> crate::types::RcMigrationCheck for ConvictionVotingMigrator<T> {
 		// Collect ClassLocksFor
 		for (account_id, balance_per_class) in pallet_conviction_voting::ClassLocksFor::<T>::iter()
 		{
-			let mut balance_per_class = balance_per_class.into_inner();
-			balance_per_class.retain(|(_, balance)| !balance.is_zero());
-			if !balance_per_class.is_empty() {
-				messages
-					.push(RcConvictionVotingMessage::ClassLocksFor(account_id, balance_per_class));
-			}
+			messages.push(RcConvictionVotingMessage::ClassLocksFor(
+				account_id,
+				balance_per_class.into_inner(),
+			));
 		}
 
 		messages

--- a/pallets/rc-migrator/src/conviction_voting.rs
+++ b/pallets/rc-migrator/src/conviction_voting.rs
@@ -115,12 +115,10 @@ impl<T: Config> PalletMigration for ConvictionVotingMigrator<T> {
 					match iter.next() {
 						Some((account_id, balance_per_class)) => {
 							ClassLocksFor::<T>::remove(&account_id);
-							if balance_per_class.len() > 0 {
-								messages.push(RcConvictionVotingMessage::ClassLocksFor(
-									account_id.clone(),
-									balance_per_class.into_inner(),
-								));
-							}
+							messages.push(RcConvictionVotingMessage::ClassLocksFor(
+								account_id.clone(),
+								balance_per_class.into_inner(),
+							));
 							ConvictionVotingStage::ClassLocksFor(Some(account_id))
 						},
 						None => ConvictionVotingStage::Finished,

--- a/pallets/rc-migrator/src/conviction_voting.rs
+++ b/pallets/rc-migrator/src/conviction_voting.rs
@@ -95,6 +95,7 @@ impl<T: Config> PalletMigration for ConvictionVotingMigrator<T> {
 					};
 					match iter.next() {
 						Some((account_id, class, voting)) => {
+							alias::VotingFor::<T>::remove(&account_id, &class);
 							messages.push(RcConvictionVotingMessage::VotingFor(
 								account_id.clone(),
 								class.clone(),

--- a/pallets/rc-migrator/src/conviction_voting.rs
+++ b/pallets/rc-migrator/src/conviction_voting.rs
@@ -95,21 +95,11 @@ impl<T: Config> PalletMigration for ConvictionVotingMigrator<T> {
 					};
 					match iter.next() {
 						Some((account_id, class, voting)) => {
-							alias::VotingFor::<T>::remove(&account_id, &class);
-							if Pallet::<T>::is_empty_conviction_vote(&voting) {
-								// from the Polkadot 17.01.2025 snapshot 20575 records
-								// issue: https://github.com/paritytech/polkadot-sdk/issues/7458
-								log::debug!(target: LOG_TARGET,
-									"VotingFor {:?} is ignored since it has zero voting capital",
-									(&account_id, &class)
-								);
-							} else {
-								messages.push(RcConvictionVotingMessage::VotingFor(
-									account_id.clone(),
-									class.clone(),
-									voting,
-								));
-							}
+							messages.push(RcConvictionVotingMessage::VotingFor(
+								account_id.clone(),
+								class.clone(),
+								voting,
+							));
 							ConvictionVotingStage::VotingFor(Some((account_id, class)))
 						},
 						None => ConvictionVotingStage::ClassLocksFor(None),
@@ -124,24 +114,10 @@ impl<T: Config> PalletMigration for ConvictionVotingMigrator<T> {
 					match iter.next() {
 						Some((account_id, balance_per_class)) => {
 							ClassLocksFor::<T>::remove(&account_id);
-							let mut balance_per_class = balance_per_class.into_inner();
-							balance_per_class.retain(|(class, balance)| {
-								if balance.is_zero() {
-									// from the Polkadot 17.01.2025 snapshot 8522 records
-									// issue: https://github.com/paritytech/polkadot-sdk/issues/7458
-									log::debug!(target: LOG_TARGET,
-										"ClassLocksFor {:?} is ignored since it has a zero balance",
-										(&account_id, &class)
-									);
-									false
-								} else {
-									true
-								}
-							});
 							if balance_per_class.len() > 0 {
 								messages.push(RcConvictionVotingMessage::ClassLocksFor(
 									account_id.clone(),
-									balance_per_class,
+									balance_per_class.into_inner(),
 								));
 							}
 							ConvictionVotingStage::ClassLocksFor(Some(account_id))
@@ -167,19 +143,6 @@ impl<T: Config> PalletMigration for ConvictionVotingMigrator<T> {
 			Ok(None)
 		} else {
 			Ok(Some(last_key))
-		}
-	}
-}
-
-impl<T: Config> Pallet<T> {
-	fn is_empty_conviction_vote(voting: &alias::VotingOf<T>) -> bool {
-		if !voting.locked_balance().is_zero() {
-			return false;
-		}
-		match voting {
-			Voting::Casting(casting) if casting.delegations.capital.is_zero() => true,
-			Voting::Delegating(delegating) if delegating.delegations.capital.is_zero() => true,
-			_ => false,
 		}
 	}
 }
@@ -273,9 +236,7 @@ impl<T: Config> crate::types::RcMigrationCheck for ConvictionVotingMigrator<T> {
 
 		// Collect VotingFor
 		for (account_id, class, voting) in alias::VotingFor::<T>::iter() {
-			if !Pallet::<T>::is_empty_conviction_vote(&voting) {
-				messages.push(RcConvictionVotingMessage::VotingFor(account_id, class, voting));
-			}
+			messages.push(RcConvictionVotingMessage::VotingFor(account_id, class, voting));
 		}
 
 		// Collect ClassLocksFor


### PR DESCRIPTION
Remove empty conviction voting filter.

Since the source of these empty votes is not fixed (more info https://github.com/paritytech/polkadot-sdk/issues/7458) we do not filter them while migrating data for simple post state assertion. 