### PR TITLE
🚧 [AHM] Implement RC->AH account translation migration across all involved pallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10096,6 +10096,7 @@ dependencies = [
  "pallet-proxy",
  "pallet-rc-migrator",
  "pallet-timestamp",
+ "pallet-vesting",
  "pallet-whitelist",
  "pallet-xcm",
  "parachains-common",

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -26,6 +26,7 @@ pallet-balances = { workspace = true, default-features = true }
 pallet-indices = { workspace = true, default-features = true }
 pallet-message-queue = { workspace = true, default-features = true }
 pallet-timestamp = { workspace = true, default-features = true }
+pallet-vesting = { workspace = true, default-features = true }
 parachains-common = { workspace = true, default-features = true }
 pallet-multisig = { workspace = true, default-features = true }
 polkadot-parachain-primitives = { workspace = true, default-features = true }
@@ -83,6 +84,7 @@ runtime-benchmarks = [
 	"pallet-proxy/runtime-benchmarks",
 	"pallet-rc-migrator/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
+	"pallet-vesting/runtime-benchmarks",
 	"pallet-whitelist/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
 	"parachains-common/runtime-benchmarks",

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -248,7 +248,8 @@ fn sovereign_account_translation() {
 		let rc_acc = AccountId32::from_str(rc_acc).unwrap();
 		let ah_acc = AccountId32::from_str(ah_acc).unwrap();
 
-		let (translated, _para_id) = pallet_rc_migrator::accounts::AccountsMigrator::<Polkadot>::try_translate_rc_sovereign_to_ah(rc_acc).unwrap().unwrap();
+		let (translated, para_id) = pallet_ah_migrator::translate_rc_sovereign_to_ah(&rc_acc);
+		assert!(para_id.is_some());
 		assert_eq!(translated, ah_acc);
 	}
 
@@ -264,8 +265,9 @@ fn sovereign_account_translation() {
 	for rc_acc in bad_cases {
 		let rc_acc = AccountId32::from_str(rc_acc).unwrap();
 
-		let translated = pallet_rc_migrator::accounts::AccountsMigrator::<Polkadot>::try_translate_rc_sovereign_to_ah(rc_acc).unwrap();
-		assert!(translated.is_none());
+		let (translated, para_id) = pallet_ah_migrator::translate_rc_sovereign_to_ah(&rc_acc);
+		assert!(para_id.is_none());
+		assert_eq!(translated, rc_acc); // Should return original account
 	}
 }
 

--- a/pallets/ah-migrator/src/account.rs
+++ b/pallets/ah-migrator/src/account.rs
@@ -74,6 +74,7 @@ impl<T: Config> Pallet<T> {
 		// Emit translation event if account was translated
 		if let Some(para_id) = para_id {
 			Self::deposit_event(Event::<T>::AccountTranslated {
+				pallet: PalletEventName::Balances,
 				original: account.who.clone(),
 				translated: translated_account.clone(),
 				para_id,

--- a/pallets/ah-migrator/src/account.rs
+++ b/pallets/ah-migrator/src/account.rs
@@ -68,7 +68,19 @@ impl<T: Config> Pallet<T> {
 			frame_system::Pallet::<T>::inc_providers(&account.who);
 		}
 
-		let who = account.who;
+		// Extract and translate the account
+		let (translated_account, para_id) = crate::translate_rc_sovereign_to_ah(&account.who);
+
+		// Emit translation event if account was translated
+		if let Some(para_id) = para_id {
+			Self::deposit_event(Event::<T>::AccountTranslated {
+				original: account.who.clone(),
+				translated: translated_account.clone(),
+				para_id,
+			});
+		}
+
+		let who = translated_account;
 		let total_balance = account.free + account.reserved;
 		let minted = match <T as pallet::Config>::Currency::mint_into(&who, total_balance) {
 			Ok(minted) => minted,

--- a/pallets/ah-migrator/src/account_translator_test.rs
+++ b/pallets/ah-migrator/src/account_translator_test.rs
@@ -1,0 +1,150 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the AccountTranslator trait implementation.
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use codec::Encode;
+	use sp_runtime::AccountId32;
+
+	#[test]
+	fn test_try_translate_rc_sovereign_to_ah_with_valid_para_account() {
+		// Create a valid parachain sovereign account
+		let para_id = 1000u16;
+		let mut raw_account = [0u8; 32];
+		raw_account[0..4].copy_from_slice(b"para");
+		raw_account[4..6].copy_from_slice(&para_id.encode());
+		// The remaining bytes are already zero (26 zero bytes as expected)
+
+		let rc_account = AccountId32::from(raw_account);
+
+		// Test translation
+		let (ah_account, extracted_para_id) = crate::translate_rc_sovereign_to_ah(&rc_account);
+
+		assert!(extracted_para_id.is_some());
+		let extracted_para_id = extracted_para_id.unwrap();
+
+		// Verify the para_id was extracted correctly
+		assert_eq!(extracted_para_id, para_id);
+
+		// Verify the AH account has the correct "sibl" prefix
+		let ah_raw: &[u8; 32] = ah_account.as_ref();
+		assert_eq!(&ah_raw[0..4], b"sibl");
+		assert_eq!(&ah_raw[4..6], &para_id.encode());
+
+		// Verify the remaining bytes are zeros
+		assert_eq!(&ah_raw[6..], &[0u8; 26]);
+	}
+
+	#[test]
+	fn test_try_translate_rc_sovereign_to_ah_with_invalid_prefix() {
+		// Create an account with invalid prefix
+		let mut raw_account = [0u8; 32];
+		raw_account[0..4].copy_from_slice(b"inva");
+
+		let rc_account = AccountId32::from(raw_account);
+
+		// Test translation
+		let (ah_account, extracted_para_id) = crate::translate_rc_sovereign_to_ah(&rc_account);
+
+		assert!(extracted_para_id.is_none());
+		assert_eq!(ah_account, rc_account); // Should return original account
+	}
+
+	#[test]
+	fn test_try_translate_rc_sovereign_to_ah_with_non_zero_suffix() {
+		// Create an account with "para" prefix but non-zero suffix
+		let para_id = 1000u16;
+		let mut raw_account = [0u8; 32];
+		raw_account[0..4].copy_from_slice(b"para");
+		raw_account[4..6].copy_from_slice(&para_id.encode());
+		raw_account[31] = 1; // Set last byte to non-zero
+
+		let rc_account = AccountId32::from(raw_account);
+
+		// Test translation
+		let (ah_account, extracted_para_id) = crate::translate_rc_sovereign_to_ah(&rc_account);
+
+		assert!(extracted_para_id.is_none());
+		assert_eq!(ah_account, rc_account); // Should return original account
+	}
+
+	#[test]
+	fn test_try_translate_rc_sovereign_to_ah_with_regular_account() {
+		// Create a regular account (not a parachain sovereign account)
+		let regular_account = AccountId32::from([1u8; 32]);
+
+		// Test translation
+		let (ah_account, extracted_para_id) = crate::translate_rc_sovereign_to_ah(&regular_account);
+
+		assert!(extracted_para_id.is_none());
+		assert_eq!(ah_account, regular_account); // Should return original account
+	}
+
+	#[test]
+	fn test_try_translate_rc_sovereign_to_ah_with_various_para_ids() {
+		// Test with different para IDs
+		let para_ids = [0u16, 1u16, 1000u16, 2000u16, 65535u16];
+
+		for para_id in para_ids {
+			let mut raw_account = [0u8; 32];
+			raw_account[0..4].copy_from_slice(b"para");
+			raw_account[4..6].copy_from_slice(&para_id.encode());
+
+			let rc_account = AccountId32::from(raw_account);
+
+			// Test translation
+			let (ah_account, extracted_para_id) = crate::translate_rc_sovereign_to_ah(&rc_account);
+
+			assert!(extracted_para_id.is_some());
+			let extracted_para_id = extracted_para_id.unwrap();
+
+			// Verify the para_id was extracted correctly
+			assert_eq!(extracted_para_id, para_id);
+
+			// Verify the AH account has the correct "sibl" prefix
+			let ah_raw: &[u8; 32] = ah_account.as_ref();
+			assert_eq!(&ah_raw[0..4], b"sibl");
+			assert_eq!(&ah_raw[4..6], &para_id.encode());
+		}
+	}
+
+	#[test]
+	fn test_roundtrip_consistency() {
+		// Test that we can't accidentally translate an already translated account
+		let para_id = 1000u16;
+		let mut raw_account = [0u8; 32];
+		raw_account[0..4].copy_from_slice(b"para");
+		raw_account[4..6].copy_from_slice(&para_id.encode());
+
+		let rc_account = AccountId32::from(raw_account);
+
+		// First translation
+		let (ah_account, para_id1) = crate::translate_rc_sovereign_to_ah(&rc_account);
+		assert!(para_id1.is_some());
+
+		// Try to translate the already translated account
+		let (ah_account2, para_id2) = crate::translate_rc_sovereign_to_ah(&ah_account);
+		assert!(
+			para_id2.is_none(),
+			"Should not be able to translate an already translated account"
+		);
+		assert_eq!(ah_account, ah_account2); // Should return the same account
+	}
+}

--- a/pallets/ah-migrator/src/account_translator_test.rs
+++ b/pallets/ah-migrator/src/account_translator_test.rs
@@ -19,7 +19,7 @@
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+
 	use codec::Encode;
 	use sp_runtime::AccountId32;
 

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -92,7 +92,7 @@ use pallet_rc_migrator::{
 	proxy::*,
 	staking::{
 		bags_list::RcBagsListMessage, delegated_staking::RcDelegatedStakingMessageOf,
-		fast_unstake::RcFastUnstakeMessage, nom_pools::*, *,
+		fast_unstake::RcFastUnstakeMessage, nom_pools::*,
 	},
 	types::MigrationFinishedData,
 	vesting::RcVestingSchedule,
@@ -551,6 +551,15 @@ pub mod pallet {
 		},
 		/// An account was translated from RC format to AH format.
 		AccountTranslated {
+			/// The original account before translation.
+			original: T::AccountId,
+			/// The translated account after translation.
+			translated: T::AccountId,
+			/// The para ID that was extracted from the sovereign account.
+			para_id: u16,
+		},
+		/// A vesting schedule account was translated from RC format to AH format.
+		VestingTranslated {
 			/// The original account before translation.
 			original: T::AccountId,
 			/// The translated account after translation.

--- a/pallets/ah-migrator/src/vesting.rs
+++ b/pallets/ah-migrator/src/vesting.rs
@@ -59,7 +59,8 @@ impl<T: Config> Pallet<T> {
 
 		// Emit translation event if account was translated
 		if let Some(para_id) = para_id {
-			Self::deposit_event(Event::<T>::VestingTranslated {
+			Self::deposit_event(Event::<T>::AccountTranslated {
+				pallet: PalletEventName::Vesting,
 				original: original_account,
 				translated: translated_account.clone(),
 				para_id,

--- a/pallets/rc-migrator/src/accounts.rs
+++ b/pallets/rc-migrator/src/accounts.rs
@@ -17,14 +17,14 @@
 //! Account/Balance data migrator module.
 
 use crate::{types::*, *};
-use codec::DecodeAll;
+
 use frame_support::{
 	traits::tokens::{Balance as BalanceT, IdAmount},
 	weights::WeightMeter,
 };
 use frame_system::Account as SystemAccount;
 use pallet_balances::{AccountData, BalanceLock};
-use sp_core::ByteArray;
+
 use sp_runtime::{traits::Zero, BoundedVec};
 
 /// Account type meant to transfer data between RC and AH.
@@ -776,47 +776,6 @@ impl<T: Config> AccountsMigrator<T> {
 		RcAccounts::<T>::insert(&on_demand_pallet_account, AccountState::Preserve);
 
 		weight
-	}
-
-	/// Try to translate a Parachain sovereign account to the Parachain AH sovereign account.
-	///
-	/// Returns:
-	/// - `Ok(None)` if the account is not a Parachain sovereign account
-	/// - `Ok(Some((ah_account, para_id)))` with the translated account and the para id
-	/// - `Err(())` otherwise
-	///
-	/// The way that this normally works is through the configured `SiblingParachainConvertsVia`:
-	/// https://github.com/polkadot-fellows/runtimes/blob/7b096c14c2b16cc81ca4e2188eea9103f120b7a4/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs#L93-L94
-	/// it passes the `Sibling` type into it which has type-ID `sibl`:
-	/// https://github.com/paritytech/polkadot-sdk/blob/c10e25aaa8b8afd8665b53f0a0b02e4ea44caa77/polkadot/parachain/src/primitives.rs#L272-L274.
-	/// This type-ID gets used by the converter here:
-	/// https://github.com/paritytech/polkadot-sdk/blob/7ecf3f757a5d6f622309cea7f788e8a547a5dce8/polkadot/xcm/xcm-builder/src/location_conversion.rs#L314
-	/// and eventually ends up in the encoding here
-	/// https://github.com/paritytech/polkadot-sdk/blob/cdf107de700388a52a17b2fb852c98420c78278e/substrate/primitives/runtime/src/traits/mod.rs#L1997-L1999
-	/// The `para` conversion is likewise with `ChildParachainConvertsVia` and the `para` type-ID
-	/// https://github.com/paritytech/polkadot-sdk/blob/c10e25aaa8b8afd8665b53f0a0b02e4ea44caa77/polkadot/parachain/src/primitives.rs#L162-L164
-	pub fn try_translate_rc_sovereign_to_ah(
-		acc: T::AccountId,
-	) -> Result<Option<(T::AccountId, u16)>, ()> {
-		let raw = acc.to_raw_vec();
-
-		// Must start with "para"
-		let Some(raw) = raw.strip_prefix(b"para") else {
-			return Ok(None);
-		};
-		// Must end with 26 zero bytes
-		let Some(raw) = raw.strip_suffix(&[0u8; 26]) else {
-			return Ok(None);
-		};
-		let para_id = u16::decode_all(&mut &raw[..]).map_err(|_| ())?;
-
-		// Translate to AH sibling account
-		let mut ah_raw = [0u8; 32];
-		ah_raw[0..4].copy_from_slice(b"sibl");
-		ah_raw[4..6].copy_from_slice(&para_id.encode());
-		let ah_acc = ah_raw.try_into().map_err(|_| ()).defensive()?;
-
-		Ok(Some((ah_acc, para_id)))
 	}
 }
 


### PR DESCRIPTION
## 🎯 Goal

The goal is to ensure that all `AccountIDs` are properly translated when moved from RC to AH, particularly for sovereign accounts that need translation from `para` prefix to `sibl` prefix.

During the migration from Relay Chain to Asset Hub, accounts need to be translated in two scenarios:

1. **Regular user accounts**: Keep the same AccountID
2. **Parachain sovereign accounts**: Translate from RC format (`"para" ++ para_id ++ 00..`) to AH format (`"sibl" ++ para_id ++ 00..`)

Account translation logic has now been implemented in `pallets/ah-migrator/src/lib.rs` as part of the `AccountTranslator` trait. 

This logic needs to be applied by all pallets that store AccountIDs in their storage maps before inserting data on Asset Hub.

##  Migration Data Flow

- **RC-Migrator** sends accounts with their **original AccountIds** (including sovereign accounts with `para` prefix)
- **AH-Migrator** receives the accounts and translates them (e.g. converting `para` prefix into `sibl`)

## Pallets requiring account translation
	
- ✅ Balances (`System::Account` storage)
- ✅ Vesting
-  👷‍♂️**TODO:**   add a complete list of pallets to migrate

##  🙋 Open points

- Do we need to benchmark the account translation?
