### PR TITLE
[AHM] Optional migration manager account id

### DIFF
--- a/integration-tests/ahm/src/bench_ah.rs
+++ b/integration-tests/ahm/src/bench_ah.rs
@@ -265,3 +265,10 @@ fn test_bench_set_dmp_queue_priority() {
 		test_set_dmp_queue_priority::<AssetHub>();
 	});
 }
+
+#[test]
+fn test_bench_set_manager() {
+	new_test_ext().execute_with(|| {
+		test_set_manager::<AssetHub>();
+	});
+}

--- a/integration-tests/ahm/src/bench_rc.rs
+++ b/integration-tests/ahm/src/bench_rc.rs
@@ -106,3 +106,10 @@ fn test_bench_force_ah_ump_queue_priority() {
 		test_force_ah_ump_queue_priority::<RelayChain>();
 	});
 }
+
+#[test]
+fn test_bench_set_manager() {
+	new_test_ext().execute_with(|| {
+		test_set_manager::<RelayChain>();
+	});
+}

--- a/pallets/ah-migrator/src/benchmarking.rs
+++ b/pallets/ah-migrator/src/benchmarking.rs
@@ -981,6 +981,16 @@ pub mod benchmarks {
 		assert_last_event::<T>(Event::DmpQueuePriorityConfigSet { old, new }.into());
 	}
 
+	#[benchmark]
+	fn set_manager() {
+		let old = Manager::<T>::get();
+		let new = Some([0; 32].into());
+		#[extrinsic_call]
+		_(RawOrigin::Root, new.clone());
+
+		assert_last_event::<T>(Event::ManagerSet { old, new }.into());
+	}
+
 	#[cfg(feature = "std")]
 	pub fn test_receive_multisigs<T>(n: u32)
 	where
