### PR TITLE
[AHM] DMP prioritization on AH

### DIFF
--- a/integration-tests/ahm/src/bench_ah.rs
+++ b/integration-tests/ahm/src/bench_ah.rs
@@ -251,3 +251,17 @@ fn test_bench_receive_preimage_request_status() {
 		test_receive_preimage_request_status::<AssetHub>(BENCHMARK_N);
 	});
 }
+
+#[test]
+fn test_bench_force_dmp_queue_priority() {
+	new_test_ext().execute_with(|| {
+		test_force_dmp_queue_priority::<AssetHub>();
+	});
+}
+
+#[test]
+fn test_bench_set_dmp_queue_priority() {
+	new_test_ext().execute_with(|| {
+		test_set_dmp_queue_priority::<AssetHub>();
+	});
+}

--- a/integration-tests/ahm/src/lib.rs
+++ b/integration-tests/ahm/src/lib.rs
@@ -28,6 +28,7 @@ pub mod mock;
 pub mod multisig_still_work;
 pub mod multisig_test;
 pub mod proxy;
+pub mod queues_priority;
 pub mod tests;
 
 /// Imports for the AHM tests that can be reused for other chains.
@@ -65,10 +66,12 @@ pub mod porting_prelude {
 
 	// Convenience aliases:
 	pub use asset_hub_polkadot_runtime::{
-		Runtime as AhRuntime, RuntimeCall as AhRuntimeCall, RuntimeOrigin as AhRuntimeOrigin,
+		Runtime as AhRuntime, RuntimeCall as AhRuntimeCall, RuntimeEvent as AhRuntimeEvent,
+		RuntimeOrigin as AhRuntimeOrigin,
 	};
 	pub use polkadot_runtime::{
-		Runtime as RcRuntime, RuntimeCall as RcRuntimeCall, RuntimeOrigin as RcRuntimeOrigin,
+		Runtime as RcRuntime, RuntimeCall as RcRuntimeCall, RuntimeEvent as RcRuntimeEvent,
+		RuntimeOrigin as RcRuntimeOrigin,
 	};
 
 	// Westend does not support remote proxies, so we have to figure out the import location:

--- a/integration-tests/ahm/src/queues_priority.rs
+++ b/integration-tests/ahm/src/queues_priority.rs
@@ -1,0 +1,181 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::porting_prelude::*;
+use asset_hub_polkadot_runtime::{AhMigrator, BuildStorage};
+use frame_support::traits::OnFinalize;
+use pallet_ah_migrator::{
+	AhMigrationStage, DmpQueuePriority, DmpQueuePriorityConfig,
+	Event::DmpQueuePrioritySet as DmpQueuePrioritySetEvent, MigrationStage,
+};
+
+#[test]
+fn test_force_dmp_queue_priority() {
+	let mut t: sp_io::TestExternalities = frame_system::GenesisConfig::<AhRuntime>::default()
+		.build_storage()
+		.unwrap()
+		.into();
+
+	// prioritization is not even attempted if the migration is not ongoing
+	t.execute_with(|| {
+		let now = 1;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::Pending);
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		let events = frame_system::Pallet::<AhRuntime>::events();
+		assert!(!events.iter().any(|record| {
+			matches!(record.event, AhRuntimeEvent::AhMigrator(DmpQueuePrioritySetEvent { .. }))
+		}));
+	});
+
+	// prioritization with default config setup is attempted if the migration is ongoing
+	t.execute_with(|| {
+		let now = 1;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		let events = frame_system::Pallet::<AhRuntime>::events();
+		assert!(events.iter().any(|record| {
+			matches!(record.event, AhRuntimeEvent::AhMigrator(DmpQueuePrioritySetEvent { .. }))
+		}));
+	});
+
+	// prioritization is disabled
+	t.execute_with(|| {
+		let now = 1;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::Disabled);
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		let events = frame_system::Pallet::<AhRuntime>::events();
+		assert!(!events.iter().any(|record| {
+			matches!(record.event, AhRuntimeEvent::AhMigrator(DmpQueuePrioritySetEvent { .. }))
+		}));
+	});
+
+	// prioritization with (10, 2) pattern
+
+	t.execute_with(|| {
+		let now = 11;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::OverrideConfig(10, 2));
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		frame_system::Pallet::<AhRuntime>::assert_has_event(AhRuntimeEvent::AhMigrator(
+			DmpQueuePrioritySetEvent { prioritized: false, cycle_block: 12, cycle_period: 12 }
+				.into(),
+		));
+	});
+
+	t.execute_with(|| {
+		let now = 12;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::OverrideConfig(10, 2));
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		frame_system::Pallet::<AhRuntime>::assert_has_event(AhRuntimeEvent::AhMigrator(
+			DmpQueuePrioritySetEvent { prioritized: true, cycle_block: 1, cycle_period: 12 }.into(),
+		));
+	});
+
+	t.execute_with(|| {
+		let now = 13;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::OverrideConfig(10, 2));
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		frame_system::Pallet::<AhRuntime>::assert_has_event(AhRuntimeEvent::AhMigrator(
+			DmpQueuePrioritySetEvent { prioritized: true, cycle_block: 2, cycle_period: 12 }.into(),
+		));
+	});
+
+	t.execute_with(|| {
+		let now = 21;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::OverrideConfig(10, 2));
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		frame_system::Pallet::<AhRuntime>::assert_has_event(AhRuntimeEvent::AhMigrator(
+			DmpQueuePrioritySetEvent { prioritized: true, cycle_block: 10, cycle_period: 12 }
+				.into(),
+		));
+	});
+
+	t.execute_with(|| {
+		let now = 22;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::OverrideConfig(10, 2));
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		frame_system::Pallet::<AhRuntime>::assert_has_event(AhRuntimeEvent::AhMigrator(
+			DmpQueuePrioritySetEvent { prioritized: false, cycle_block: 11, cycle_period: 12 }
+				.into(),
+		));
+	});
+
+	t.execute_with(|| {
+		let now = 23;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::OverrideConfig(10, 2));
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		frame_system::Pallet::<AhRuntime>::assert_has_event(AhRuntimeEvent::AhMigrator(
+			DmpQueuePrioritySetEvent { prioritized: false, cycle_block: 12, cycle_period: 12 }
+				.into(),
+		));
+	});
+
+	t.execute_with(|| {
+		let now = 24;
+		frame_system::Pallet::<AhRuntime>::reset_events();
+		frame_system::Pallet::<AhRuntime>::set_block_number(now);
+
+		AhMigrationStage::<AhRuntime>::put(MigrationStage::DataMigrationOngoing);
+		DmpQueuePriorityConfig::<AhRuntime>::put(DmpQueuePriority::OverrideConfig(10, 2));
+		<AhMigrator as OnFinalize<_>>::on_finalize(now);
+
+		frame_system::Pallet::<AhRuntime>::assert_has_event(AhRuntimeEvent::AhMigrator(
+			DmpQueuePrioritySetEvent { prioritized: true, cycle_block: 1, cycle_period: 12 }.into(),
+		));
+	});
+}

