### PR TITLE
[AHM]  Flow Control System

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8892,6 +8892,7 @@ dependencies = [
  "pallet-staking",
  "pallet-treasury",
  "pallet-vesting",
+ "pallet-xcm",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-runtime-common",

--- a/integration-tests/ahm/src/bench_ah.rs
+++ b/integration-tests/ahm/src/bench_ah.rs
@@ -64,13 +64,6 @@ fn test_bench_receive_multisigs() {
 }
 
 #[test]
-fn test_bench_on_finalize() {
-	new_test_ext().execute_with(|| {
-		test_on_finalize::<AssetHub>();
-	});
-}
-
-#[test]
 fn test_bench_receive_proxy_proxies() {
 	new_test_ext().execute_with(|| {
 		test_receive_proxy_proxies::<AssetHub>(BENCHMARK_N);

--- a/integration-tests/ahm/src/bench_rc.rs
+++ b/integration-tests/ahm/src/bench_rc.rs
@@ -71,3 +71,10 @@ fn test_bench_send_chunked_xcm_and_track() {
 		test_send_chunked_xcm_and_track::<RelayChain>();
 	});
 }
+
+#[test]
+fn test_bench_receive_query_response() {
+	new_test_ext().execute_with(|| {
+		test_receive_query_response::<RelayChain>();
+	});
+}

--- a/integration-tests/ahm/src/bench_rc.rs
+++ b/integration-tests/ahm/src/bench_rc.rs
@@ -66,13 +66,6 @@ fn test_bench_start_data_migration() {
 }
 
 #[test]
-fn test_bench_update_ah_msg_processed_count() {
-	new_test_ext().execute_with(|| {
-		test_update_ah_msg_processed_count::<RelayChain>();
-	});
-}
-
-#[test]
 fn test_bench_send_chunked_xcm_and_track() {
 	new_test_ext().execute_with(|| {
 		test_send_chunked_xcm_and_track::<RelayChain>();

--- a/integration-tests/ahm/src/bench_rc.rs
+++ b/integration-tests/ahm/src/bench_rc.rs
@@ -78,3 +78,10 @@ fn test_bench_receive_query_response() {
 		test_receive_query_response::<RelayChain>();
 	});
 }
+
+#[test]
+fn test_bench_resend_xcm() {
+	new_test_ext().execute_with(|| {
+		test_resend_xcm::<RelayChain>();
+	});
+}

--- a/integration-tests/ahm/src/bench_rc.rs
+++ b/integration-tests/ahm/src/bench_rc.rs
@@ -85,3 +85,10 @@ fn test_bench_resend_xcm() {
 		test_resend_xcm::<RelayChain>();
 	});
 }
+
+#[test]
+fn test_bench_set_unprocessed_msg_buffer() {
+	new_test_ext().execute_with(|| {
+		test_set_unprocessed_msg_buffer::<RelayChain>();
+	});
+}

--- a/integration-tests/ahm/src/mock.rs
+++ b/integration-tests/ahm/src/mock.rs
@@ -26,8 +26,8 @@ use cumulus_primitives_core::{
 use frame_support::traits::{EnqueueMessage, OnFinalize, OnInitialize};
 use frame_system::pallet_prelude::BlockNumberFor;
 use pallet_rc_migrator::{
-	DmpDataMessageCounts as RcDmpDataMessageCounts, MigrationStage as RcMigrationStage,
-	MigrationStageOf as RcMigrationStageOf, RcMigrationStage as RcMigrationStageStorage,
+	MigrationStage as RcMigrationStage, MigrationStageOf as RcMigrationStageOf,
+	RcMigrationStage as RcMigrationStageStorage,
 };
 use polkadot_primitives::UpwardMessage;
 use polkadot_runtime::{
@@ -285,11 +285,6 @@ pub fn rc_migrate(
 		// Loop until no more DMPs are added and we had at least 1
 		loop {
 			next_block_rc();
-
-			// Bypass the unconfirmed DMP messages limit since we do not send the messages to the AH
-			// on every RC block.
-			let (sent, _) = RcDmpDataMessageCounts::<Polkadot>::get();
-			RcDmpDataMessageCounts::<Polkadot>::put((sent, sent));
 
 			let new_dmps = DownwardMessageQueues::<Polkadot>::take(para_id);
 			dmps.extend(new_dmps);

--- a/pallets/ah-migrator/src/benchmarking.rs
+++ b/pallets/ah-migrator/src/benchmarking.rs
@@ -66,17 +66,6 @@ pub mod benchmarks {
 	use super::*;
 
 	#[benchmark]
-	fn on_finalize() {
-		let block_num = BlockNumberFor::<T>::from(1u32);
-		DmpDataMessageCounts::<T>::put((1, 0));
-
-		#[block]
-		{
-			Pallet::<T>::on_finalize(block_num)
-		}
-	}
-
-	#[benchmark]
 	fn receive_multisigs(n: Linear<1, 255>) {
 		let create_multisig = |n: u8| -> RcMultisigOf<T> {
 			let creator: AccountId32 = [n; 32].into();
@@ -382,7 +371,7 @@ pub mod benchmarks {
 		}
 
 		#[extrinsic_call]
-		_(RawOrigin::Root, referendum_count, deciding_count, track_queue);
+		_(RawOrigin::Root, vec![(referendum_count, deciding_count, track_queue)]);
 
 		assert_last_event::<T>(
 			Event::BatchProcessed {
@@ -901,12 +890,14 @@ pub mod benchmarks {
 
 	#[benchmark]
 	fn finish_migration() {
+		AhMigrationStage::<T>::put(&MigrationStage::DataMigrationOngoing);
+
 		#[extrinsic_call]
 		_(RawOrigin::Root, MigrationFinishedData { rc_balance_kept: 100 });
 
 		assert_last_event::<T>(
 			Event::StageTransition {
-				old: MigrationStage::Pending,
+				old: MigrationStage::DataMigrationOngoing,
 				new: MigrationStage::MigrationDone,
 			}
 			.into(),
@@ -920,15 +911,6 @@ pub mod benchmarks {
 		ConvictionVotingIndexOf<T>: From<u8>,
 	{
 		_receive_multisigs::<T>(n, true /* enable checks */)
-	}
-
-	#[cfg(feature = "std")]
-	pub fn test_on_finalize<T>()
-	where
-		T: Config,
-		ConvictionVotingIndexOf<T>: From<u8>,
-	{
-		_on_finalize::<T>(true)
 	}
 
 	#[cfg(feature = "std")]

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -569,6 +569,8 @@ pub mod pallet {
 		) -> DispatchResult {
 			ensure_root(origin)?;
 
+			ensure!(values.len() == 1, Error::<T>::InvalidParameters);
+
 			let (referendum_count, deciding_count, track_queue) =
 				values.pop().ok_or(Error::<T>::InvalidParameters)?;
 

--- a/pallets/rc-migrator/Cargo.toml
+++ b/pallets/rc-migrator/Cargo.toml
@@ -38,6 +38,7 @@ pallet-fast-unstake = { workspace = true }
 pallet-referenda = { workspace = true }
 pallet-vesting = { workspace = true }
 pallet-nomination-pools = { workspace = true }
+pallet-xcm = { workspace = true }
 polkadot-runtime-common = { workspace = true }
 runtime-parachains = { workspace = true }
 polkadot-parachain-primitives = { workspace = true }
@@ -74,6 +75,7 @@ std = [
 	"pallet-staking/std",
 	"pallet-treasury/std",
 	"pallet-vesting/std",
+	"pallet-xcm/std",
 	"polkadot-parachain-primitives/std",
 	"polkadot-runtime-common/std",
 	"polkadot-runtime-constants/std",
@@ -113,6 +115,7 @@ runtime-benchmarks = [
 	"pallet-staking/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"pallet-vesting/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"polkadot-runtime-common/runtime-benchmarks",
 	"polkadot-runtime-constants/runtime-benchmarks",
@@ -142,6 +145,7 @@ try-runtime = [
 	"pallet-staking/try-runtime",
 	"pallet-treasury/try-runtime",
 	"pallet-vesting/try-runtime",
+	"pallet-xcm/try-runtime",
 	"polkadot-runtime-common/try-runtime",
 	"runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",

--- a/pallets/rc-migrator/src/benchmarking.rs
+++ b/pallets/rc-migrator/src/benchmarking.rs
@@ -89,12 +89,14 @@ pub mod benchmarks {
 
 	#[benchmark]
 	fn start_data_migration() {
+		RcMigrationStage::<T>::put(&MigrationStage::WaitingForAh);
+
 		#[extrinsic_call]
 		_(RawOrigin::Root);
 
 		assert_last_event::<T>(
 			Event::StageTransition {
-				old: MigrationStageOf::<T>::Pending,
+				old: MigrationStageOf::<T>::WaitingForAh,
 				new: MigrationStageOf::<T>::Starting,
 			}
 			.into(),
@@ -117,18 +119,6 @@ pub mod benchmarks {
 		}
 	}
 
-	#[benchmark]
-	fn update_ah_msg_processed_count() {
-		let new_processed = 100;
-
-		#[extrinsic_call]
-		_(RawOrigin::Root, new_processed);
-
-		let (sent, processed) = DmpDataMessageCounts::<T>::get();
-		assert_eq!(processed, new_processed);
-		assert_eq!(sent, 0);
-	}
-
 	#[cfg(feature = "std")]
 	pub fn test_withdraw_account<T: Config>() {
 		_withdraw_account::<T>(true /* enable checks */)
@@ -147,11 +137,6 @@ pub mod benchmarks {
 	#[cfg(feature = "std")]
 	pub fn test_start_data_migration<T: Config>() {
 		_start_data_migration::<T>(true /* enable checks */);
-	}
-
-	#[cfg(feature = "std")]
-	pub fn test_update_ah_msg_processed_count<T: Config>() {
-		_update_ah_msg_processed_count::<T>(true /* enable checks */);
 	}
 
 	#[cfg(feature = "std")]

--- a/pallets/rc-migrator/src/benchmarking.rs
+++ b/pallets/rc-migrator/src/benchmarking.rs
@@ -140,6 +140,22 @@ pub mod benchmarks {
 		);
 	}
 
+	#[benchmark]
+	fn resend_xcm() {
+		let query_id = 1;
+		let xcm = Xcm(vec![Instruction::UnpaidExecution {
+			weight_limit: WeightLimit::Unlimited,
+			check_origin: None,
+		}]);
+		PendingXcmMessages::<T>::insert(query_id, xcm);
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, query_id);
+
+		assert!(PendingXcmMessages::<T>::get(query_id).is_some());
+		assert_last_event::<T>(Event::XcmResendAttempt { query_id, send_error: None }.into());
+	}
+
 	#[cfg(feature = "std")]
 	pub fn test_withdraw_account<T: Config>() {
 		_withdraw_account::<T>(true /* enable checks */)
@@ -168,5 +184,10 @@ pub mod benchmarks {
 	#[cfg(feature = "std")]
 	pub fn test_receive_query_response<T: Config>() {
 		_receive_query_response::<T>(true /* enable checks */);
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_resend_xcm<T: Config>() {
+		_resend_xcm::<T>(true /* enable checks */);
 	}
 }

--- a/pallets/rc-migrator/src/benchmarking.rs
+++ b/pallets/rc-migrator/src/benchmarking.rs
@@ -119,6 +119,27 @@ pub mod benchmarks {
 		}
 	}
 
+	#[benchmark]
+	fn receive_query_response() {
+		let query_id = 1;
+		let xcm = Xcm(vec![Instruction::UnpaidExecution {
+			weight_limit: WeightLimit::Unlimited,
+			check_origin: None,
+		}]);
+		PendingXcmMessages::<T>::insert(query_id, xcm);
+
+		let maybe_error = MaybeErrorCode::Success;
+		let response = Response::DispatchResult(maybe_error.clone());
+
+		#[extrinsic_call]
+		_(RawOrigin::Root, query_id, response);
+
+		assert!(PendingXcmMessages::<T>::get(query_id).is_none());
+		assert_last_event::<T>(
+			Event::QueryResponseReceived { query_id, response: maybe_error }.into(),
+		);
+	}
+
 	#[cfg(feature = "std")]
 	pub fn test_withdraw_account<T: Config>() {
 		_withdraw_account::<T>(true /* enable checks */)
@@ -142,5 +163,10 @@ pub mod benchmarks {
 	#[cfg(feature = "std")]
 	pub fn test_send_chunked_xcm_and_track<T: Config>() {
 		_send_chunked_xcm_and_track::<T>(true /* enable checks */);
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_receive_query_response<T: Config>() {
+		_receive_query_response::<T>(true /* enable checks */);
 	}
 }

--- a/pallets/rc-migrator/src/benchmarking.rs
+++ b/pallets/rc-migrator/src/benchmarking.rs
@@ -156,6 +156,18 @@ pub mod benchmarks {
 		assert_last_event::<T>(Event::XcmResendAttempt { query_id, send_error: None }.into());
 	}
 
+	#[benchmark]
+	fn set_unprocessed_msg_buffer() {
+		let old = Pallet::<T>::get_unprocessed_msg_buffer_size();
+		let size = 111u32;
+		#[extrinsic_call]
+		_(RawOrigin::Root, Some(size));
+
+		let new = Pallet::<T>::get_unprocessed_msg_buffer_size();
+		assert_eq!(new, size);
+		assert_last_event::<T>(Event::UnprocessedMsgBufferSet { new: size, old }.into());
+	}
+
 	#[cfg(feature = "std")]
 	pub fn test_withdraw_account<T: Config>() {
 		_withdraw_account::<T>(true /* enable checks */)
@@ -189,5 +201,10 @@ pub mod benchmarks {
 	#[cfg(feature = "std")]
 	pub fn test_resend_xcm<T: Config>() {
 		_resend_xcm::<T>(true /* enable checks */);
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_set_unprocessed_msg_buffer<T: Config>() {
+		_set_unprocessed_msg_buffer::<T>(true /* enable checks */);
 	}
 }

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -615,7 +615,7 @@ pub mod pallet {
 
 		/// Receive a query response from the Asset Hub for a previously sent xcm message.
 		#[pallet::call_index(3)]
-		#[pallet::weight({1})] // TODO: weight
+		#[pallet::weight(T::RcWeightInfo::receive_query_response())]
 		pub fn receive_query_response(
 			origin: OriginFor<T>,
 			query_id: u64,

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -1594,7 +1594,7 @@ pub mod pallet {
 					SetAppendix(Xcm(vec![ReportTransactStatus(QueryResponseInfo {
 						destination: Location::parent(),
 						query_id,
-						max_weight: Weight::from_all(1), // TODO: weight
+						max_weight: T::RcWeightInfo::receive_query_response(),
 					})])),
 				]);
 

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -68,9 +68,14 @@ pub enum AhMigratorCall<T: Config> {
 	ReceiveFastUnstakeMessages { messages: Vec<staking::fast_unstake::RcFastUnstakeMessage<T>> },
 	#[codec(index = 10)]
 	ReceiveReferendaValues {
-		referendum_count: u32,
-		deciding_count: Vec<(TrackIdOf<T, ()>, u32)>,
-		track_queue: Vec<(TrackIdOf<T, ()>, Vec<(u32, u128)>)>,
+		values: Vec<(
+			// referendum_count
+			u32,
+			// deciding_count (track_id, count)
+			Vec<(TrackIdOf<T, ()>, u32)>,
+			// track_queue (referendum_id, votes)
+			Vec<(TrackIdOf<T, ()>, Vec<(u32, u128)>)>,
+		)>,
 	},
 	#[codec(index = 11)]
 	ReceiveReferendums { referendums: Vec<(u32, ReferendumInfoOf<T, ()>)> },

--- a/pallets/rc-migrator/src/weights.rs
+++ b/pallets/rc-migrator/src/weights.rs
@@ -59,6 +59,7 @@ pub trait WeightInfo {
 	fn send_chunked_xcm_and_track() -> Weight;
 	fn update_ah_msg_processed_count() -> Weight;
 	fn receive_query_response() -> Weight;
+	fn resend_xcm() -> Weight;
 }
 
 /// Weights for `pallet_rc_migrator` using the Substrate node and recommended hardware.
@@ -151,6 +152,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn receive_query_response() -> Weight {
 		Weight::from_parts(10_000_000, 1000)
 	}
+	fn resend_xcm() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -241,6 +245,10 @@ impl WeightInfo for () {
 	}
 
 	fn receive_query_response() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
+
+	fn resend_xcm() -> Weight {
 		Weight::from_parts(10_000_000, 1000)
 	}
 }

--- a/pallets/rc-migrator/src/weights.rs
+++ b/pallets/rc-migrator/src/weights.rs
@@ -58,6 +58,7 @@ pub trait WeightInfo {
 	fn start_data_migration() -> Weight;
 	fn send_chunked_xcm_and_track() -> Weight;
 	fn update_ah_msg_processed_count() -> Weight;
+	fn receive_query_response() -> Weight;
 }
 
 /// Weights for `pallet_rc_migrator` using the Substrate node and recommended hardware.
@@ -147,6 +148,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	fn receive_query_response() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -234,5 +238,9 @@ impl WeightInfo for () {
 		Weight::from_parts(9_000_000, 1493)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+
+	fn receive_query_response() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
 	}
 }

--- a/pallets/rc-migrator/src/weights.rs
+++ b/pallets/rc-migrator/src/weights.rs
@@ -60,6 +60,7 @@ pub trait WeightInfo {
 	fn update_ah_msg_processed_count() -> Weight;
 	fn receive_query_response() -> Weight;
 	fn resend_xcm() -> Weight;
+	fn set_unprocessed_msg_buffer() -> Weight;
 }
 
 /// Weights for `pallet_rc_migrator` using the Substrate node and recommended hardware.
@@ -153,6 +154,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(10_000_000, 1000)
 	}
 	fn resend_xcm() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
+	fn set_unprocessed_msg_buffer() -> Weight {
 		Weight::from_parts(10_000_000, 1000)
 	}
 }
@@ -249,6 +253,10 @@ impl WeightInfo for () {
 	}
 
 	fn resend_xcm() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
+
+	fn set_unprocessed_msg_buffer() -> Weight {
 		Weight::from_parts(10_000_000, 1000)
 	}
 }

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1527,6 +1527,7 @@ parameter_types! {
 	pub AhMigratorMaxWeight: Weight = Perbill::from_percent(80) * AhMqServiceWeight::get(); // ~ 0.2 sec + 2 mb
 	pub RcMigratorMaxWeight: Weight = Perbill::from_percent(50) * BlockWeights::get().max_block; // TODO set the actual max weight
 	pub AhExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT / 100;
+	pub const XcmResponseTimeout: BlockNumber = 30 * DAYS;
 }
 
 pub struct ContainsAssetHub;
@@ -1537,6 +1538,8 @@ impl Contains<Location> for ContainsAssetHub {
 }
 
 impl pallet_rc_migrator::Config for Runtime {
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeEvent = RuntimeEvent;
 	type ManagerOrigin = EitherOfDiverse<
@@ -1559,6 +1562,7 @@ impl pallet_rc_migrator::Config for Runtime {
 	type StakingDelegationReason = ahm_phase1::StakingDelegationReason;
 	type OnDemandPalletId = OnDemandPalletId;
 	type UnprocessedMsgBuffer = ConstU32<5>;
+	type XcmResponseTimeout = XcmResponseTimeout;
 }
 
 #[cfg(not(feature = "zombie-bite-sudo"))]

--- a/relay/polkadot/src/weights/pallet_rc_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_rc_migrator.rs
@@ -138,4 +138,7 @@ impl<T: frame_system::Config> pallet_rc_migrator::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	fn receive_query_response() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }

--- a/relay/polkadot/src/weights/pallet_rc_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_rc_migrator.rs
@@ -144,4 +144,7 @@ impl<T: frame_system::Config> pallet_rc_migrator::WeightInfo for WeightInfo<T> {
 	fn resend_xcm() -> Weight {
 		Weight::from_parts(10_000_000, 1000)
 	}
+	fn set_unprocessed_msg_buffer() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }

--- a/relay/polkadot/src/weights/pallet_rc_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_rc_migrator.rs
@@ -141,4 +141,7 @@ impl<T: frame_system::Config> pallet_rc_migrator::WeightInfo for WeightInfo<T> {
 	fn receive_query_response() -> Weight {
 		Weight::from_parts(10_000_000, 1000)
 	}
+	fn resend_xcm() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }


### PR DESCRIPTION
Flow Control System

The new system uses the XCM buildin reporting mechanism to notify the Relay Chain about processed messages. For every data message sent to Asset Hub, we register a query and use the XCM `ReportTransactStatus` instruction within the `Appendix` to initiate reporting after the XCM message is processed and its status is known. On the Relay Chain side, we keep the entire XCM message until confirmation is received. If confirmation is never received, we can manually resend it with a call. Individual messages can also be manually acknowledged. The PR also introduces a storage value for unprocessed message buffer size to override the config value on the fly if needed, with a dedicated dispatchable call. The old counter-based backpressure system is removed.