### PR TITLE
Activate validator re-enabling + slashes for lazy or spammy validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Slash and disable lazy and spammy validators as part of validator disabling strategy ([SDK #6827](https://github.com/paritytech/polkadot-sdk/pull/6827),
-- Switch to UpToLimitWithReEnablingDisablingStrategy which always prioritises highest offenders for disabling instead of stopping when limit is reached
+- Slash and disable lazy and spammy validators as part of the new validator disabling strategy ([SDK #6827](https://github.com/paritytech/polkadot-sdk/pull/6827),
+- Switch to UpToLimitWithReEnablingDisablingStrategy (Polkadot & Kusama) which always prioritises highest offenders for disabling instead of stopping when limit is reached
 - [polkadot-fellows/runtimes/pull/782](https://github.com/polkadot-fellows/runtimes/pull/782))
 
 ## [1.6.0] 19.06.2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- Slash for more offence types as part of validator disabling strategy ([SDK #6827](https://github.com/paritytech/polkadot-sdk/pull/6827), [polkadot-fellows/runtimes/pull/782](https://github.com/polkadot-fellows/runtimes/pull/782))
+- Slash and disable lazy and spammy validators as part of validator disabling strategy ([SDK #6827](https://github.com/paritytech/polkadot-sdk/pull/6827),
+- Switch to UpToLimitWithReEnablingDisablingStrategy which always prioritises highest offenders for disabling instead of stopping when limit is reached
+- [polkadot-fellows/runtimes/pull/782](https://github.com/polkadot-fellows/runtimes/pull/782))
 
 ## [1.6.0] 19.06.2025
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -513,7 +513,7 @@ impl pallet_session::Config for Runtime {
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
 	type WeightInfo = weights::pallet_session::WeightInfo<Runtime>;
-	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
+	type DisablingStrategy = pallet_session::disabling::UpToLimitWithReEnablingDisablingStrategy;
 }
 
 impl pallet_session::historical::Config for Runtime {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -489,7 +489,7 @@ impl pallet_session::Config for Runtime {
 	type SessionHandler = <SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
 	type WeightInfo = weights::pallet_session::WeightInfo<Runtime>;
-	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
+	type DisablingStrategy = pallet_session::disabling::UpToLimitWithReEnablingDisablingStrategy;
 }
 
 impl pallet_session::historical::Config for Runtime {


### PR DESCRIPTION
This PR switches to a more robust validator disabling strategy `UpToLimitWithReEnablingDisablingStrategy` in both Kusama and Polkadot. When disabling limit capacity will be reached the system will prioritise disabling the highest offenders. See this PR for more information: https://github.com/paritytech/polkadot-sdk/pull/5724

Additionally crates `polkadot-runtime-parachains` and `polkadot-primitives` are bumped to newer versions. The bumps primarily affect validators as they introduce a new slashing offence for lazy validators or spammy validators. See this PR for more information: https://github.com/paritytech/polkadot-sdk/pull/6827

edit: got rebased on top of oty-1-6-1 where the crates are already bumped