--- a/pallets/ah-migrator/src/benchmarking.rs
+++ b/pallets/ah-migrator/src/benchmarking.rs
@@ -941,14 +941,15 @@ pub mod benchmarks {
 
 	#[benchmark]
 	fn set_dmp_queue_priority() {
-		let priority = DmpQueuePriority::OverrideConfig(
+		let old = DmpQueuePriorityConfig::<T>::get();
+		let new = DmpQueuePriority::OverrideConfig(
 			BlockNumberFor::<T>::from(10u32),
 			BlockNumberFor::<T>::from(1u32),
 		);
 		#[extrinsic_call]
-		_(RawOrigin::Root, priority.clone());
+		_(RawOrigin::Root, new.clone());
 
-		assert_last_event::<T>(Event::DmpQueuePriorityConfigSet { priority }.into());
+		assert_last_event::<T>(Event::DmpQueuePriorityConfigSet { old, new }.into());
 	}
 
 	#[cfg(feature = "std")]

--- a/pallets/ah-migrator/src/benchmarking.rs
+++ b/pallets/ah-migrator/src/benchmarking.rs
@@ -932,7 +932,7 @@ pub mod benchmarks {
 		assert_last_event::<T>(
 			Event::DmpQueuePrioritySet {
 				prioritized: true,
-				cycle_block: now,
+				cycle_block: now + BlockNumberFor::<T>::from(1u32),
 				cycle_period: priority_blocks + round_robin_blocks,
 			}
 			.into(),

--- a/pallets/ah-migrator/src/benchmarking.rs
+++ b/pallets/ah-migrator/src/benchmarking.rs
@@ -901,16 +901,54 @@ pub mod benchmarks {
 
 	#[benchmark]
 	fn finish_migration() {
+		AhMigrationStage::<T>::put(MigrationStage::DataMigrationOngoing);
 		#[extrinsic_call]
 		_(RawOrigin::Root, MigrationFinishedData { rc_balance_kept: 100 });
 
 		assert_last_event::<T>(
 			Event::StageTransition {
-				old: MigrationStage::Pending,
+				old: MigrationStage::DataMigrationOngoing,
 				new: MigrationStage::MigrationDone,
 			}
 			.into(),
 		);
+	}
+
+	#[benchmark]
+	fn force_dmp_queue_priority() {
+		let now = BlockNumberFor::<T>::from(1u32);
+		let priority_blocks = BlockNumberFor::<T>::from(10u32);
+		let round_robin_blocks = BlockNumberFor::<T>::from(1u32);
+		DmpQueuePriorityConfig::<T>::put(DmpQueuePriority::OverrideConfig(
+			priority_blocks,
+			round_robin_blocks,
+		));
+
+		#[block]
+		{
+			Pallet::<T>::force_dmp_queue_priority(now)
+		}
+
+		assert_last_event::<T>(
+			Event::DmpQueuePrioritySet {
+				prioritized: true,
+				cycle_block: now,
+				cycle_period: priority_blocks + round_robin_blocks,
+			}
+			.into(),
+		);
+	}
+
+	#[benchmark]
+	fn set_dmp_queue_priority() {
+		let priority = DmpQueuePriority::OverrideConfig(
+			BlockNumberFor::<T>::from(10u32),
+			BlockNumberFor::<T>::from(1u32),
+		);
+		#[extrinsic_call]
+		_(RawOrigin::Root, priority.clone());
+
+		assert_last_event::<T>(Event::DmpQueuePriorityConfigSet { priority }.into());
 	}
 
 	#[cfg(feature = "std")]
@@ -1172,5 +1210,23 @@ pub mod benchmarks {
 		ConvictionVotingIndexOf<T>: From<u8>,
 	{
 		_receive_preimage_chunk::<T>(m, true)
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_force_dmp_queue_priority<T>()
+	where
+		T: Config,
+		ConvictionVotingIndexOf<T>: From<u8>,
+	{
+		_force_dmp_queue_priority::<T>(true)
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_set_dmp_queue_priority<T>()
+	where
+		T: Config,
+		ConvictionVotingIndexOf<T>: From<u8>,
+	{
+		_set_dmp_queue_priority::<T>(true)
 	}
 }

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -1056,6 +1056,11 @@ pub mod pallet {
 				"Failed to send XCM message to update XCM data message processed count"
 			);
 		}
+
+		fn integrity_test() {
+			let (dmp_priority_blocks, _) = T::DmpQueuePriorityPattern::get();
+			assert!(!dmp_priority_blocks.is_zero(), "the `dmp_priority_blocks` should be non-zero");
+		}
 	}
 
 	impl<T: Config> Pallet<T> {

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -488,8 +488,10 @@ pub mod pallet {
 		},
 		/// The DMP queue priority config was set.
 		DmpQueuePriorityConfigSet {
+			/// The old priority pattern.
+			old: DmpQueuePriority<BlockNumberFor<T>>,
 			/// The new priority pattern.
-			priority: DmpQueuePriority<BlockNumberFor<T>>,
+			new: DmpQueuePriority<BlockNumberFor<T>>,
 		},
 	}
 
@@ -977,11 +979,12 @@ pub mod pallet {
 		#[pallet::weight(T::AhWeightInfo::set_dmp_queue_priority())]
 		pub fn set_dmp_queue_priority(
 			origin: OriginFor<T>,
-			priority: DmpQueuePriority<BlockNumberFor<T>>,
+			new: DmpQueuePriority<BlockNumberFor<T>>,
 		) -> DispatchResult {
 			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
-			DmpQueuePriorityConfig::<T>::put(priority.clone());
-			Self::deposit_event(Event::DmpQueuePriorityConfigSet { priority });
+			let old = DmpQueuePriorityConfig::<T>::get();
+			DmpQueuePriorityConfig::<T>::put(new.clone());
+			Self::deposit_event(Event::DmpQueuePriorityConfigSet { old, new });
 			Ok(())
 		}
 

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -989,6 +989,8 @@ pub mod pallet {
 		}
 
 		/// Set the DMP queue priority configuration.
+		///
+		/// Can only be called by the `ManagerOrigin`.
 		#[pallet::call_index(102)]
 		#[pallet::weight(T::AhWeightInfo::set_dmp_queue_priority())]
 		pub fn set_dmp_queue_priority(

--- a/pallets/rc-migrator/src/weights_ah.rs
+++ b/pallets/rc-migrator/src/weights_ah.rs
@@ -81,6 +81,8 @@ pub trait WeightInfo {
 	fn start_migration() -> Weight;
 	fn finish_migration() -> Weight;
 	fn receive_preimage_chunk(m: u32, ) -> Weight;
+	fn set_dmp_queue_priority() -> Weight;
+	fn force_dmp_queue_priority() -> Weight;
 }
 
 /// Weights for `pallet_ah_migrator` using the Substrate node and recommended hardware.
@@ -630,6 +632,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	fn set_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
+	fn force_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -1177,5 +1185,11 @@ impl WeightInfo for () {
 		Weight::from_parts(21_000_000, 3593)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	fn set_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
+	fn force_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
 	}
 }

--- a/relay/polkadot/src/weights/pallet_ah_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_ah_migrator.rs
@@ -621,4 +621,10 @@ impl<T: crate::ah_migration::weights::DbConfig> pallet_rc_migrator::weights_ah::
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	fn set_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
+	fn force_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1131,6 +1131,10 @@ impl pallet_ah_ops::Config for Runtime {
 	type WeightInfo = weights::pallet_ah_ops::WeightInfo<Runtime>;
 }
 
+parameter_types! {
+	pub const DmpQueuePriorityPattern: (BlockNumber, BlockNumber) = (18, 2);
+}
+
 impl pallet_ah_migrator::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeEvent = RuntimeEvent;
@@ -1159,6 +1163,9 @@ impl pallet_ah_migrator::Config for Runtime {
 	type RcToAhTreasurySpend = ah_migration::RcToAhTreasurySpend;
 	type AhIntraMigrationCalls = ah_migration::call_filter::CallsEnabledDuringMigration;
 	type AhPostMigrationCalls = ah_migration::call_filter::CallsEnabledAfterMigration;
+	// TODO: set actual message queue instance when upgraded to sdk/2503
+	type MessageQueue = ();
+	type DmpQueuePriorityPattern = DmpQueuePriorityPattern;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_ah_migrator.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_ah_migrator.rs
@@ -621,4 +621,10 @@ impl<T: frame_system::Config> pallet_ah_migrator::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	fn set_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
+	fn force_dmp_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
 }


### PR DESCRIPTION
DMP queue prioritization over HRMP on AH during migration.

Implements DMP queue prioritization during Asset Hub migration by setting the message queue head to the Relay Chain origin on block finalization. This ensures Relay Chain messages (or DMP) are processed first in the next block instead of following the default round-robin pattern.

To maintain balanced processing of HRMP messages, the system allows configuration of a repeating priority pattern:
- Number of consecutive blocks where Relay Chain messages get priority
- Number of blocks for normal round-robin processing

The priority pattern can be configured either through pallet config or runtime call override, with three options:
- Default pallet configuration
- Custom pattern (e.g., 18 blocks priority, 2 blocks round-robin)
- Disabled priority

Refer to the types documentation for more details.