### PR TITLE
Add Secretary Salary Pay Test Over XCM

### DIFF
--- a/integration-tests/emulated/tests/collectives/collectives-polkadot/src/tests/collectives_salary.rs
+++ b/integration-tests/emulated/tests/collectives/collectives-polkadot/src/tests/collectives_salary.rs
@@ -16,6 +16,7 @@
 use crate::*;
 use asset_hub_polkadot_runtime::xcm_config::LocationToAccountId;
 use collectives_polkadot_runtime::fellowship::FellowshipSalaryPaymaster;
+use collectives_polkadot_runtime::secretary::SecretarySalaryPaymaster;
 use frame_support::{
 	assert_ok,
 	traits::{fungibles::Mutate, tokens::Pay},
@@ -25,8 +26,10 @@ use xcm_executor::traits::ConvertLocation;
 const FELLOWSHIP_SALARY_PALLET_ID: u8 =
 	collectives_polkadot_runtime_constants::FELLOWSHIP_SALARY_PALLET_INDEX;
 
+const SECRETARY_SALARY_PALLET_ID: u8 = collectives_polkadot_runtime_constants::SECRETARY_SALARY_PALLET_INDEX;
+
 #[test]
-fn pay_salary() {
+fn pay_salary_technical_fellowship() {
 	const USDT_ID: u32 = 1984;
 	let fellowship_salary = (
 		Parent,
@@ -47,6 +50,48 @@ fn pay_salary() {
 		type RuntimeEvent = <CollectivesPolkadot as Chain>::RuntimeEvent;
 
 		assert_ok!(FellowshipSalaryPaymaster::pay(&pay_to, (), pay_amount));
+		assert_expected_events!(
+			CollectivesPolkadot,
+			vec![
+				RuntimeEvent::XcmpQueue(cumulus_pallet_xcmp_queue::Event::XcmpMessageSent { .. }) => {},
+			]
+		);
+	});
+
+	AssetHubPolkadot::execute_with(|| {
+		type RuntimeEvent = <AssetHubPolkadot as Chain>::RuntimeEvent;
+		assert_expected_events!(
+			AssetHubPolkadot,
+			vec![
+				RuntimeEvent::Assets(pallet_assets::Event::Transferred { .. }) => {},
+				RuntimeEvent::MessageQueue(pallet_message_queue::Event::Processed { success: true ,.. }) => {},
+			]
+		);
+	});
+}
+
+#[test]
+fn pay_salary_secretary() {
+	const USDT_ID: u32 = 1984;
+	let secretary_salary = (
+		Parent,
+		Parachain(CollectivesPolkadot::para_id().into()),
+		PalletInstance(SECRETARY_SALARY_PALLET_ID),
+	);
+	let pay_from = LocationToAccountId::convert_location(&secretary_salary.into()).unwrap();
+	let pay_to = Polkadot::account_id_of(ALICE);
+	let pay_amount = 9_000_000_000;
+
+	AssetHubPolkadot::execute_with(|| {
+		type AssetHubAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
+		// USDT registered in genesis, now mint some into the payer's account
+		assert_ok!(<AssetHubAssets as Mutate<_>>::mint_into(USDT_ID, &pay_from, pay_amount * 2));
+	});
+
+	CollectivesPolkadot::execute_with(|| {
+		type RuntimeEvent = <CollectivesPolkadot as Chain>::RuntimeEvent;
+
+		assert_ok!(SecretarySalaryPaymaster::pay(&pay_to, (), pay_amount));
 		assert_expected_events!(
 			CollectivesPolkadot,
 			vec![

--- a/integration-tests/emulated/tests/collectives/collectives-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/collectives/collectives-polkadot/src/tests/mod.rs
@@ -14,6 +14,6 @@
 // limitations under the License.
 
 mod fellowship;
-mod fellowship_salary;
+mod collectives_salary;
 mod fellowship_treasury;
 mod teleport;


### PR DESCRIPTION
This PR adds test coverage for XCM-based salary payments to Secretary members in the Collectives parachain. The implementation verifies end-to-end functionality of the SecretarySalaryPaymaster by:

- Creating a dedicated test case that mirrors existing Fellowship salary payment tests.

- Validating proper XCM message construction and delivery.

- Confirming correct asset transfer execution across parachains.

- Ensuring successful processing of salary payments through the entire stack.