### PR TITLE
[AHM] Disable #[pallet::hooks] for migrating pallets during migration

### DIFF
--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -57,7 +57,7 @@ pub mod vesting;
 pub mod xcm_config;
 
 pub use pallet::*;
-pub use pallet_rc_migrator::{types::ZeroWeightOr, weights_ah};
+pub use pallet_rc_migrator::{types::LeftOrRight, weights_ah};
 pub use weights_ah::WeightInfo;
 
 use frame_support::{

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -57,7 +57,10 @@ pub mod vesting;
 pub mod xcm_config;
 
 pub use pallet::*;
-pub use pallet_rc_migrator::{types::LeftOrRight, weights_ah};
+pub use pallet_rc_migrator::{
+	types::{LeftOrRight, MaxOnIdleOrInner},
+	weights_ah,
+};
 pub use weights_ah::WeightInfo;
 
 use frame_support::{

--- a/pallets/rc-migrator/src/scheduler.md
+++ b/pallets/rc-migrator/src/scheduler.md
@@ -6,4 +6,4 @@ Based on the scheduler pallet's usage in the Polkadot/Kusama runtime, it primari
 
 We plan to map all calls that are used in the Governance by inspecting the production snapshots.
 
-During the migration process, we will disable the processing of scheduled tasks on both the Relay Chain and Asset Hub. This is achieved by setting the `MaximumWeight` parameter to zero for the scheduler using the `rc_pallet_migrator::types::ZeroWeightOr` helper type. Once the migration is complete, any tasks that are due for execution on Asset Hub will be processed, even if they are delayed. This behavior is appropriate for both types of tasks we handle.
+During the migration process, we will disable the processing of scheduled tasks on both the Relay Chain and Asset Hub. This is achieved by setting the `MaximumWeight` parameter to zero for the scheduler using the `rc_pallet_migrator::types::LeftOrRight` helper type. Once the migration is complete, any tasks that are due for execution on Asset Hub will be processed, even if they are delayed. This behavior is appropriate for both types of tasks we handle.

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -205,13 +205,16 @@ pub trait MigrationStatus {
 	fn is_ongoing() -> bool;
 }
 
-/// A weight that is zero if the migration is ongoing, otherwise it is the default weight.
-pub struct ZeroWeightOr<Status, Default>(PhantomData<(Status, Default)>);
-impl<Status: MigrationStatus, Default: Get<Weight>> Get<Weight> for ZeroWeightOr<Status, Default> {
-	fn get() -> Weight {
-		Status::is_ongoing().then(Weight::zero).unwrap_or_else(Default::get)
+/// A value that is `Left::get()` if the migration is ongoing, otherwise it is `Right::get()`.
+pub struct LeftOrRight<Status, Left, Right>(PhantomData<(Status, Left, Right)>);
+impl<Status: MigrationStatus, Left: TypedGet, Right: Get<Left::Type>> Get<Left::Type>
+	for LeftOrRight<Status, Left, Right>
+{
+	fn get() -> Left::Type {
+		Status::is_ongoing().then(|| Left::get()).unwrap_or_else(|| Right::get())
 	}
 }
+
 /// A utility struct for batching XCM messages to stay within size limits.
 ///
 /// This struct manages collections of XCM messages, automatically creating

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -725,7 +725,10 @@ impl pallet_fast_unstake::Config for Runtime {
 	type ControlOrigin = EnsureRoot<AccountId>;
 	type Staking = Staking;
 	type MaxErasToCheckPerBlock = ConstU32<1>;
-	type WeightInfo = weights::pallet_fast_unstake::WeightInfo<Runtime>;
+	type WeightInfo = pallet_rc_migrator::types::MaxOnIdleOrInner<
+		RcMigrator,
+		weights::pallet_fast_unstake::WeightInfo<Runtime>,
+	>;
 }
 
 parameter_types! {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -228,6 +228,7 @@ impl frame_system::Config for Runtime {
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
 		BlockWeights::get().max_block;
+	pub ZeroWeight: Weight = Weight::zero();
 	pub const MaxScheduledPerBlock: u32 = 50;
 	pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
@@ -256,7 +257,7 @@ impl pallet_scheduler::Config for Runtime {
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
 	type MaximumWeight =
-		pallet_rc_migrator::types::ZeroWeightOr<RcMigrator, MaximumSchedulerWeight>;
+		pallet_rc_migrator::types::LeftOrRight<RcMigrator, ZeroWeight, MaximumSchedulerWeight>;
 	// The goal of having ScheduleOrigin include AuctionAdmin is to allow the auctions track of
 	// OpenGov to schedule periodic auctions.
 	// Also allow Treasurer to schedule recurring payments.
@@ -732,6 +733,7 @@ parameter_types! {
 	pub const ProposalBondMinimum: Balance = 100 * DOLLARS;
 	pub const ProposalBondMaximum: Balance = 500 * DOLLARS;
 	pub const SpendPeriod: BlockNumber = 24 * DAYS;
+	pub const DisableSpends: BlockNumber = BlockNumber::MAX;
 	pub const Burn: Permill = Permill::from_percent(1);
 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
 	pub const PayoutSpendPeriod: BlockNumber = 30 * DAYS;
@@ -756,7 +758,8 @@ impl pallet_treasury::Config for Runtime {
 	type Currency = Balances;
 	type RejectOrigin = EitherOfDiverse<EnsureRoot<AccountId>, Treasurer>;
 	type RuntimeEvent = RuntimeEvent;
-	type SpendPeriod = SpendPeriod;
+	type SpendPeriod =
+		pallet_rc_migrator::types::LeftOrRight<RcMigrator, DisableSpends, SpendPeriod>;
 	type Burn = Burn;
 	type BurnDestination = ();
 	type SpendFunds = Bounties;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1074,6 +1074,7 @@ impl pallet_preimage::Config for Runtime {
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
 		RuntimeBlockWeights::get().max_block;
+	pub ZeroWeight: Weight = Weight::zero();
 	pub const MaxScheduledPerBlock: u32 = 50;
 	pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
@@ -1102,7 +1103,8 @@ impl pallet_scheduler::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
-	type MaximumWeight = pallet_ah_migrator::ZeroWeightOr<AhMigrator, MaximumSchedulerWeight>;
+	type MaximumWeight =
+		pallet_ah_migrator::LeftOrRight<AhMigrator, ZeroWeight, MaximumSchedulerWeight>;
 	// Also allow Treasurer to schedule recurring payments.
 	type ScheduleOrigin = EitherOf<EnsureRoot<AccountId>, Treasurer>;
 	type MaxScheduledPerBlock = MaxScheduledPerBlock;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/staking/mod.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/staking/mod.rs
@@ -36,7 +36,8 @@ impl pallet_fast_unstake::Config for Runtime {
 	type ControlOrigin = EnsureRoot<AccountId>;
 	type Staking = nom_pools::StakingMock;
 	type MaxErasToCheckPerBlock = ConstU32<1>;
-	type WeightInfo = (); // TODO weights::pallet_fast_unstake::WeightInfo<Runtime>;
+	// TODO: use weights::pallet_fast_unstake::WeightInfo<Runtime> instead of ()
+	type WeightInfo = pallet_ah_migrator::MaxOnIdleOrInner<AhMigrator, ()>;
 }
 
 parameter_types! {

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/treasury.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/treasury.rs
@@ -20,6 +20,7 @@ use system_parachains_common::pay::{LocalPay, VersionedLocatableAccount};
 
 parameter_types! {
 	pub const SpendPeriod: BlockNumber = 24 * RC_DAYS;
+	pub const DisableSpends: BlockNumber = BlockNumber::MAX;
 	pub const Burn: Permill = Permill::from_percent(1);
 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
 	pub const PayoutSpendPeriod: BlockNumber = 30 * RC_DAYS;
@@ -33,7 +34,7 @@ impl pallet_treasury::Config for Runtime {
 	type Currency = Balances;
 	type RejectOrigin = EitherOfDiverse<EnsureRoot<AccountId>, Treasurer>;
 	type RuntimeEvent = RuntimeEvent;
-	type SpendPeriod = SpendPeriod;
+	type SpendPeriod = pallet_ah_migrator::LeftOrRight<AhMigrator, DisableSpends, SpendPeriod>;
 	type Burn = Burn;
 	type BurnDestination = ();
 	type SpendFunds = Bounties;


### PR DESCRIPTION
Disable #[pallet::hooks] for migrating pallets during migration

Since there is no built-in feature to disable specific hooks at the runtime level, we configured certain parameters to cause those hooks to return early. To properly review this PR, you’ll need to look into the implementation of the affected hooks.

An alternative would be to write a custom container instead of using the AllPalletsWithSystem type for executables, but I believe that approach would be significantly more complex and the presented solution is more reasonable. 

These disables hooks for `treasury`, `scheduler` and `fast_unstake` pallets on RC and AH.