@@ -1258,5 +1268,14 @@ pub mod benchmarks {
 		ConvictionVotingIndexOf<T>: From<u8>,
 	{
 		_set_dmp_queue_priority::<T>(true)
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_set_manager<T>()
+	where
+		T: Config,
+		ConvictionVotingIndexOf<T>: From<u8>,
+	{
+		_set_manager::<T>(true)
 	}
 }

--- a/pallets/rc-migrator/src/benchmarking.rs
+++ b/pallets/rc-migrator/src/benchmarking.rs
@@ -224,6 +224,16 @@ pub mod benchmarks {
 		assert_last_event::<T>(Event::AhUmpQueuePriorityConfigSet { old, new }.into());
 	}
 
+	#[benchmark]
+	fn set_manager() {
+		let old = Manager::<T>::get();
+		let new = Some([0; 32].into());
+		#[extrinsic_call]
+		_(RawOrigin::Root, new.clone());
+
+		assert_last_event::<T>(Event::ManagerSet { old, new }.into());
+	}
+
 	#[cfg(feature = "std")]
 	pub fn test_withdraw_account<T: Config>() {
 		_withdraw_account::<T>(true /* enable checks */)
@@ -271,5 +281,10 @@ pub mod benchmarks {
 	#[cfg(feature = "std")]
 	pub fn test_set_ah_ump_queue_priority<T: Config>() {
 		_set_ah_ump_queue_priority::<T>(true /* enable checks */);
+	}
+
+	#[cfg(feature = "std")]
+	pub fn test_set_manager<T: Config>() {
+		_set_manager::<T>(true /* enable checks */);
 	}
 }

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -466,7 +466,7 @@ pub mod pallet {
 		/// The origin that can perform permissioned operations like setting the migration stage.
 		///
 		/// This is generally root, Asset Hub and Fellows origins.
-		type ManagerOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
+		type AdminOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 		/// Native asset registry type.
 		type Currency: Mutate<Self::AccountId, Balance = u128>
 			+ MutateHold<Self::AccountId, Reason = <Self as Config>::RuntimeHoldReason>
@@ -626,6 +626,13 @@ pub mod pallet {
 		MigratedBalanceRecordSet { kept: T::Balance, migrated: T::Balance },
 		/// The RC kept balance was consumed.
 		MigratedBalanceConsumed { kept: T::Balance, migrated: T::Balance },
+		/// The manager account id was set.
+		ManagerSet {
+			/// The old manager account id.
+			old: Option<T::AccountId>,
+			/// The new manager account id.
+			new: Option<T::AccountId>,
+		},
 	}
 
 	/// The Relay Chain migration state.
@@ -676,6 +683,13 @@ pub mod pallet {
 	pub type AhUmpQueuePriorityConfig<T: Config> =
 		StorageValue<_, AhUmpQueuePriority<BlockNumberFor<T>>, ValueQuery>;
 
+	/// An optional account id of a manager.
+	///
+	/// This account id has the similar to [`Config::AdminOrigin`] privileges except that it
+	/// can not set the manager account id via `set_manager` call.
+	#[pallet::storage]
+	pub type Manager<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
 	/// Alias for `Paras` from `paras_registrar`.
 	///
 	/// The fields of the type stored in the original storage item are private, so we define the
@@ -699,14 +713,15 @@ pub mod pallet {
 		/// Set the migration stage.
 		///
 		/// This call is intended for emergency use only and is guarded by the
-		/// [`Config::ManagerOrigin`].
+		/// [`Config::AdminOrigin`].
 		#[pallet::call_index(0)]
 		#[pallet::weight(T::RcWeightInfo::force_set_stage())]
 		pub fn force_set_stage(
 			origin: OriginFor<T>,
 			stage: Box<MigrationStageOf<T>>,
 		) -> DispatchResult {
-			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
+			Self::ensure_admin_or_manager(origin)?;
+
 			Self::transition(*stage);
 			Ok(())
 		}
@@ -725,7 +740,8 @@ pub mod pallet {
 			start: DispatchTime<BlockNumberFor<T>>,
 			cool_off_end: DispatchTime<BlockNumberFor<T>>,
 		) -> DispatchResult {
-			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
+			Self::ensure_admin_or_manager(origin)?;
+
 			let now = frame_system::Pallet::<T>::block_number();
 			let start = start.evaluate(now);
 			let cool_off_end = cool_off_end.evaluate(now);
@@ -742,7 +758,8 @@ pub mod pallet {
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::RcWeightInfo::start_data_migration())]
 		pub fn start_data_migration(origin: OriginFor<T>) -> DispatchResult {
-			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
+			Self::ensure_admin_or_manager(origin)?;
+
 			let cool_off_end = match RcMigrationStage::<T>::get() {
 				MigrationStage::WaitingForAh { cool_off_end } => cool_off_end,
 				stage => {
@@ -762,9 +779,9 @@ pub mod pallet {
 			query_id: QueryId,
 			response: Response,
 		) -> DispatchResult {
-			match <T as Config>::ManagerOrigin::ensure_origin(origin.clone()) {
+			match Self::ensure_admin_or_manager(origin.clone()) {
 				Ok(_) => {
-					// Origin is valid [`Config::ManagerOrigin`].
+					// Origin is valid [`Config::AdminOrigin`] or [`Manager`].
 				},
 				Err(_) => {
 					match <T as Config>::RuntimeOrigin::from(origin.clone()).into() {
@@ -810,7 +827,7 @@ pub mod pallet {
 		#[pallet::call_index(4)]
 		#[pallet::weight(T::RcWeightInfo::resend_xcm())]
 		pub fn resend_xcm(origin: OriginFor<T>, query_id: u64) -> DispatchResultWithPostInfo {
-			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
+			Self::ensure_admin_or_manager(origin)?;
 
 			let xcm = PendingXcmMessages::<T>::get(query_id).ok_or(Error::<T>::QueryNotFound)?;
 
@@ -836,7 +853,8 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: Option<u32>,
 		) -> DispatchResult {
-			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
+			Self::ensure_admin_or_manager(origin)?;
+
 			let old = Self::get_unprocessed_msg_buffer_size();
 			UnprocessedMsgBuffer::<T>::set(new);
 			let new = Self::get_unprocessed_msg_buffer_size();
@@ -846,14 +864,15 @@ pub mod pallet {
 
 		/// Set the AH UMP queue priority configuration.
 		///
-		/// Can only be called by the `ManagerOrigin`.
+		/// Can only be called by the `AdminOrigin`.
 		#[pallet::call_index(6)]
 		#[pallet::weight(T::RcWeightInfo::set_ah_ump_queue_priority())]
 		pub fn set_ah_ump_queue_priority(
 			origin: OriginFor<T>,
 			new: AhUmpQueuePriority<BlockNumberFor<T>>,
 		) -> DispatchResult {
-			<T as Config>::ManagerOrigin::ensure_origin(origin)?;
+			Self::ensure_admin_or_manager(origin)?;
+
 			let old = AhUmpQueuePriorityConfig::<T>::get();
 			if old == new {
 				return Err(Error::<T>::AhUmpQueuePriorityAlreadySet.into());
@@ -864,6 +883,20 @@ pub mod pallet {
 			);
 			AhUmpQueuePriorityConfig::<T>::put(new.clone());
 			Self::deposit_event(Event::AhUmpQueuePriorityConfigSet { old, new });
+			Ok(())
+		}
+
+		/// Set the manager account id.
+		///
+		/// The manager has the similar to [`Config::AdminOrigin`] privileges except that it
+		/// can not set the manager account id via `set_manager` call.
+		#[pallet::call_index(7)]
+		#[pallet::weight(T::RcWeightInfo::set_manager())]
+		pub fn set_manager(origin: OriginFor<T>, new: Option<T::AccountId>) -> DispatchResult {
+			<T as Config>::AdminOrigin::ensure_origin(origin)?;
+			let old = Manager::<T>::get();
+			Manager::<T>::set(new.clone());
+			Self::deposit_event(Event::ManagerSet { old, new });
 			Ok(())
 		}
 	}
@@ -1764,6 +1797,17 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
+		/// Ensure that the origin is [`Config::AdminOrigin`] or signed by [`Manager`] account id.
+		fn ensure_admin_or_manager(origin: OriginFor<T>) -> DispatchResult {
+			if let Ok(account_id) = ensure_signed(origin.clone()) {
+				if Manager::<T>::get().map_or(false, |manager_id| manager_id == account_id) {
+					return Ok(());
+				}
+			}
+			<T as Config>::AdminOrigin::ensure_origin(origin)?;
+			Ok(())
+		}
+
 		/// Returns `true` if the migration is ongoing and the Asset Hub has not confirmed
 		/// processing the same number of XCM messages as we have sent to it.
 		fn has_excess_unconfirmed_dmp(current: &MigrationStageOf<T>) -> bool {

--- a/pallets/rc-migrator/src/weights.rs
+++ b/pallets/rc-migrator/src/weights.rs
@@ -63,6 +63,7 @@ pub trait WeightInfo {
 	fn set_unprocessed_msg_buffer() -> Weight;
 	fn set_ah_ump_queue_priority() -> Weight;
 	fn force_ah_ump_queue_priority() -> Weight;
+	fn set_manager() -> Weight;
 }
 
 /// Weights for `pallet_rc_migrator` using the Substrate node and recommended hardware.
@@ -162,10 +163,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(10_000_000, 1000)
 	}
 	fn set_ah_ump_queue_priority() -> Weight {
-		Weight::from_parts(1, 1)
+		Weight::from_parts(10_000_000, 1000)
 	}
 	fn force_ah_ump_queue_priority() -> Weight {
-		Weight::from_parts(1, 1)
+		Weight::from_parts(10_000_000, 1000)
+	}
+	fn set_manager() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
 	}
 }
 
@@ -268,9 +272,12 @@ impl WeightInfo for () {
 		Weight::from_parts(10_000_000, 1000)
 	}
 	fn set_ah_ump_queue_priority() -> Weight {
-		Weight::from_parts(1, 1)
+		Weight::from_parts(10_000_000, 1000)
 	}
 	fn force_ah_ump_queue_priority() -> Weight {
-		Weight::from_parts(1, 1)
+		Weight::from_parts(10_000_000, 1000)
+	}
+	fn set_manager() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
 	}
 }

--- a/pallets/rc-migrator/src/weights_ah.rs
+++ b/pallets/rc-migrator/src/weights_ah.rs
@@ -83,6 +83,7 @@ pub trait WeightInfo {
 	fn receive_preimage_chunk(m: u32, ) -> Weight;
 	fn set_dmp_queue_priority() -> Weight;
 	fn force_dmp_queue_priority() -> Weight;
+	fn set_manager() -> Weight;
 }
 
 /// Weights for `pallet_ah_migrator` using the Substrate node and recommended hardware.
@@ -661,6 +662,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+
+	fn set_manager() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -1237,5 +1242,9 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(0, 1494))
 			.saturating_add(RocksDbWeight::get().reads(1))
 			.saturating_add(RocksDbWeight::get().writes(1))
+	}
+
+	fn set_manager() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
 	}
 }

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1587,7 +1587,7 @@ impl pallet_rc_migrator::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeEvent = RuntimeEvent;
-	type ManagerOrigin = EitherOfDiverse<
+	type AdminOrigin = EitherOfDiverse<
 		EnsureRoot<AccountId>,
 		EitherOfDiverse<
 			EnsureXcm<IsVoiceOfBody<CollectivesLocation, FellowsBodyId>>,

--- a/relay/polkadot/src/weights/pallet_ah_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_ah_migrator.rs
@@ -563,4 +563,8 @@ impl<T: crate::ah_migration::weights::DbConfig> pallet_rc_migrator::weights_ah::
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+
+	fn set_manager() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }

--- a/relay/polkadot/src/weights/pallet_rc_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_rc_migrator.rs
@@ -148,9 +148,12 @@ impl<T: frame_system::Config> pallet_rc_migrator::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(10_000_000, 1000)
 	}
 	fn set_ah_ump_queue_priority() -> Weight {
-		Weight::from_parts(1, 1)
+		Weight::from_parts(10_000_000, 1000)
 	}
 	fn force_ah_ump_queue_priority() -> Weight {
-		Weight::from_parts(1, 1)
+		Weight::from_parts(10_000_000, 1000)
+	}
+	fn set_manager() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
 	}
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1165,7 +1165,7 @@ parameter_types! {
 impl pallet_ah_migrator::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type RuntimeEvent = RuntimeEvent;
-	type ManagerOrigin = EitherOfDiverse<
+	type AdminOrigin = EitherOfDiverse<
 		EnsureRoot<AccountId>,
 		EnsureXcm<IsVoiceOfBody<FellowshipLocation, FellowsBodyId>>,
 	>;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_ah_migrator.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_ah_migrator.rs
@@ -563,4 +563,8 @@ impl<T: frame_system::Config> pallet_ah_migrator::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
+
+	fn set_manager() -> Weight {
+		Weight::from_parts(10_000_000, 1000)
+	}
 }


### PR DESCRIPTION
Optional migration manager account id

Adds the possibility to set a specific account id as a manager for the migrators pallets. The manager has the similar to migrators `AdminOrigin` (`ManagerOrigin` before) privileges except that it can not set the manager account id via `set_manager` call. The account id later can be an off-chain multisig set by Governance or Fellowship to manage the migration process. 