### PR TITLE
[CI] Add timeout to review bot action

### DIFF
--- a/.github/workflows/review-trigger.yml
+++ b/.github/workflows/review-trigger.yml
@@ -19,6 +19,7 @@ jobs:
     if: ${{ github.event.pull_request.draft != true && (github.event_name != 'pull_request_review' || (github.event.review && github.event.review.state == 'APPROVED')) }}
     runs-on: ubuntu-latest
     name: trigger review bot
+    timeout-minutes: 10
     steps:
       - name: Get PR data
         id: comments


### PR DESCRIPTION
Silly bot job just running for >30 minutes 🤪 https://github.com/polkadot-fellows/runtimes/actions/runs/15977152592/job/45062513600 I manually cancelled it now.

Spamming the log with:
```pre
2025-06-30T15:42:06.2142836Z RangeError: Map maximum size exceeded
2025-06-30T15:42:06.2142845Z 
2025-06-30T15:42:06.2142993Z Exception in PromiseRejectCallback:
2025-06-30T15:42:06.2143134Z node:internal/process/promises:260
2025-06-30T15:42:06.2143312Z   pendingUnhandledRejections.set(promise, {
2025-06-30T15:42:06.2143433Z                              ^
2025-06-30T15:42:06.2143441Z 
2025-06-30T15:42:06.2143583Z RangeError: Map maximum size exceeded
2025-06-30T15:42:06.2143590Z 
2025-06-30T15:42:06.2143742Z Exception in PromiseRejectCallback:
2025-06-30T15:42:06.2143885Z node:internal/process/promises:260
2025-06-30T15:42:06.2144058Z   pendingUnhandledRejections.set(promise, {
2025-06-30T15:42:06.2144173Z                              ^
```

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
