### PR TITLE
[AHM] Missing `SecretaryEntities` for AHP

### DIFF
--- a/pallets/ah-migrator/src/xcm_config.rs
+++ b/pallets/ah-migrator/src/xcm_config.rs
@@ -99,6 +99,26 @@ pub mod common {
 		}
 	}
 
+	/// Location type to determine the Secretary Collective related
+	/// pallets for use in XCM.
+	pub struct SecretaryEntities;
+	impl Contains<Location> for SecretaryEntities {
+		fn contains(location: &Location) -> bool {
+			matches!(
+				location.unpack(),
+				(
+					1,
+					[
+						Parachain(system_parachain::COLLECTIVES_ID),
+						PalletInstance(
+							collectives_polkadot_runtime_constants::SECRETARY_SALARY_PALLET_INDEX
+						)
+					]
+				)
+			)
+		}
+	}
+
 	// Teleport filters are a special case because we might want to have finer control over which
 	// one to use at fine-grained stages of the migration.
 
@@ -120,7 +140,9 @@ pub mod common {
 
 mod before {
 	use super::{
-		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities, RootLocation},
+		common::{
+			AmbassadorEntities, AssetHubParaId, FellowshipEntities, RootLocation, SecretaryEntities,
+		},
 		*,
 	};
 
@@ -151,6 +173,7 @@ mod before {
 		Equals<RelayTreasuryLocation>,
 		FellowshipEntities,
 		AmbassadorEntities,
+		SecretaryEntities,
 	)>;
 
 	/// Locations that will not be charged fees in the executor, either execution or delivery.
@@ -163,12 +186,15 @@ mod before {
 		Equals<RelayTreasuryLocation>,
 		FellowshipEntities,
 		AmbassadorEntities,
+		SecretaryEntities,
 	);
 }
 
 mod after {
 	use super::{
-		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities, RootLocation},
+		common::{
+			AmbassadorEntities, AssetHubParaId, FellowshipEntities, RootLocation, SecretaryEntities,
+		},
 		*,
 	};
 
@@ -183,6 +209,7 @@ mod after {
 		IsSiblingSystemParachain<ParaId, AssetHubParaId>,
 		FellowshipEntities,
 		AmbassadorEntities,
+		SecretaryEntities,
 	)>;
 
 	/// Locations that will not be charged fees in the executor, either execution or delivery.
@@ -196,6 +223,7 @@ mod after {
 		IsSiblingSystemParachain<ParaId, AssetHubParaId>,
 		FellowshipEntities,
 		AmbassadorEntities,
+		SecretaryEntities,
 	);
 }
 


### PR DESCRIPTION
At the time of adding this PR ([https://github.com/polkadot-fellows/runtimes/pull/722](https://github.com/polkadot-fellows/runtimes/pull/722)) to the `dev-ahm` branch, `SecretaryEntities` wasn’t present yet. It was introduced later for AHP.

cc: @ggwpez Probably there should/will be similar changes, which we need to port, at the very least, we need to make sure to recheck all the settings when we finally merge dev-ahm into fellows-main.


- [X] Does not require a CHANGELOG entry
