### PR TITLE
[AHM] Missing `RootLocation` for WaivedLocation for AHP

### DIFF
--- a/pallets/ah-migrator/src/xcm_config.rs
+++ b/pallets/ah-migrator/src/xcm_config.rs
@@ -38,6 +38,7 @@ pub mod common {
 	parameter_types! {
 		pub const AssetHubParaId: ParaId = ParaId::new(system_parachain::ASSET_HUB_ID);
 		pub const DotLocation: Location = Location::parent();
+		pub const RootLocation: Location = Location::here();
 	}
 
 	pub struct FellowshipEntities;
@@ -119,7 +120,7 @@ pub mod common {
 
 mod before {
 	use super::{
-		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities},
+		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities, RootLocation},
 		*,
 	};
 
@@ -156,6 +157,7 @@ mod before {
 	///
 	/// We only waive fees for system functions, which these locations represent.
 	pub type WaivedLocationsBeforeDuring = (
+		Equals<RootLocation>,
 		Equals<ParentLocation>,
 		IsSiblingSystemParachain<ParaId, AssetHubParaId>,
 		Equals<RelayTreasuryLocation>,
@@ -166,7 +168,7 @@ mod before {
 
 mod after {
 	use super::{
-		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities},
+		common::{AmbassadorEntities, AssetHubParaId, FellowshipEntities, RootLocation},
 		*,
 	};
 
@@ -187,6 +189,7 @@ mod after {
 	///
 	/// We only waive fees for system functions, which these locations represent.
 	pub type WaivedLocationsAfter = (
+		Equals<RootLocation>,
 		// outside this pallet, when the `Runtime` type is available, the below can be replaced
 		// with `RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>`
 		Equals<ParentLocation>,

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -76,9 +76,9 @@ use frame_support::{
 	traits::{
 		fungible::HoldConsideration,
 		tokens::{imbalance::ResolveTo, UnityOrOuterConversion},
-		ConstU32, ConstU8, Contains, EitherOf, EitherOfDiverse, Everything, FromContains, Get,
-		InstanceFilter, KeyOwnerProofSystem, LinearStoragePrice, OnRuntimeUpgrade, PrivilegeCmp,
-		ProcessMessage, ProcessMessageError, WithdrawReasons,
+		ConstU32, ConstU8, Contains, EitherOf, EitherOfDiverse, Equals, Everything, FromContains,
+		Get, InstanceFilter, KeyOwnerProofSystem, LinearStoragePrice, OnRuntimeUpgrade,
+		PrivilegeCmp, ProcessMessage, ProcessMessageError, WithdrawReasons,
 	},
 	weights::{
 		constants::{WEIGHT_PROOF_SIZE_PER_KB, WEIGHT_REF_TIME_PER_MICROS},
@@ -1581,13 +1581,6 @@ parameter_types! {
 	pub const AhUmpQueuePriorityPattern: (BlockNumber, BlockNumber) = (18, 2);
 }
 
-pub struct ContainsAssetHub;
-impl Contains<Location> for ContainsAssetHub {
-	fn contains(loc: &Location) -> bool {
-		*loc == AssetHubLocation::get()
-	}
-}
-
 impl pallet_rc_migrator::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
@@ -1597,7 +1590,7 @@ impl pallet_rc_migrator::Config for Runtime {
 		EnsureRoot<AccountId>,
 		EitherOfDiverse<
 			EnsureXcm<IsVoiceOfBody<CollectivesLocation, FellowsBodyId>>,
-			EnsureXcm<ContainsAssetHub, Location>,
+			EnsureXcm<Equals<AssetHubLocation>, Location>,
 		>,
 	>;
 	type Currency = Balances;


### PR DESCRIPTION
At the time of adding this PR ([https://github.com/polkadot-fellows/runtimes/pull/722](https://github.com/polkadot-fellows/runtimes/pull/722)) to the `dev-ahm` branch, `RootLocation` wasn’t present yet. It was introduced later for AHP with the bump to `stable2503` here: [https://github.com/polkadot-fellows/runtimes/pull/711](https://github.com/polkadot-fellows/runtimes/pull/711).

So it's better to add it now than risk forgetting when merging `master` into `dev` here: [https://github.com/polkadot-fellows/runtimes/pull/793](https://github.com/polkadot-fellows/runtimes/pull/793).

cc: @ggwpez or do you want me to open PR on the top of `oty-rebase-dev`? Probably there should be similar changes, for example as https://github.com/polkadot-fellows/runtimes/pull/797.


- [X] Does not require a CHANGELOG entry
