### PR TITLE
[AHM] AH messages prioritization on RC

### DIFF
--- a/integration-tests/ahm/src/bench_rc.rs
+++ b/integration-tests/ahm/src/bench_rc.rs
@@ -78,3 +78,17 @@ fn test_bench_send_chunked_xcm_and_track() {
 		test_send_chunked_xcm_and_track::<RelayChain>();
 	});
 }
+
+#[test]
+fn test_bench_set_ah_ump_queue_priority() {
+	new_test_ext().execute_with(|| {
+		test_set_ah_ump_queue_priority::<RelayChain>();
+	});
+}
+
+#[test]
+fn test_bench_force_ah_ump_queue_priority() {
+	new_test_ext().execute_with(|| {
+		test_force_ah_ump_queue_priority::<RelayChain>();
+	});
+}

--- a/pallets/rc-migrator/src/benchmarking.rs
+++ b/pallets/rc-migrator/src/benchmarking.rs
@@ -89,12 +89,14 @@ pub mod benchmarks {
 
 	#[benchmark]
 	fn start_data_migration() {
+		RcMigrationStage::<T>::put(&MigrationStageOf::<T>::WaitingForAh);
+
 		#[extrinsic_call]
 		_(RawOrigin::Root);
 
 		assert_last_event::<T>(
 			Event::StageTransition {
-				old: MigrationStageOf::<T>::Pending,
+				old: MigrationStageOf::<T>::WaitingForAh,
 				new: MigrationStageOf::<T>::Starting,
 			}
 			.into(),
@@ -129,6 +131,44 @@ pub mod benchmarks {
 		assert_eq!(sent, 0);
 	}
 
+	#[benchmark]
+	fn force_ah_ump_queue_priority() {
+		let now = BlockNumberFor::<T>::from(1u32);
+		let priority_blocks = BlockNumberFor::<T>::from(10u32);
+		let round_robin_blocks = BlockNumberFor::<T>::from(1u32);
+		AhUmpQueuePriorityConfig::<T>::put(AhUmpQueuePriority::OverrideConfig(
+			priority_blocks,
+			round_robin_blocks,
+		));
+
+		#[block]
+		{
+			Pallet::<T>::force_ah_ump_queue_priority(now)
+		}
+
+		assert_last_event::<T>(
+			Event::AhUmpQueuePrioritySet {
+				prioritized: true,
+				cycle_block: now + BlockNumberFor::<T>::from(1u32),
+				cycle_period: priority_blocks + round_robin_blocks,
+			}
+			.into(),
+		);
+	}
+
+	#[benchmark]
+	fn set_ah_ump_queue_priority() {
+		let old = AhUmpQueuePriorityConfig::<T>::get();
+		let new = AhUmpQueuePriority::OverrideConfig(
+			BlockNumberFor::<T>::from(10u32),
+			BlockNumberFor::<T>::from(1u32),
+		);
+		#[extrinsic_call]
+		_(RawOrigin::Root, new.clone());
+
+		assert_last_event::<T>(Event::AhUmpQueuePriorityConfigSet { old, new }.into());
+	}
+
 	#[cfg(feature = "std")]
 	pub fn test_withdraw_account<T: Config>() {
 		_withdraw_account::<T>(true /* enable checks */)
@@ -157,5 +197,15 @@ pub mod benchmarks {
 	#[cfg(feature = "std")]
 	pub fn test_send_chunked_xcm_and_track<T: Config>() {
 		_send_chunked_xcm_and_track::<T>(true /* enable checks */);
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_force_ah_ump_queue_priority<T: Config>() {
+		_force_ah_ump_queue_priority::<T>(true /* enable checks */);
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_set_ah_ump_queue_priority<T: Config>() {
+		_set_ah_ump_queue_priority::<T>(true /* enable checks */);
 	}
 }

--- a/pallets/rc-migrator/src/conviction_voting.rs
+++ b/pallets/rc-migrator/src/conviction_voting.rs
@@ -17,7 +17,6 @@
 use crate::*;
 use frame_support::traits::{Currency, Polling};
 use pallet_conviction_voting::{ClassLocksFor, TallyOf, Voting};
-use sp_runtime::traits::Zero;
 
 /// Stage of the scheduler pallet migration.
 #[derive(Encode, Decode, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen, PartialEq, Eq)]

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -212,6 +212,55 @@ impl<Status: MigrationStatus, Default: Get<Weight>> Get<Weight> for ZeroWeightOr
 		Status::is_ongoing().then(Weight::zero).unwrap_or_else(Default::get)
 	}
 }
+
+// TODO: replace by pallet_message_queue::ForceSetHead once the 2503 merged from master.
+/// Allows to force the processing head to a specific queue.
+pub trait ForceSetHead<O> {
+	/// Set the `ServiceHead` to `origin`.
+	///
+	/// This function:
+	/// - `Err`: Queue did not exist, not enough weight or other error.
+	/// - `Ok(true)`: The service head was updated.
+	/// - `Ok(false)`: The service head was not updated since the queue is empty.
+	fn force_set_head(weight: &mut WeightMeter, origin: &O) -> Result<bool, ()>;
+}
+
+impl<O> ForceSetHead<O> for () {
+	fn force_set_head(_weight: &mut WeightMeter, _origin: &O) -> Result<bool, ()> {
+		Ok(true)
+	}
+}
+
+/// The priority of the DMP/UMP queue during migration.
+///
+/// Controls how the DMP (Downward Message Passing) or UMP (Upward Message Passing) queue is
+/// processed relative to other queues during the migration process. This helps ensure timely
+/// processing of migration messages. The default priority pattern is defined in the pallet
+/// configuration, but can be overridden by a storage value of this type.
+#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "stable2503", derive(DecodeWithMemTracking))]
+pub enum QueuePriority<BlockNumber: Copy> {
+	/// Use the default priority pattern from the pallet configuration.
+	#[default]
+	Config,
+	/// Override the default priority pattern from the configuration.
+	/// The tuple (priority_blocks, round_robin_blocks) defines how many blocks to prioritize
+	/// DMP queue processing vs normal round-robin processing.
+	OverrideConfig(BlockNumber, BlockNumber),
+	/// Disable DMP queue priority processing entirely.
+	Disabled,
+}
+
+impl<BlockNumber: Copy> QueuePriority<BlockNumber> {
+	pub fn get_priority_blocks(&self) -> Option<BlockNumber> {
+		match self {
+			QueuePriority::Config => None,
+			QueuePriority::OverrideConfig(priority_blocks, _) => Some(*priority_blocks),
+			QueuePriority::Disabled => None,
+		}
+	}
+}
+
 /// A utility struct for batching XCM messages to stay within size limits.
 ///
 /// This struct manages collections of XCM messages, automatically creating

--- a/pallets/rc-migrator/src/weights.rs
+++ b/pallets/rc-migrator/src/weights.rs
@@ -58,6 +58,8 @@ pub trait WeightInfo {
 	fn start_data_migration() -> Weight;
 	fn send_chunked_xcm_and_track() -> Weight;
 	fn update_ah_msg_processed_count() -> Weight;
+	fn set_ah_ump_queue_priority() -> Weight;
+	fn force_ah_ump_queue_priority() -> Weight;
 }
 
 /// Weights for `pallet_rc_migrator` using the Substrate node and recommended hardware.
@@ -147,6 +149,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	fn set_ah_ump_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
+	fn force_ah_ump_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -234,5 +242,11 @@ impl WeightInfo for () {
 		Weight::from_parts(9_000_000, 1493)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	fn set_ah_ump_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
+	fn force_ah_ump_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
 	}
 }

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1527,6 +1527,7 @@ parameter_types! {
 	pub AhMigratorMaxWeight: Weight = Perbill::from_percent(80) * AhMqServiceWeight::get(); // ~ 0.2 sec + 2 mb
 	pub RcMigratorMaxWeight: Weight = Perbill::from_percent(50) * BlockWeights::get().max_block; // TODO set the actual max weight
 	pub AhExistentialDeposit: Balance = EXISTENTIAL_DEPOSIT / 100;
+	pub const AhUmpQueuePriorityPattern: (BlockNumber, BlockNumber) = (18, 2);
 }
 
 pub struct ContainsAssetHub;
@@ -1559,6 +1560,9 @@ impl pallet_rc_migrator::Config for Runtime {
 	type StakingDelegationReason = ahm_phase1::StakingDelegationReason;
 	type OnDemandPalletId = OnDemandPalletId;
 	type UnprocessedMsgBuffer = ConstU32<5>;
+	// TODO: set actual message queue instance when upgraded to sdk/2503
+	type MessageQueue = ();
+	type AhUmpQueuePriorityPattern = AhUmpQueuePriorityPattern;
 }
 
 #[cfg(not(feature = "zombie-bite-sudo"))]

--- a/relay/polkadot/src/weights/pallet_rc_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_rc_migrator.rs
@@ -138,4 +138,10 @@ impl<T: frame_system::Config> pallet_rc_migrator::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+	fn set_ah_ump_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
+	fn force_ah_ump_queue_priority() -> Weight {
+		Weight::from_parts(1, 1)
+	}
 }


### PR DESCRIPTION
Asset Hub messages prioritization over other parachains messages on RC during migration.

The solution is identical to the one introduced for DMP on AH by the PR https://github.com/polkadot-fellows/runtimes/pull/772

Implements Asset Hub messages prioritization during Asset Hub migration by setting the message queue head on RC to the Asset Hub origin on block finalization. This ensures Asset Hub messages are processed first in the next block instead of following the default round-robin pattern.

To maintain balanced processing of UMP messages, the system allows configuration of a repeating priority pattern:
- Number of consecutive blocks where Asset Hub messages get priority
- Number of blocks for normal round-robin processing

The priority pattern can be configured either through pallet config or runtime call override, with three options:
- Default pallet configuration
- Custom pattern (e.g., 18 blocks priority, 2 blocks round-robin)
- Disabled priority

Refer to the types documentation for more details.