### PR TITLE
[AHM] Staking migration

### DIFF
--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         'propagate-feature',
         # These are the features to check:
-        '--features=try-runtime,runtime-benchmarks,std,ahm-kusama,ahm-staking-migration,stable2503',
+        '--features=try-runtime,runtime-benchmarks,std,ahm-kusama,ahm-staking-migration,stable2503,ahm-staking-migration',
         # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
         '--left-side-feature-missing=ignore',
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/.config/zepter.yaml
+++ b/.config/zepter.yaml
@@ -12,7 +12,7 @@ workflows:
         # Check that `A` activates the features of `B`.
         'propagate-feature',
         # These are the features to check:
-        '--features=try-runtime,runtime-benchmarks,std,ahm-kusama,ahm-staking-migration,stable2503,ahm-staking-migration',
+        '--features=try-runtime,runtime-benchmarks,std,ahm-kusama,stable2503',
         # Do not try to add a new section into `[features]` of `A` only because `B` expose that feature. There are edge-cases where this is still needed, but we can add them manually.
         '--left-side-feature-missing=ignore',
         # Ignore the case that `A` it outside of the workspace. Otherwise it will report errors in external dependencies that we have no influence on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fix `experimental_inflation_info` in Polkadot and remove unused code (https://github.com/polkadot-fellows/runtimes/pull/497)
+- Fix `experimental_inflation_info` in Polkadot and remove unused code (<https://github.com/polkadot-fellows/runtimes/pull/497>)
 
 ## [1.3.3] 01.10.2024
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8917,6 +8917,8 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-staking",
+ "pallet-staking-async",
+ "pallet-staking-async-ah-client",
  "pallet-state-trie-migration",
  "pallet-treasury",
  "pallet-vesting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "asset-test-utils"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -1137,7 +1137,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1430,7 +1430,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "hash-db",
  "log",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "bp-bridge-hub-cumulus"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.20.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.20.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.20.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.20.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.20.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1845,7 +1845,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.6.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1894,7 +1894,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.13.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -3343,7 +3343,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3360,7 +3360,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3419,7 +3419,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.19.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3434,7 +3434,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -3459,7 +3459,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.18.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3498,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "sp-externalities 0.30.0 (git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo)",
  "sp-runtime-interface 29.0.1 (git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo)",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4074,7 +4074,7 @@ dependencies = [
 [[package]]
 name = "emulated-integration-tests-common"
 version = "20.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -4468,7 +4468,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4491,7 +4491,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "40.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4529,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4599,7 +4599,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "futures",
  "indicatif",
@@ -4637,7 +4637,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "33.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4698,7 +4698,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4720,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4763,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8003,7 +8003,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -8023,7 +8023,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8041,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8070,7 +8070,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8087,7 +8087,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8119,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8134,7 +8134,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8147,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8170,7 +8170,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8191,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "41.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8207,7 +8207,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "41.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8226,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -8251,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8268,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -8287,7 +8287,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.20.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8306,7 +8306,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8349,7 +8349,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.19.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8385,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8421,7 +8421,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8437,7 +8437,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "24.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8455,7 +8455,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8470,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8491,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8512,7 +8512,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8525,7 +8525,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8543,7 +8543,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8583,7 +8583,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8599,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8618,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8633,7 +8633,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "43.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8652,7 +8652,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8671,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8694,7 +8694,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "34.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8727,7 +8727,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8746,7 +8746,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "38.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8764,7 +8764,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8809,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8849,7 +8849,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8865,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8875,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8944,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8958,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8997,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.6.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -9045,7 +9045,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.3.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9069,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -9081,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -9093,7 +9093,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "41.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9110,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9132,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9148,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9165,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "40.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9231,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9248,7 +9248,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -9259,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9268,7 +9268,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "44.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9328,7 +9328,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9356,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9375,7 +9375,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9389,7 +9389,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9418,7 +9418,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "19.1.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9451,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.16.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -9509,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9538,7 +9538,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -9737,7 +9737,7 @@ dependencies = [
 [[package]]
 name = "penpal-runtime"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",
@@ -10153,7 +10153,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "16.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "18.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "19.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10456,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -10468,7 +10468,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "19.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.9.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11582,7 +11582,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11939,7 +11939,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "log",
  "sp-core 36.1.0",
@@ -11950,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11965,7 +11965,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "docify",
@@ -11991,7 +11991,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -12002,7 +12002,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "fnv",
  "futures",
@@ -12028,7 +12028,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12051,7 +12051,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -12095,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "polkavm 0.18.0",
  "sc-allocator",
@@ -12131,7 +12131,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "log",
  "polkavm 0.18.0",
@@ -12142,7 +12142,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.38.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "anyhow",
  "log",
@@ -12158,7 +12158,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -12186,7 +12186,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.49.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12236,7 +12236,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -12246,7 +12246,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "ahash",
  "futures",
@@ -12265,7 +12265,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12300,7 +12300,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.15.4"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bs58",
  "bytes",
@@ -12319,7 +12319,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12339,7 +12339,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "28.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "chrono",
  "futures",
@@ -12358,7 +12358,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "futures",
@@ -12375,7 +12375,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -13027,7 +13027,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -13178,7 +13178,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-beacon-primitives"
 version = "0.13.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "byte-slice-cast",
  "frame-support",
@@ -13200,7 +13200,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.13.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bp-relayers",
  "ethabi-decode",
@@ -13225,7 +13225,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-ethereum"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "ethabi-decode",
  "ethbloom",
@@ -13245,7 +13245,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-inbound-queue-primitives"
 version = "0.2.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "alloy-core",
  "frame-support",
@@ -13269,7 +13269,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-merkle-tree"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13295,7 +13295,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-primitives"
 version = "0.2.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "alloy-core",
  "ethabi-decode",
@@ -13321,7 +13321,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-outbound-queue-runtime-api"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -13335,7 +13335,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13361,7 +13361,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
 version = "0.21.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -13374,7 +13374,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue"
 version = "0.13.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "alloy-core",
  "frame-benchmarking",
@@ -13401,7 +13401,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-inbound-queue-fixtures"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives",
@@ -13414,7 +13414,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-outbound-queue"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
@@ -13437,7 +13437,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-pallet-system"
 version = "0.13.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13458,7 +13458,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-common"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13477,7 +13477,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-runtime-test-common"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -13508,7 +13508,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-system-runtime-api"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
@@ -13520,7 +13520,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-verification-primitives"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -13558,7 +13558,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "hash-db",
@@ -13580,7 +13580,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "22.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -13594,7 +13594,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13606,7 +13606,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -13620,7 +13620,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13632,7 +13632,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -13642,7 +13642,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -13661,7 +13661,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "futures",
@@ -13675,7 +13675,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13691,7 +13691,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.42.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -13709,7 +13709,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "24.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13729,7 +13729,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "23.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -13746,7 +13746,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.42.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13804,7 +13804,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -13865,7 +13865,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -13878,7 +13878,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo)",
@@ -13888,7 +13888,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -13908,7 +13908,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13929,7 +13929,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13939,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13951,7 +13951,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13964,7 +13964,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "40.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bytes",
  "docify",
@@ -13990,7 +13990,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "sp-core 36.1.0",
  "sp-runtime",
@@ -14000,7 +14000,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -14011,7 +14011,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -14020,7 +14020,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -14030,7 +14030,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14041,7 +14041,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "36.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14058,7 +14058,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14071,7 +14071,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "sp-api",
  "sp-core 36.1.0",
@@ -14081,7 +14081,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "backtrace",
  "regex",
@@ -14090,7 +14090,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -14100,7 +14100,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -14148,7 +14148,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -14181,7 +14181,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "Inflector",
  "expander",
@@ -14194,7 +14194,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "38.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14208,7 +14208,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -14221,7 +14221,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "hash-db",
  "log",
@@ -14247,7 +14247,7 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 
 [[package]]
 name = "sp-storage"
@@ -14265,7 +14265,7 @@ dependencies = [
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14277,7 +14277,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -14301,7 +14301,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -14312,7 +14312,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -14321,7 +14321,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "39.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "ahash",
  "hash-db",
@@ -14343,7 +14343,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -14360,7 +14360,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -14384,7 +14384,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -14396,7 +14396,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -14592,7 +14592,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -14605,7 +14605,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "16.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -14626,7 +14626,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "20.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "environmental",
  "frame-support",
@@ -14650,7 +14650,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "19.1.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14749,7 +14749,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -14774,7 +14774,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -14788,7 +14788,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -14801,7 +14801,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "26.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -15190,7 +15190,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "testnet-parachains-constants"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -16450,7 +16450,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17050,7 +17050,7 @@ dependencies = [
 [[package]]
 name = "xcm-emulator"
 version = "0.19.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17084,7 +17084,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -17095,7 +17095,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17109,7 +17109,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "20.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#4fa01d41c6de9a52c69483e7026bac568dbc2cbf"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=oty-2503-paseo#599ff333d2e930db8ed96fc1cba6022b74d9c06f"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7956,6 +7956,7 @@ dependencies = [
  "pallet-referenda",
  "pallet-scheduler",
  "pallet-staking",
+ "pallet-staking-async",
  "pallet-state-trie-migration",
  "pallet-timestamp",
  "pallet-treasury",

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ To submit a fix to release `x.y.z` and make a point release:
 - Check for other planned releases which originally targeted the same semver version and post on the issue letting them know that they should bump
 - Once the release is out, amend the GitHub release and delete all unchanged runtime blobs. Highlight if this release only affects some runtimes (contact a maintainer)
 - Backport your changes to the `CHANGELOG.md` to the main branch
+
 ## Release guidelines
 
 Here is an overview of the recommended steps.
@@ -98,7 +99,6 @@ Here is an overview of the recommended steps.
 |8 |Create the **[whitelisted caller referendum (OpenGov)](https://github.com/joepetrowski/opengov-cli)** with contextual information and **instructions for following up** on breaking changes or disruptions. |
 |9 |Close the issue for the release once the referendum is **approved and executed**. |
 |10 |Open an issue for **the next release** in the runtimes repo, if applicable.|
-
 
 ## Communication channels
 

--- a/docs/removing-migrations.md
+++ b/docs/removing-migrations.md
@@ -7,7 +7,8 @@ The following is a quick guide/process for removing applied migrations while mak
 ## Prerequisites
 
 For some chain runtime `spec_version: a_bcd_efg,` (e.g. `spec_version: 1_000_001`):
-- has been officially released on https://github.com/polkadot-fellows/runtimes/releases/ as part of `Runtimes X.Y.Z` release/tag.
+
+- has been officially released on <https://github.com/polkadot-fellows/runtimes/releases/> as part of `Runtimes X.Y.Z` release/tag.
 - the **on-chain** runtime version has been upgraded to spec version `a_bcd_efg` (using wasm blob released above).
 
 ## Steps

--- a/docs/running-commands.md
+++ b/docs/running-commands.md
@@ -8,7 +8,6 @@ You can run commands in PRs by triggering it via comment. It will use the contex
 
 `/cmd <command> --help` to see the usage of a specific command
 
-
 ### Commands
 
 - `/cmd fmt` to format the code in the PR. It commits back with the formatted code (fmt) and configs (taplo).
@@ -17,16 +16,17 @@ You can run commands in PRs by triggering it via comment. It will use the contex
 
 ### Flags
 
-1.`--quiet` to suppress the output of the command in the comments. 
-By default, the Start and End/Failure of the command will be commented with the link to a pipeline. 
+1.`--quiet` to suppress the output of the command in the comments.
+By default, the Start and End/Failure of the command will be commented with the link to a pipeline.
 If you want to avoid, use this flag. Go to [Action Tab](https://github.com/polkadot-fellows/runtimes/actions/workflows/cmd.yml) to see the pipeline status.
 
-2.`--continue-on-fail` to continue running the command even if something inside a command (like specific pallet weight generation) are failed. 
+2.`--continue-on-fail` to continue running the command even if something inside a command (like specific pallet weight generation) are failed.
 Basically avoids interruption in the middle with `exit 1`
 The pipeline logs will include what is failed (like which runtimes/pallets), then you can re-run them separately or not.
 
 3.`--clean` to clean up all yours and bot's comments in PR relevant to `/cmd` commands. If you run too many commands, or they keep failing, and you're rerunning them again, it's handy to add this flag to keep a PR clean.
 
 ### Adding new Commands
+
 Feel free to add new commands to the workflow, however **_note_** that triggered workflows will use the actions from `main` (default) branch, meaning they will take effect only after the PR with new changes/command is merged.
 If you want to test the new command, it's better to test in your fork and local-to-fork PRs, where you control the default branch.

--- a/docs/weight-generation.md
+++ b/docs/weight-generation.md
@@ -1,8 +1,8 @@
 # Weight Generation
 
-To generate weights for a runtime. 
+To generate weights for a runtime.
 Weights generation is using self-hosted runner which is provided by [Amforc](https://amforc.com/), the rest commands are using standard Github runners on `ubuntu-latest` or `ubuntu-20.04`.
-Self-hosted runner for benchmarks is configured to meet requirements of reference hardware for running validators https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot#reference-hardware
+Self-hosted runner for benchmarks is configured to meet requirements of reference hardware for running validators <https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot#reference-hardware>
 
 In a PR run the actions through comment:
 
@@ -15,6 +15,7 @@ In a PR run the actions through comment:
 ```
 
 To generate weights for all pallets in a particular runtime(s), run the following command:
+
 ```sh
 /cmd bench --runtime kusama polkadot
 ```
@@ -22,19 +23,20 @@ To generate weights for all pallets in a particular runtime(s), run the followin
 > **📝 Note**: The action is not being run right-away, it will be queued and run in the next available runner. So might be quick, but might also take up to 10 mins (That's in control of Github).  
 Once the action is run, you'll see reaction 👀 on original comment, and if you didn't pass `--quiet` - it will also send a link to a pipeline when started, and link to whole workflow when finished.
 
-> **💡Hint #1** : if you run all runtimes or all pallets, it might be that some pallet in the middle is failed to generate weights, thus it stops (fails) the whole pipeline. 
-> If you want, you can make it to continue running, even if some pallets are failed, add `--continue-on-fail` flag to the command. The report will include which runtimes/pallets have failed, then you can re-run them separately after all is done. 
+> **💡Hint #1** : if you run all runtimes or all pallets, it might be that some pallet in the middle is failed to generate weights, thus it stops (fails) the whole pipeline.
+> If you want, you can make it to continue running, even if some pallets are failed, add `--continue-on-fail` flag to the command. The report will include which runtimes/pallets have failed, then you can re-run them separately after all is done.
 
 This way it runs all possible runtimes for the specified pallets, if it finds them in the runtime
-```sh 
+
+```sh
 /cmd bench --pallet pallet_balances pallet_xcm_benchmarks::generic pallet_xcm_benchmarks::fungible
 ```
 
 If you want to run all specific pallet(s) for specific runtime(s), you can do it like this:
+
 ```sh
 /cmd bench --runtime bridge-hub-polkadot --pallet pallet_xcm_benchmarks::generic pallet_xcm_benchmarks::fungible
 ```
-
 
 > **💡Hint #2** : Sometimes when you run too many commands, or they keep failing and you're rerunning them again, it's handy to add `--clean` flag to the command. This will clean up all yours and bot's comments in PR relevant to /cmd commands.
 

--- a/integration-tests/ahm/src/tests.rs
+++ b/integration-tests/ahm/src/tests.rs
@@ -57,7 +57,7 @@ use pallet_ah_migrator::{
 	MigrationStage as AhMigrationStage,
 };
 use pallet_rc_migrator::{
-	types::RcMigrationCheck, MigrationStage as RcMigrationStage,
+	staking::StakingMigratedCorrectly, types::RcMigrationCheck, MigrationStage as RcMigrationStage,
 	RcMigrationStage as RcMigrationStageStorage,
 };
 use polkadot_primitives::UpwardMessage;
@@ -107,6 +107,7 @@ pub type RcPolkadotChecks = (
 	pallet_rc_migrator::claims::ClaimsMigrator<Polkadot>,
 	pallet_rc_migrator::crowdloan::CrowdloanMigrator<Polkadot>,
 	ProxyWhaleWatching,
+	StakingMigratedCorrectly<Polkadot>,
 );
 
 type AhChecks = (
@@ -144,6 +145,7 @@ pub type AhPolkadotChecks = (
 	pallet_rc_migrator::claims::ClaimsMigrator<AssetHub>,
 	pallet_rc_migrator::crowdloan::CrowdloanMigrator<AssetHub>,
 	ProxyWhaleWatching,
+	StakingMigratedCorrectly<AssetHub>,
 );
 
 #[ignore] // we use the equivalent [migration_works_time] test instead

--- a/integration-tests/bridges/README.md
+++ b/integration-tests/bridges/README.md
@@ -7,23 +7,27 @@ To start a test, you need to:
 
 - download latest [zombienet release](https://github.com/paritytech/zombienet/releases) to  `~/local_bridge_testing/bin/zombienet`.
 - build Polkadot binaries by running commands in the [`polkadot-sdk`](https://github.com/paritytech/polkadot-sdk) repository clone:
+
   ```
   cargo build -p polkadot --release
   cargo build --bin polkadot-prepare-worker --release
   cargo build --bin polkadot-execute-worker --release
   ```
+
   Copy the binaries to:
+
   ```
   ~/local_bridge_testing/bin/polkadot
   ~/local_bridge_testing/bin/polkadot-prepare-worker
   ~/local_bridge_testing/bin/polkadot-execute-worker
   ```
+
 - build Polkadot Parachain binary by running `cargo build -p polkadot-parachain-bin --release` command in the
 [`polkadot-sdk`](https://github.com/paritytech/polkadot-sdk) repository clone. Copy the binary to `~/local_bridge_testing/bin/polkadot-parachain`.
 - ensure that you have [`node`](https://nodejs.org/en) installed. Additionally, we'll need globally installed
 `polkadot/api-cli` / `polkadot/api` packages (use `yarn global add @polkadot/api-cli` to install it).
 - build Substrate relay by running `cargo build -p substrate-relay --release` command in the
-[`parity-bridges-common`](https://github.com/paritytech/parity-bridges-common) repository clone. Copy the binary to `~/local_bridge_testing/bin/substrate-relay`. 
+[`parity-bridges-common`](https://github.com/paritytech/parity-bridges-common) repository clone. Copy the binary to `~/local_bridge_testing/bin/substrate-relay`.
 - build chain spec generator:
   - (you can use the current branch, or you can build generators from different branches, such as from specific tags or releases)
   - add the `sudo` pallet to the Polkadot and Kusama runtimes and give sudo rights to Alice, e.g. by running `git apply ./integration-tests/bridges/sudo-relay.patch` from the fellows root dir.

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -35,6 +35,7 @@ pallet-rc-migrator = { workspace = true }
 pallet-referenda = { workspace = true }
 pallet-scheduler = { workspace = true }
 pallet-staking = { workspace = true }
+pallet-staking-async = { workspace = true }
 pallet-state-trie-migration = { workspace = true }
 pallet-vesting = { workspace = true }
 pallet-treasury = { workspace = true }
@@ -120,6 +121,7 @@ std = [
 	"xcm-executor/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"pallet-staking-async/std"
 ]
 runtime-benchmarks = [
 	"assets-common/runtime-benchmarks",
@@ -162,6 +164,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm/runtime-benchmarks",
+	"pallet-staking-async/runtime-benchmarks"
 	# "asset-hub-polkadot-runtime/runtime-benchmarks"
 ]
 try-runtime = [
@@ -193,4 +196,5 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-staking-async/try-runtime"
 ]

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -93,6 +93,7 @@ std = [
 	"pallet-rc-migrator/std",
 	"pallet-referenda/std",
 	"pallet-scheduler/std",
+	"pallet-staking-async/std",
 	"pallet-staking/std",
 	"pallet-state-trie-migration/std",
 	"pallet-timestamp/std",
@@ -118,7 +119,6 @@ std = [
 	"xcm-executor/std",
 	"xcm-executor/std",
 	"xcm/std",
-	"pallet-staking-async/std"
 ]
 runtime-benchmarks = [
 	"assets-common/runtime-benchmarks",
@@ -145,6 +145,7 @@ runtime-benchmarks = [
 	"pallet-rc-migrator/runtime-benchmarks",
 	"pallet-referenda/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
+	"pallet-staking-async/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
 	"pallet-state-trie-migration/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
@@ -161,7 +162,6 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm/runtime-benchmarks",
-	"pallet-staking-async/runtime-benchmarks"
 	# "asset-hub-polkadot-runtime/runtime-benchmarks"
 ]
 try-runtime = [
@@ -185,6 +185,7 @@ try-runtime = [
 	"pallet-rc-migrator/try-runtime",
 	"pallet-referenda/try-runtime",
 	"pallet-scheduler/try-runtime",
+	"pallet-staking-async/try-runtime",
 	"pallet-staking/try-runtime",
 	"pallet-state-trie-migration/try-runtime",
 	"pallet-timestamp/try-runtime",
@@ -193,5 +194,4 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
-	"pallet-staking-async/try-runtime"
 ]

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -65,9 +65,6 @@ pallet-ah-ops = { workspace = true }
 
 [features]
 default = ["std"]
-ahm-staking-migration = [
-	"pallet-rc-migrator/ahm-staking-migration"
-]
 std = [
 	"assets-common/std",
 	"assets-common/std",

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -64,6 +64,9 @@ pallet-ah-ops = { workspace = true }
 
 [features]
 default = ["std"]
+ahm-staking-migration = [
+	"pallet-rc-migrator/ahm-staking-migration"
+]
 std = [
 	"assets-common/std",
 	"assets-common/std",

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -79,8 +79,7 @@ use frame_system::pallet_prelude::*;
 use pallet_balances::{AccountData, Reasons as LockReasons};
 use pallet_rc_migrator::{
 	bounties::RcBountiesMessageOf, claims::RcClaimsMessageOf, crowdloan::RcCrowdloanMessageOf,
-	treasury::RcTreasuryMessage, types::MigrationStatus,
-	staking::PortableStakingMessage,
+	staking::PortableStakingMessage, treasury::RcTreasuryMessage, types::MigrationStatus,
 };
 
 use cumulus_primitives_core::AggregateMessageOrigin;
@@ -859,7 +858,6 @@ pub mod pallet {
 			Self::do_receive_delegated_staking_messages(messages).map_err(Into::into)
 		}
 
-		#[cfg(feature = "ahm-staking-migration")]
 		#[pallet::call_index(30)]
 		#[pallet::weight({1})] // TODO: @ggwpez weight
 		pub fn receive_staking_messages(

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -80,6 +80,7 @@ use pallet_balances::{AccountData, Reasons as LockReasons};
 use pallet_rc_migrator::{
 	bounties::RcBountiesMessageOf, claims::RcClaimsMessageOf, crowdloan::RcCrowdloanMessageOf,
 	treasury::RcTreasuryMessage, types::MigrationStatus,
+	staking::PortableStakingMessage,
 };
 
 use cumulus_primitives_core::AggregateMessageOrigin;
@@ -265,6 +266,7 @@ pub mod pallet {
 		+ pallet_bounties::Config
 		+ pallet_treasury::Config
 		+ pallet_delegated_staking::Config
+		+ pallet_staking_async::Config<CurrencyBalance = u128>
 	{
 		type RuntimeHoldReason: Parameter
 			+ VariantCount
@@ -862,7 +864,7 @@ pub mod pallet {
 		#[pallet::weight({1})] // TODO: @ggwpez weight
 		pub fn receive_staking_messages(
 			origin: OriginFor<T>,
-			messages: Vec<T::PortableStakingMessage>,
+			messages: Vec<PortableStakingMessage>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -859,7 +859,9 @@ pub mod pallet {
 		}
 
 		#[pallet::call_index(30)]
-		#[pallet::weight({1})] // TODO: @ggwpez weight
+		#[pallet::weight(
+			T::DbWeight::get().reads_writes(3, 3).saturating_add(Weight::from_parts(10_000_000, 200)).saturating_mul(messages.len() as u64)
+		)] // TODO @ggwpez weight
 		pub fn receive_staking_messages(
 			origin: OriginFor<T>,
 			messages: Vec<PortableStakingMessage>,

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -862,7 +862,7 @@ pub mod pallet {
 		#[pallet::weight({1})] // TODO: @ggwpez weight
 		pub fn receive_staking_messages(
 			origin: OriginFor<T>,
-			messages: Vec<T::RcStakingMessage>,
+			messages: Vec<T::PortableStakingMessage>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 

--- a/pallets/ah-migrator/src/staking/checks.rs
+++ b/pallets/ah-migrator/src/staking/checks.rs
@@ -36,7 +36,7 @@ impl<T: crate::Config> crate::types::AhMigrationCheck
 	fn post_check(rc: Self::RcPrePayload, _ah_pre_payload: Self::AhPrePayload) {
 		// Storage Values
 		assert_eq!(rc.validator_count, pallet_staking_async::ValidatorCount::<T>::get());
-		// Min validator count is not migrated @kianenigma review
+		// Min validator count is not migrated and instead configured via `MinimumValidatorSetSize`
 		assert_eq!(rc.min_nominator_bond, pallet_staking_async::MinNominatorBond::<T>::get());
 		assert_eq!(rc.min_validator_bond, pallet_staking_async::MinValidatorBond::<T>::get());
 		assert_eq!(rc.min_active_stake, pallet_staking_async::MinimumActiveStake::<T>::get());
@@ -61,7 +61,7 @@ impl<T: crate::Config> crate::types::AhMigrationCheck
 		assert_eq!(rc.max_staked_rewards, pallet_staking_async::MaxStakedRewards::<T>::get());
 		assert_eq!(rc.slash_reward_fraction, pallet_staking_async::SlashRewardFraction::<T>::get());
 		assert_eq!(rc.canceled_slash_payout, pallet_staking_async::CanceledSlashPayout::<T>::get());
-		// Current planned session is not migrated @kianenigma review
+		// Current planned session is not migrated
 		assert_eq!(rc.chill_threshold, pallet_staking_async::ChillThreshold::<T>::get());
 
 		// Storage Maps

--- a/pallets/ah-migrator/src/staking/checks.rs
+++ b/pallets/ah-migrator/src/staking/checks.rs
@@ -1,0 +1,129 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Checks that the staking migration succeeded.
+
+use pallet_rc_migrator::staking::{message::PortableNominations, PortableStakingMessage, RcData};
+use sp_runtime::AccountId32;
+
+impl<T: crate::Config> crate::types::AhMigrationCheck
+	for pallet_rc_migrator::staking::StakingMigratedCorrectly<T>
+{
+	type RcPrePayload = RcData;
+	type AhPrePayload = ();
+
+	fn pre_check(_rc: Self::RcPrePayload) -> Self::AhPrePayload {}
+
+	fn post_check(rc: Self::RcPrePayload, _ah_pre_payload: Self::AhPrePayload) {
+		// Storage Values
+		assert_eq!(rc.validator_count, pallet_staking_async::ValidatorCount::<T>::get());
+		// Min validator count is not migrated @kianenigma review
+		assert_eq!(rc.min_nominator_bond, pallet_staking_async::MinNominatorBond::<T>::get());
+		assert_eq!(rc.min_validator_bond, pallet_staking_async::MinValidatorBond::<T>::get());
+		assert_eq!(rc.min_active_stake, pallet_staking_async::MinimumActiveStake::<T>::get());
+		assert_eq!(rc.min_commission, pallet_staking_async::MinCommission::<T>::get());
+		assert_eq!(rc.max_validators_count, pallet_staking_async::MaxValidatorsCount::<T>::get());
+		assert_eq!(rc.max_nominators_count, pallet_staking_async::MaxNominatorsCount::<T>::get());
+		//assert_eq!(rc.current_era, pallet_staking_async::CurrentEra::<T>::get());
+		assert_eq!(
+			rc.active_era.map(translate_active_era),
+			pallet_staking_async::ActiveEra::<T>::get()
+		);
+		assert_eq!(translate_forcing(rc.force_era), pallet_staking_async::ForceEra::<T>::get());
+		assert_eq!(rc.max_staked_rewards, pallet_staking_async::MaxStakedRewards::<T>::get());
+		assert_eq!(rc.slash_reward_fraction, pallet_staking_async::SlashRewardFraction::<T>::get());
+		assert_eq!(rc.canceled_slash_payout, pallet_staking_async::CanceledSlashPayout::<T>::get());
+		// Current planned session is not migrated @kianenigma review
+		assert_eq!(rc.chill_threshold, pallet_staking_async::ChillThreshold::<T>::get());
+
+		// Storage Maps
+		assert_eq!(rc.invulnerables, pallet_staking_async::Invulnerables::<T>::get().into_inner());
+		assert_eq!(rc.bonded, pallet_staking_async::Bonded::<T>::iter().collect::<Vec<_>>());
+		assert_eq!(
+			rc.ledger.into_iter().map(|(k, v)| (k, v.into())).collect::<Vec<_>>(),
+			pallet_staking_async::Ledger::<T>::iter().collect::<Vec<_>>()
+		);
+		assert_eq!(
+			rc.payee
+				.into_iter()
+				.map(|(k, v)| (k, translate_reward_destination(v)))
+				.collect::<Vec<_>>(),
+			pallet_staking_async::Payee::<T>::iter().collect::<Vec<_>>()
+		);
+		assert_eq!(
+			rc.validators
+				.into_iter()
+				.map(|(k, v)| (k, translate_validator_prefs(v)))
+				.collect::<Vec<_>>(),
+			pallet_staking_async::Validators::<T>::iter().collect::<Vec<_>>()
+		);
+		assert_eq!(
+			rc.nominators
+				.into_iter()
+				.map(|(k, v)| (k, translate_nominations(v)))
+				.collect::<Vec<_>>(),
+			pallet_staking_async::Nominators::<T>::iter().collect::<Vec<_>>()
+		);
+		assert_eq!(
+			rc.virtual_stakers,
+			pallet_staking_async::VirtualStakers::<T>::iter_keys().collect::<Vec<_>>()
+		);
+	}
+}
+
+fn translate_reward_destination(
+	destination: pallet_staking::RewardDestination<AccountId32>,
+) -> pallet_staking_async::RewardDestination<AccountId32> {
+	use pallet_staking_async::RewardDestination::*;
+
+	match destination {
+		pallet_staking::RewardDestination::Staked => Staked,
+		pallet_staking::RewardDestination::Stash => Stash,
+		pallet_staking::RewardDestination::Controller => Controller,
+		pallet_staking::RewardDestination::Account(account) => Account(account),
+		pallet_staking::RewardDestination::None => None,
+	}
+}
+
+fn translate_active_era(era: pallet_staking::ActiveEraInfo) -> pallet_staking_async::ActiveEraInfo {
+	pallet_staking_async::ActiveEraInfo { index: era.index, start: era.start }
+}
+
+fn translate_forcing(forcing: pallet_staking::Forcing) -> pallet_staking_async::Forcing {
+	use pallet_staking_async::Forcing;
+	match forcing {
+		pallet_staking::Forcing::NotForcing => Forcing::NotForcing,
+		pallet_staking::Forcing::ForceNew => Forcing::ForceNew,
+		pallet_staking::Forcing::ForceNone => Forcing::ForceNone,
+		pallet_staking::Forcing::ForceAlways => Forcing::ForceAlways,
+	}
+}
+
+fn translate_validator_prefs(
+	prefs: pallet_staking::ValidatorPrefs,
+) -> pallet_staking_async::ValidatorPrefs {
+	pallet_staking_async::ValidatorPrefs { commission: prefs.commission, blocked: prefs.blocked }
+}
+
+fn translate_nominations<T: crate::Config>(
+	nominations: PortableNominations,
+) -> pallet_staking_async::Nominations<T> {
+	pallet_staking_async::Nominations {
+		targets: nominations.targets.into_inner().try_into().expect("Must not truncate"),
+		submitted_in: nominations.submitted_in,
+		suppressed: nominations.suppressed,
+	}
+}

--- a/pallets/ah-migrator/src/staking/checks.rs
+++ b/pallets/ah-migrator/src/staking/checks.rs
@@ -43,16 +43,10 @@ impl<T: crate::Config> crate::types::AhMigrationCheck
 		assert_eq!(rc.min_commission, pallet_staking_async::MinCommission::<T>::get());
 		assert_eq!(rc.max_validators_count, pallet_staking_async::MaxValidatorsCount::<T>::get());
 		assert_eq!(rc.max_nominators_count, pallet_staking_async::MaxNominatorsCount::<T>::get());
-		// @kianenigma please review
-		if let Some(rc_era) = rc.current_era {
-			let diff = (rc_era as i64 -
-				pallet_staking_async::CurrentEra::<T>::get().expect("Must have current era")
-					as i64)
-				.abs();
-			assert!(diff <= 2, "Current era difference is at most 1");
-		} else {
-			assert_eq!(pallet_staking_async::CurrentEra::<T>::get(), None);
-		}
+		assert_eq!(
+			pallet_staking_async::CurrentEra::<T>::get().expect("Must be set"),
+			pallet_staking_async::ActiveEra::<T>::get().expect("Must be set").index
+		);
 		assert_eq!(
 			rc.active_era.map(translate_active_era),
 			pallet_staking_async::ActiveEra::<T>::get()

--- a/pallets/ah-migrator/src/staking/checks.rs
+++ b/pallets/ah-migrator/src/staking/checks.rs
@@ -133,8 +133,7 @@ impl<T: crate::Config> crate::types::AhMigrationCheck
 			pallet_staking_async::ErasTotalStake::<T>::iter().collect::<Vec<_>>()
 		);
 		check_unapplied_slashes::<T>(rc.unapplied_slashes);
-		// TODO assert_eq!(rc.bonded_eras,
-		// pallet_staking_async::BondedEras::<T>::get().into_inner());
+		assert_eq!(rc.bonded_eras, pallet_staking_async::BondedEras::<T>::get().into_inner());
 		assert_eq!(
 			rc.validator_slash_in_era,
 			pallet_staking_async::ValidatorSlashInEra::<T>::iter().collect::<Vec<_>>()

--- a/pallets/ah-migrator/src/staking/mod.rs
+++ b/pallets/ah-migrator/src/staking/mod.rs
@@ -18,8 +18,9 @@
 //! Staking migration logic.
 
 pub mod bags_list;
+#[cfg(feature = "std")]
+pub mod checks;
 pub mod delegated_staking;
 pub mod fast_unstake;
 pub mod nom_pools;
-
 pub mod staking;

--- a/pallets/ah-migrator/src/staking/mod.rs
+++ b/pallets/ah-migrator/src/staking/mod.rs
@@ -22,5 +22,4 @@ pub mod delegated_staking;
 pub mod fast_unstake;
 pub mod nom_pools;
 
-#[cfg(feature = "ahm-staking-migration")]
 pub mod staking;

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -17,7 +17,8 @@
 //! Pallet staking migration.
 
 use crate::*;
-use crate::types::DefensiveTruncateInto;
+use pallet_rc_migrator::types::DefensiveTruncateInto;
+use pallet_rc_migrator::staking::PortableStakingMessage;
 use sp_runtime::Perbill;
 
 impl<T: Config> Pallet<T> {
@@ -25,7 +26,7 @@ impl<T: Config> Pallet<T> {
 
 	pub fn staking_migration_finish_hook() {}
 
-	pub fn do_receive_staking_messages(messages: Vec<T::PortableStakingMessage>) -> Result<(), Error<T>> {
+	pub fn do_receive_staking_messages(messages: Vec<PortableStakingMessage>) -> Result<(), Error<T>> {
 		let (mut good, mut bad) = (0, 0);
 		log::info!(target: LOG_TARGET, "Integrating {} StakingMessages", messages.len());
 		Self::deposit_event(Event::BatchReceived {
@@ -34,8 +35,7 @@ impl<T: Config> Pallet<T> {
 		});
 
 		for message in messages {
-			let translated = T::PortableStakingMessage::intoAh(message);
-			match Self::do_receive_staking_message(translated) {
+			match Self::do_receive_staking_message(message) {
 				Ok(_) => good += 1,
 				Err(_) => bad += 1,
 			}
@@ -51,7 +51,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn do_receive_staking_message(
-		message: AhEquivalentStakingMessageOf<T>,
+		message: PortableStakingMessage,
 	) -> Result<(), Error<T>> {
 		use PortableStakingMessage::*;
 
@@ -60,7 +60,7 @@ impl<T: Config> Pallet<T> {
 				log::debug!(target: LOG_TARGET, "Integrating StakingValues");
 				pallet_rc_migrator::staking::StakingMigrator::<T>::put_values(values);
 			},
-			Invulnerables(invulnerables) => {
+			/*Invulnerables(invulnerables) => {
 				log::debug!(target: LOG_TARGET, "Integrating StakingInvulnerables");
 				let bounded = BoundedVec::truncate_from(invulnerables);
 				pallet_staking_async::Invulnerables::<T>::put(bounded);
@@ -148,7 +148,8 @@ impl<T: Config> Pallet<T> {
 			SpanSlash { account, span, slash } => {
 				log::debug!(target: LOG_TARGET, "Integrating SpanSlash {:?}/{:?}", account, span);
 				pallet_staking_async::SpanSlash::<T>::insert((account, span), slash);
-			},
+			},*/
+			_ => todo!(),
 		}
 
 		Ok(())

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -134,11 +134,15 @@ impl<T: Config> Pallet<T> {
 				let slash: pallet_staking_async::UnappliedSlash<_> = slash.into();
 				pallet_staking_async::UnappliedSlashes::<T>::insert(era, slash_key, slash);
 			},
-			BondedEras(bonded_eras) => {
-				log::debug!(target: LOG_TARGET, "Integrating BondedEras");
-				let bounded: BoundedVec<_, _> = bonded_eras.clone().defensive_truncate_into();
-				pallet_staking_async::BondedEras::<T>::put(bounded);
-			},
+			BondedEras(bonded_eras) =>
+				if pallet_staking_async::BondedEras::<T>::exists() {
+					log::error!("BondedEras already exists, skipping insert");
+					defensive_assert!(bonded_eras.is_empty());
+				} else {
+					log::debug!(target: LOG_TARGET, "Integrating BondedEras");
+					let bounded: BoundedVec<_, _> = bonded_eras.clone().defensive_truncate_into();
+					pallet_staking_async::BondedEras::<T>::put(bounded);
+				},
 			ValidatorSlashInEra { era, validator, slash } => {
 				log::debug!(target: LOG_TARGET, "Integrating ValidatorSlashInEra {:?}/{:?}", validator, era);
 				pallet_staking_async::ValidatorSlashInEra::<T>::insert(era, validator, slash);

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -136,7 +136,7 @@ impl<T: Config> Pallet<T> {
 			},
 			BondedEras(bonded_eras) => {
 				log::debug!(target: LOG_TARGET, "Integrating BondedEras");
-				let bounded: BoundedVec<_, _> = bonded_eras.defensive_truncate_into();
+				let bounded: BoundedVec<_, _> = bonded_eras.clone().defensive_truncate_into();
 				pallet_staking_async::BondedEras::<T>::put(bounded);
 			},
 			ValidatorSlashInEra { era, validator, slash } => {

--- a/pallets/ah-migrator/src/staking/staking.rs
+++ b/pallets/ah-migrator/src/staking/staking.rs
@@ -17,7 +17,7 @@
 //! Pallet staking migration.
 
 use crate::*;
-use frame_support::traits::DefensiveTruncateInto;
+use crate::types::DefensiveTruncateInto;
 use sp_runtime::Perbill;
 
 impl<T: Config> Pallet<T> {
@@ -25,7 +25,7 @@ impl<T: Config> Pallet<T> {
 
 	pub fn staking_migration_finish_hook() {}
 
-	pub fn do_receive_staking_messages(messages: Vec<T::RcStakingMessage>) -> Result<(), Error<T>> {
+	pub fn do_receive_staking_messages(messages: Vec<T::PortableStakingMessage>) -> Result<(), Error<T>> {
 		let (mut good, mut bad) = (0, 0);
 		log::info!(target: LOG_TARGET, "Integrating {} StakingMessages", messages.len());
 		Self::deposit_event(Event::BatchReceived {
@@ -34,7 +34,7 @@ impl<T: Config> Pallet<T> {
 		});
 
 		for message in messages {
-			let translated = T::RcStakingMessage::intoAh(message);
+			let translated = T::PortableStakingMessage::intoAh(message);
 			match Self::do_receive_staking_message(translated) {
 				Ok(_) => good += 1,
 				Err(_) => bad += 1,
@@ -53,7 +53,7 @@ impl<T: Config> Pallet<T> {
 	fn do_receive_staking_message(
 		message: AhEquivalentStakingMessageOf<T>,
 	) -> Result<(), Error<T>> {
-		use RcStakingMessage::*;
+		use PortableStakingMessage::*;
 
 		match message {
 			Values(values) => {

--- a/pallets/rc-migrator/Cargo.toml
+++ b/pallets/rc-migrator/Cargo.toml
@@ -80,6 +80,8 @@ std = [
 	"pallet-referenda/std",
 	"pallet-scheduler/std",
 	"pallet-session/std",
+	"pallet-staking-async-ah-client/std",
+	"pallet-staking-async/std",
 	"pallet-staking/std",
 	"pallet-state-trie-migration/std",
 	"pallet-treasury/std",
@@ -102,8 +104,6 @@ std = [
 	"xcm-executor/std",
 	"xcm-executor/std",
 	"xcm/std",
-	"pallet-staking-async/std",
-	"pallet-staking-async-ah-client/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -125,6 +125,8 @@ runtime-benchmarks = [
 	"pallet-proxy/runtime-benchmarks",
 	"pallet-referenda/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
+	"pallet-staking-async-ah-client/runtime-benchmarks",
+	"pallet-staking-async/runtime-benchmarks",
 	"pallet-staking/runtime-benchmarks",
 	"pallet-state-trie-migration/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
@@ -139,8 +141,6 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm/runtime-benchmarks",
-	"pallet-staking-async/runtime-benchmarks",
-	"pallet-staking-async-ah-client/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-election-provider-support/try-runtime",
@@ -162,6 +162,8 @@ try-runtime = [
 	"pallet-referenda/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-session/try-runtime",
+	"pallet-staking-async-ah-client/try-runtime",
+	"pallet-staking-async/try-runtime",
 	"pallet-staking/try-runtime",
 	"pallet-state-trie-migration/try-runtime",
 	"pallet-treasury/try-runtime",
@@ -170,6 +172,4 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
-	"pallet-staking-async/try-runtime",
-	"pallet-staking-async-ah-client/try-runtime"
 ]

--- a/pallets/rc-migrator/Cargo.toml
+++ b/pallets/rc-migrator/Cargo.toml
@@ -56,7 +56,6 @@ frame-election-provider-support = { workspace = true }
 
 [features]
 default = ["std"]
-ahm-staking-migration = []
 
 std = [
 	"codec/std",

--- a/pallets/rc-migrator/Cargo.toml
+++ b/pallets/rc-migrator/Cargo.toml
@@ -32,11 +32,13 @@ pallet-proxy = { workspace = true }
 pallet-indices = { workspace = true }
 pallet-message-queue = { workspace = true }
 pallet-multisig = { workspace = true }
+pallet-staking-async = { workspace = true }
 pallet-preimage = { workspace = true }
 pallet-treasury = { workspace = true }
 pallet-fast-unstake = { workspace = true }
 pallet-referenda = { workspace = true }
 pallet-vesting = { workspace = true }
+pallet-staking-async-ah-client = { workspace = true }
 pallet-session = { workspace = true }
 pallet-nomination-pools = { workspace = true }
 pallet-state-trie-migration = { workspace = true }
@@ -54,6 +56,8 @@ frame-election-provider-support = { workspace = true }
 
 [features]
 default = ["std"]
+ahm-staking-migration = []
+
 std = [
 	"codec/std",
 	"frame-benchmarking?/std",
@@ -99,6 +103,8 @@ std = [
 	"xcm-executor/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"pallet-staking-async/std",
+	"pallet-staking-async-ah-client/std"
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
@@ -134,6 +140,8 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm/runtime-benchmarks",
+	"pallet-staking-async/runtime-benchmarks",
+	"pallet-staking-async-ah-client/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-election-provider-support/try-runtime",
@@ -163,4 +171,6 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-staking-async/try-runtime",
+	"pallet-staking-async-ah-client/try-runtime"
 ]

--- a/pallets/rc-migrator/README.md
+++ b/pallets/rc-migrator/README.md
@@ -25,6 +25,7 @@ fix this by either block number or on an era and submit this to the Relay Chain.
 ### Migration
 
 The migration will begin to run from the fixed block number and emit the following events to notify of this:
+
 - `pallet_rc_migrator::AssetHubMigrationStarted` on the Relay Chain
 - `pallet_ah_migrator::AssetHubMigrationStarted` on the Asset Hub
 

--- a/pallets/rc-migrator/src/accounts.md
+++ b/pallets/rc-migrator/src/accounts.md
@@ -21,6 +21,7 @@ the Relay or a parachain (like Asset Hub).
 
 There are different kinds of sovereign accounts. In this context, we only focus on these parachain
 sovereign accounts:
+
 - On the Relay: derived from `"para" ++ para_id ++ 00..`
 - On the Asset Hub and all other sibling parachains: derived from `"sibl" ++ para_id ++ 00..`
 
@@ -82,26 +83,26 @@ Pallets Increasing Provider References (Polkadot / Kusama / Westend):
 - delegate_staking (P/K/W): One extra provider reference should be migrated to AH for every account
 with the hold reason `pallet_delegated_staking::HoldReason::StakingDelegation`. This ensures the
 entire balance, including the ED, can be staked via holds.
-Source: https://github.com/paritytech/polkadot-sdk/blob/ab1e12ab6f6c3946c3c61b97328702e719cd1223/substrate/frame/delegated-staking/src/types.rs#L81
+Source: <https://github.com/paritytech/polkadot-sdk/blob/ab1e12ab6f6c3946c3c61b97328702e719cd1223/substrate/frame/delegated-staking/src/types.rs#L81>
 
 - parachains_on_demand (P/K/W): The on-demand pallet pot account should not be migrated to AH and
 will remain untouched.
-Source: https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/polkadot/runtime/parachains/src/on_demand/mod.rs#L407
+Source: <https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/polkadot/runtime/parachains/src/on_demand/mod.rs#L407>
 
 - crowdloan (P/K/W): The provider reference for a crowdloan fund account allows it to exist without
 an ED until funding is received. Since new crowdloans can no longer be created, and only successful
 ones are being migrated, we don’t expect any new fund accounts below ED. This reference can be
 ignored.
-Source: https://github.com/paritytech/polkadot-sdk/blob/9abe25d974f6045d1e97537e0f1e860459053722/polkadot/runtime/common/src/crowdloan/mod.rs#L417
+Source: <https://github.com/paritytech/polkadot-sdk/blob/9abe25d974f6045d1e97537e0f1e860459053722/polkadot/runtime/common/src/crowdloan/mod.rs#L417>
 
 - balances (P/K/W): No special handling is needed, as this is covered by the fungible implementation
 during injection on AH.
-Source: https://github.com/paritytech/polkadot-sdk/blob/9abe25d974f6045d1e97537e0f1e860459053722/substrate/frame/balances/src/lib.rs#L1035
+Source: <https://github.com/paritytech/polkadot-sdk/blob/9abe25d974f6045d1e97537e0f1e860459053722/substrate/frame/balances/src/lib.rs#L1035>
 
 - session (P/K/W): Validator accounts may receive a provider reference at genesis if they did not
 previously exist. This is not relevant for migration. Even if a validator is fully reaped during
 migration, they can restore their account by teleporting funds to RC post-migration.
-Source: https://github.com/paritytech/polkadot-sdk/blob/8d4138f77106a6af49920ad84f3283f696f3f905/substrate/frame/session/src/lib.rs#L462-L465
+Source: <https://github.com/paritytech/polkadot-sdk/blob/8d4138f77106a6af49920ad84f3283f696f3f905/substrate/frame/session/src/lib.rs#L462-L465>
 
 - broker (//_): Not relevant for RC and AH runtimes.
 
@@ -109,22 +110,21 @@ Pallets Increasing Consumer References (Polkadot / Kusama / Westend):
 
 - balances (P/K/W): No custom handling is required, as this is covered by the fungible
 implementation during account injection on AH.
-Source: https://github.com/paritytech/polkadot-sdk/blob/9abe25d974f6045d1e97537e0f1e860459053722/substrate/frame/balances/src/lib.rs#L1035
+Source: <https://github.com/paritytech/polkadot-sdk/blob/9abe25d974f6045d1e97537e0f1e860459053722/substrate/frame/balances/src/lib.rs#L1035>
 
 - recovery (/K/W): A consumer reference is added to the proxy account when it claims an already
 initiated recovery process. This reference is later removed when the recovery process ends. For
 simplicity, we can ignore this consumer reference, as it might affect only a small number of
 accounts, and a decrease without a prior increase will not cause any issues.
 See test: `polkadot_integration_tests_ahm::tests::test_account_references`
-Source: https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/substrate/frame/recovery/src/lib.rs#L610
+Source: <https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/substrate/frame/recovery/src/lib.rs#L610>
 
 - session (P/K/W): TODO: @Ank4n session set keys moving to AH
-Source: https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/substrate/frame/session/src/lib.rs#L812
+Source: <https://github.com/paritytech/polkadot-sdk/blob/ace62f120fbc9ec617d6bab0a5180f0be4441537/substrate/frame/session/src/lib.rs#L812>
 
 - staking (P/K/W): No references are migrated in the new staking pallet version; legacy references are not relevant.
 
 - assets, contracts, nfts, uniques, revive (//): Not relevant for RC and AH runtimes.
-
 
 ### XCM "Checking Account" and DOT/KSM Total Issuance Tracking
 
@@ -156,19 +156,18 @@ the source of truth for DOT/KSM *total issuance*.
 
 | DOT Teleports (in or out) | **Relay** | **AH** |
 |----------|-----|--------|
-| _Before_ | Yes | Yes |
-| _During_ | No  | No  |
-| _After_  | Yes | Yes |
-
+| *Before* | Yes | Yes |
+| *During* | No  | No  |
+| *After*  | Yes | Yes |
 
 The runtime configurations of Relay and AH need to change in terms of how they use the checking
 account before, during and after the migration.
 
 |     DOT Teleports tracking in Checking Account    | **Relay** | **AH** |
 |----------|-----------|--------|
-| _Before_ |     Yes, MintLocal       |   No Checking     |
-| _During_ |     No Checking       |   No Checking     |
-| _After_  |     No Checking      |   Yes, MintLocal     |
+| *Before* |     Yes, MintLocal       |   No Checking     |
+| *During* |     No Checking       |   No Checking     |
+| *After*  |     No Checking      |   Yes, MintLocal     |
 
 #### Tracking Total Issuance Post-Migration
 
@@ -186,30 +185,30 @@ To achieve this, we implement the following arithmetic algorithm:
 After all accounts (including checking account) are migrated from RC to AH:
 
 ```
-	ah_checking_intermediate = ah_check_before + rc_check_before
-	(0) rc_check_before = ah_checking_intermediate - ah_check_before
+ ah_checking_intermediate = ah_check_before + rc_check_before
+ (0) rc_check_before = ah_checking_intermediate - ah_check_before
 
-	Invariants:
-	(1) rc_check_before = sum_total_before(ah, bh, collectives, coretime, people)
-	(2) rc_check_before = sum_total_before(bh, collectives, coretime, people) + ah_total_before
+ Invariants:
+ (1) rc_check_before = sum_total_before(ah, bh, collectives, coretime, people)
+ (2) rc_check_before = sum_total_before(bh, collectives, coretime, people) + ah_total_before
 
-	Because teleports are disabled for RC and AH during migration, we can say:
-	(3) sum_total_before(bh, collectives, coretime, people) = sum_total_after(bh, collectives, coretime, people)
+ Because teleports are disabled for RC and AH during migration, we can say:
+ (3) sum_total_before(bh, collectives, coretime, people) = sum_total_after(bh, collectives, coretime, people)
 
-	Ergo use (3) in (2):
-	(4) rc_check_before = sum_total_after(bh, collectives, coretime, people) + ah_total_before
+ Ergo use (3) in (2):
+ (4) rc_check_before = sum_total_after(bh, collectives, coretime, people) + ah_total_before
 
-	We want:
-		ah_check_after = sum_total_after(rc, bh, collectives, coretime, people)
-		ah_check_after = sum_total_after(bh, collectives, coretime, people) + rc_balance_kept
-	Use (3):
-		ah_check_after = sum_total_before(bh, collectives, coretime, people) + rc_balance_kept
-		ah_check_after = sum_total_before(ah, bh, collectives, coretime, people) - ah_total_before + rc_balance_kept
-	Use (1):
-		ah_check_after = rc_check_before - ah_total_before + rc_balance_kept
+ We want:
+  ah_check_after = sum_total_after(rc, bh, collectives, coretime, people)
+  ah_check_after = sum_total_after(bh, collectives, coretime, people) + rc_balance_kept
+ Use (3):
+  ah_check_after = sum_total_before(bh, collectives, coretime, people) + rc_balance_kept
+  ah_check_after = sum_total_before(ah, bh, collectives, coretime, people) - ah_total_before + rc_balance_kept
+ Use (1):
+  ah_check_after = rc_check_before - ah_total_before + rc_balance_kept
 
-	Finally use (0):
-		ah_check_after = ah_checking_intermediate - ah_check_before - ah_total_before + rc_balance_kept
+ Finally use (0):
+  ah_check_after = ah_checking_intermediate - ah_check_before - ah_total_before + rc_balance_kept
 ```
 
 At which point, `ah_total_issuance_after` should equal `rc_total_issuance_before`.

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -345,9 +345,7 @@ pub enum MigrationStage<
 	},
 	TreasuryMigrationDone,
 
-	#[cfg(feature = "ahm-staking-migration")]
 	StakingMigrationInit,
-	#[cfg(feature = "ahm-staking-migration")]
 	StakingMigrationOngoing {
 		next_key: Option<staking::StakingStage<AccountId>>,
 	},
@@ -1003,7 +1001,6 @@ pub mod pallet {
 				},
 				MigrationStage::Starting => {
 					log::info!(target: LOG_TARGET, "Starting the migration");
-					#[cfg(feature = "ahm-staking-migration")]
 					pallet_staking_async_ah_client::Pallet::<T>::on_migration_start();
 
 					Self::transition(MigrationStage::AccountsMigrationInit);
@@ -1725,16 +1722,11 @@ pub mod pallet {
 					}
 				},
 				MigrationStage::TreasuryMigrationDone => {
-					#[cfg(feature = "ahm-staking-migration")]
 					Self::transition(MigrationStage::StakingMigrationInit);
-					#[cfg(not(feature = "ahm-staking-migration"))]
-					Self::transition(MigrationStage::StakingMigrationDone);
 				},
-				#[cfg(feature = "ahm-staking-migration")]
 				MigrationStage::StakingMigrationInit => {
 					Self::transition(MigrationStage::StakingMigrationOngoing { next_key: None });
 				},
-				#[cfg(feature = "ahm-staking-migration")]
 				MigrationStage::StakingMigrationOngoing { next_key } => {
 					let res = with_transaction_opaque_err::<Option<_>, Error<T>, _>(|| {
 						match staking::StakingMigrator::<T>::migrate_many(
@@ -1771,7 +1763,6 @@ pub mod pallet {
 							.saturating_add(T::RcWeightInfo::send_chunked_xcm_and_track())
 					);
 
-					#[cfg(feature = "ahm-staking-migration")]
 					pallet_staking_async_ah_client::Pallet::<T>::on_migration_end();
 
 					// Send finish message to AH.

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -449,12 +449,13 @@ pub mod pallet {
 		+ pallet_asset_rate::Config
 		+ pallet_slots::Config
 		+ pallet_crowdloan::Config
-		+ pallet_staking::Config
+		+ pallet_staking::Config<CurrencyBalance = u128>
 		+ pallet_claims::Config
 		+ pallet_bounties::Config
 		+ pallet_treasury::Config
 		+ pallet_delegated_staking::Config
 		+ pallet_xcm::Config
+		+ pallet_staking_async_ah_client::Config
 	{
 		/// The overall runtime origin type.
 		type RuntimeOrigin: Into<Result<pallet_xcm::Origin, <Self as Config>::RuntimeOrigin>>

--- a/pallets/rc-migrator/src/multisig.md
+++ b/pallets/rc-migrator/src/multisig.md
@@ -18,7 +18,7 @@ approvals on a specific call hash by the Multisig members.
 
 One thing to consider is that Multisigs are constructed from account IDs. In order to allow the same
 Multisigs to be re-created, it is paramount to keep all account IDs that were accessible on the
-relay still accessible, hence: https://github.com/polkadot-fellows/runtimes/issues/526. Otherwise it
+relay still accessible, hence: <https://github.com/polkadot-fellows/runtimes/issues/526>. Otherwise it
 could happen that a Multisig cannot be re-created and loses funds to its associated accounts.
 
 Note: I considered an XCM where the call is sent back to the relay to execute instead of executing

--- a/pallets/rc-migrator/src/preimage/preimage.md
+++ b/pallets/rc-migrator/src/preimage/preimage.md
@@ -23,6 +23,7 @@ Deprecated. Will not be migrated but funds will be unreserved.
 ## User Impact
 
 For anyone who has registered a preimage:
+
 - If the preimage was in the new RequestStatusFor: Some unlocked funds 😎. We cannot calculate a list of affected accounts in advance since users can still influence this.
 - If the preimage was in the old StatusFor: will be removed and funds unlocked. [Exhaustive list](https://github.com/ggwpez/substrate-scripts/blob/master/ahm-preimage-statusfor-accounts.py) of all 166 Polkadot accounts that are affected by this and will have **UP TO** these funds unlocked (not a legally binding statement):
   

--- a/pallets/rc-migrator/src/scheduler.md
+++ b/pallets/rc-migrator/src/scheduler.md
@@ -1,6 +1,7 @@
 # Scheduler Pallet
 
 Based on the scheduler pallet's usage in the Polkadot/Kusama runtime, it primarily contains two types of tasks:
+
 1. Tasks from passed referendums
 2. Service tasks from the referendum pallet, specifically `nudge_referendum` and `refund_submission_deposit`
 

--- a/pallets/rc-migrator/src/staking/checks.rs
+++ b/pallets/rc-migrator/src/staking/checks.rs
@@ -130,5 +130,45 @@ impl<T: crate::Config> crate::types::RcMigrationCheck for StakingMigratedCorrect
 		}
 	}
 
-	fn post_check(rc_pre_payload: Self::RcPrePayload) {}
+	fn post_check(rc_pre_payload: Self::RcPrePayload) {
+		use pallet_staking::*;
+		// All storage values are gone
+		assert!(!ValidatorCount::<T>::exists());
+		assert!(!MinimumValidatorCount::<T>::exists());
+		assert!(!MinNominatorBond::<T>::exists());
+		assert!(!MinValidatorBond::<T>::exists());
+		assert!(!MinimumActiveStake::<T>::exists());
+		assert!(!MinCommission::<T>::exists());
+		assert!(!MaxValidatorsCount::<T>::exists());
+		assert!(!MaxNominatorsCount::<T>::exists());
+		assert!(!CurrentEra::<T>::exists());
+		assert!(!ActiveEra::<T>::exists());
+		assert!(!ForceEra::<T>::exists());
+		assert!(!MaxStakedRewards::<T>::exists());
+		assert!(!SlashRewardFraction::<T>::exists());
+		assert!(!CanceledSlashPayout::<T>::exists());
+		assert!(!CurrentPlannedSession::<T>::exists());
+		assert!(!ChillThreshold::<T>::exists());
+
+		assert!(!Invulnerables::<T>::exists());
+		assert!(Bonded::<T>::iter_keys().next().is_none());
+		assert!(Ledger::<T>::iter_keys().next().is_none());
+		assert!(Payee::<T>::iter_keys().next().is_none());
+		assert!(Validators::<T>::iter_keys().next().is_none());
+		assert!(Nominators::<T>::iter_keys().next().is_none());
+		assert!(VirtualStakers::<T>::iter_keys().next().is_none());
+		assert!(ErasStakersOverview::<T>::iter_keys().next().is_none());
+		assert!(ErasStakersPaged::<T>::iter_keys().next().is_none());
+		assert!(ClaimedRewards::<T>::iter_keys().next().is_none());
+		assert!(ErasValidatorPrefs::<T>::iter_keys().next().is_none());
+		assert!(ErasValidatorReward::<T>::iter_keys().next().is_none());
+		assert!(ErasRewardPoints::<T>::iter_keys().next().is_none());
+		assert!(ErasTotalStake::<T>::iter_keys().next().is_none());
+		assert!(UnappliedSlashes::<T>::iter_keys().next().is_none());
+		assert!(!BondedEras::<T>::exists());
+		assert!(ValidatorSlashInEra::<T>::iter_keys().next().is_none());
+		assert!(NominatorSlashInEra::<T>::iter_keys().next().is_none());
+		assert!(SlashingSpans::<T>::iter_keys().next().is_none());
+		assert!(SpanSlash::<T>::iter_keys().next().is_none());
+	}
 }

--- a/pallets/rc-migrator/src/staking/checks.rs
+++ b/pallets/rc-migrator/src/staking/checks.rs
@@ -18,7 +18,11 @@
 
 use crate::{
 	staking::{
-		message::{PortableForcing, PortableNominations, PortableStakingLedger, StakingValues},
+		message::{
+			PortableEraRewardPoints, PortableExposurePage, PortableForcing, PortableNominations,
+			PortablePagedExposureMetadata, PortableStakingLedger, PortableUnappliedSlash,
+			PortableValidatorPrefs, StakingValues,
+		},
 		PortableStakingMessage,
 	},
 	types::IntoPortable,
@@ -54,6 +58,16 @@ pub struct RcData {
 	pub validators: Vec<(AccountId32, pallet_staking::ValidatorPrefs)>,
 	pub nominators: Vec<(AccountId32, PortableNominations)>,
 	pub virtual_stakers: Vec<AccountId32>,
+	pub eras_stakers_overview: Vec<(u32, AccountId32, PortablePagedExposureMetadata)>,
+	pub eras_stakers_paged: Vec<((u32, AccountId32, u32), PortableExposurePage)>,
+	pub claimed_rewards: Vec<(u32, AccountId32, Vec<u32>)>,
+	pub eras_validator_prefs: Vec<(u32, AccountId32, PortableValidatorPrefs)>,
+	pub eras_validator_reward: Vec<(u32, u128)>,
+	pub eras_reward_points: Vec<(u32, PortableEraRewardPoints)>,
+	pub eras_total_stake: Vec<(u32, u128)>,
+	pub unapplied_slashes: Vec<(u32, Vec<PortableUnappliedSlash>)>,
+	pub bonded_eras: Vec<(u32, u32)>,
+	pub validator_slash_in_era: Vec<(u32, AccountId32, (Perbill, u128))>,
 }
 
 pub struct StakingMigratedCorrectly<T>(pub core::marker::PhantomData<T>);
@@ -93,6 +107,26 @@ impl<T: crate::Config> crate::types::RcMigrationCheck for StakingMigratedCorrect
 				.map(|(k, v)| (k, v.into_portable()))
 				.collect(),
 			virtual_stakers: pallet_staking::VirtualStakers::<T>::iter_keys().collect(),
+			eras_stakers_overview: pallet_staking::ErasStakersOverview::<T>::iter()
+				.map(|(k1, k2, v)| (k1, k2, v.into_portable()))
+				.collect(),
+			eras_stakers_paged: pallet_staking::ErasStakersPaged::<T>::iter()
+				.map(|(k, v)| (k, v.into_portable()))
+				.collect(),
+			claimed_rewards: pallet_staking::ClaimedRewards::<T>::iter().collect(),
+			eras_validator_prefs: pallet_staking::ErasValidatorPrefs::<T>::iter()
+				.map(|(k1, k2, v)| (k1, k2, v.into_portable()))
+				.collect(),
+			eras_validator_reward: pallet_staking::ErasValidatorReward::<T>::iter().collect(),
+			eras_reward_points: pallet_staking::ErasRewardPoints::<T>::iter()
+				.map(|(k, v)| (k, v.into_portable()))
+				.collect(),
+			eras_total_stake: pallet_staking::ErasTotalStake::<T>::iter().collect(),
+			unapplied_slashes: pallet_staking::UnappliedSlashes::<T>::iter()
+				.map(|(k, v)| (k, v.into_iter().map(IntoPortable::into_portable).collect()))
+				.collect(),
+			bonded_eras: pallet_staking::BondedEras::<T>::get(),
+			validator_slash_in_era: pallet_staking::ValidatorSlashInEra::<T>::iter().collect(),
 		}
 	}
 

--- a/pallets/rc-migrator/src/staking/checks.rs
+++ b/pallets/rc-migrator/src/staking/checks.rs
@@ -1,0 +1,100 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Checks that the staking migration succeeded.
+
+use crate::{
+	staking::{
+		message::{PortableForcing, PortableNominations, PortableStakingLedger, StakingValues},
+		PortableStakingMessage,
+	},
+	types::IntoPortable,
+	BalanceOf,
+};
+use pallet_staking::Pallet as Staking;
+use sp_runtime::{AccountId32, Perbill, Percent};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RcData {
+	// Storage Values
+	pub validator_count: u32,
+	pub min_validator_count: u32,
+	pub min_nominator_bond: u128,
+	pub min_validator_bond: u128,
+	pub min_active_stake: u128,
+	pub min_commission: Perbill,
+	pub max_validators_count: Option<u32>,
+	pub max_nominators_count: Option<u32>,
+	pub current_era: Option<u32>,
+	pub active_era: Option<pallet_staking::ActiveEraInfo>,
+	pub force_era: pallet_staking::Forcing,
+	pub max_staked_rewards: Option<Percent>,
+	pub slash_reward_fraction: Perbill,
+	pub canceled_slash_payout: u128,
+	pub current_planned_session: u32,
+	pub chill_threshold: Option<Percent>,
+	// Storage Maps
+	pub invulnerables: Vec<AccountId32>,
+	pub bonded: Vec<(AccountId32, AccountId32)>,
+	pub ledger: Vec<(AccountId32, PortableStakingLedger)>,
+	pub payee: Vec<(AccountId32, pallet_staking::RewardDestination<AccountId32>)>,
+	pub validators: Vec<(AccountId32, pallet_staking::ValidatorPrefs)>,
+	pub nominators: Vec<(AccountId32, PortableNominations)>,
+	pub virtual_stakers: Vec<AccountId32>,
+}
+
+pub struct StakingMigratedCorrectly<T>(pub core::marker::PhantomData<T>);
+
+impl<T: crate::Config> crate::types::RcMigrationCheck for StakingMigratedCorrectly<T> {
+	type RcPrePayload = RcData;
+
+	fn pre_check() -> Self::RcPrePayload {
+		RcData {
+			// Storage Values
+			validator_count: pallet_staking::ValidatorCount::<T>::get(),
+			min_validator_count: pallet_staking::MinimumValidatorCount::<T>::get(),
+			min_nominator_bond: pallet_staking::MinNominatorBond::<T>::get(),
+			min_validator_bond: pallet_staking::MinValidatorBond::<T>::get(),
+			min_active_stake: pallet_staking::MinimumActiveStake::<T>::get(),
+			min_commission: pallet_staking::MinCommission::<T>::get(),
+			max_validators_count: pallet_staking::MaxValidatorsCount::<T>::get(),
+			max_nominators_count: pallet_staking::MaxNominatorsCount::<T>::get(),
+			current_era: pallet_staking::CurrentEra::<T>::get(),
+			active_era: pallet_staking::ActiveEra::<T>::get(),
+			force_era: pallet_staking::ForceEra::<T>::get(),
+			max_staked_rewards: pallet_staking::MaxStakedRewards::<T>::get(),
+			slash_reward_fraction: pallet_staking::SlashRewardFraction::<T>::get(),
+			canceled_slash_payout: pallet_staking::CanceledSlashPayout::<T>::get(),
+			current_planned_session: pallet_staking::CurrentPlannedSession::<T>::get(),
+			chill_threshold: pallet_staking::ChillThreshold::<T>::get(),
+
+			// Storage Maps
+			invulnerables: pallet_staking::Invulnerables::<T>::get(),
+			bonded: pallet_staking::Bonded::<T>::iter().collect(),
+			ledger: pallet_staking::Ledger::<T>::iter()
+				.map(|(k, v)| (k, v.into_portable()))
+				.collect(),
+			payee: pallet_staking::Payee::<T>::iter().collect(),
+			validators: pallet_staking::Validators::<T>::iter().collect(),
+			nominators: pallet_staking::Nominators::<T>::iter()
+				.map(|(k, v)| (k, v.into_portable()))
+				.collect(),
+			virtual_stakers: pallet_staking::VirtualStakers::<T>::iter_keys().collect(),
+		}
+	}
+
+	fn post_check(rc_pre_payload: Self::RcPrePayload) {}
+}

--- a/pallets/rc-migrator/src/staking/message.rs
+++ b/pallets/rc-migrator/src/staking/message.rs
@@ -675,7 +675,15 @@ impl Into<sp_staking::IndividualExposure<AccountId32, u128>> for PortableIndivid
 }
 
 #[derive(
-	PartialEq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen, DecodeWithMemTracking,
+	PartialEq,
+	Eq,
+	Clone,
+	Encode,
+	Decode,
+	RuntimeDebug,
+	TypeInfo,
+	MaxEncodedLen,
+	DecodeWithMemTracking,
 )]
 pub struct PortableEraRewardPoints {
 	pub total: u32,

--- a/pallets/rc-migrator/src/staking/mod.rs
+++ b/pallets/rc-migrator/src/staking/mod.rs
@@ -20,11 +20,8 @@ pub mod fast_unstake;
 pub mod nom_pools;
 pub mod nom_pools_alias;
 
-#[cfg(feature = "ahm-staking-migration")]
 pub mod message;
-#[cfg(feature = "ahm-staking-migration")]
 pub mod staking;
-#[cfg(feature = "ahm-staking-migration")]
 pub use staking::*;
 
 // Copy&paster of Convert trait so that we can implement it here on external types

--- a/pallets/rc-migrator/src/staking/mod.rs
+++ b/pallets/rc-migrator/src/staking/mod.rs
@@ -15,11 +15,15 @@
 // along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
 
 pub mod bags_list;
+#[cfg(feature = "std")]
+pub mod checks;
 pub mod delegated_staking;
 pub mod fast_unstake;
+pub mod message;
 pub mod nom_pools;
 pub mod nom_pools_alias;
-
-pub mod message;
 pub mod staking;
+
+#[cfg(feature = "std")]
+pub use checks::*;
 pub use staking::*;

--- a/pallets/rc-migrator/src/staking/mod.rs
+++ b/pallets/rc-migrator/src/staking/mod.rs
@@ -23,10 +23,3 @@ pub mod nom_pools_alias;
 pub mod message;
 pub mod staking;
 pub use staking::*;
-
-// Copy&paster of Convert trait so that we can implement it here on external types
-/// Infallible conversion trait. Generic over both source and destination types.
-pub trait IntoAh<A, B> {
-	/// Make conversion.
-	fn intoAh(a: A) -> B;
-}

--- a/pallets/rc-migrator/src/staking/nom_pools.md
+++ b/pallets/rc-migrator/src/staking/nom_pools.md
@@ -15,6 +15,7 @@ to Relay Chain Block number provider.
 ## User Impact
 
 Impact here is negligible and only for pool operators - not members:
+
 - Pool commission change rate (measured in blocks) could be decreased by one block.
 - Pool operators may be able to change the commission rate one block later than anticipated. This is
   due to the nature or translating blocks of two different blockchains which does not yield

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -116,7 +116,7 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 					messages.push(PortableStakingMessage::Invulnerables(invulnerables));
 					StakingStage::Bonded(None)
 				},
-				/*StakingStage::Bonded(who) => {
+				StakingStage::Bonded(who) => {
 					let mut iter = if let Some(who) = who {
 						pallet_staking::Bonded::<T>::iter_from_key(who)
 					} else {
@@ -147,7 +147,7 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 							pallet_staking::Ledger::<T>::remove(&controller);
 							messages.push(PortableStakingMessage::Ledger {
 								controller: controller.clone(),
-								ledger,
+								ledger: ledger.into_portable(),
 							});
 							StakingStage::Ledger(Some(controller))
 						},
@@ -165,7 +165,7 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 						Some((stash, payment)) => {
 							pallet_staking::Payee::<T>::remove(&stash);
 							messages
-								.push(PortableStakingMessage::Payee { stash: stash.clone(), payment });
+								.push(PortableStakingMessage::Payee { stash: stash.clone(), payment: payment.into_portable() });
 							StakingStage::Payee(Some(stash))
 						},
 						None => StakingStage::Validators(None),
@@ -206,7 +206,7 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 							pallet_staking::Nominators::<T>::remove(&stash);
 							messages.push(PortableStakingMessage::Nominators {
 								stash: stash.clone(),
-								nominations,
+								nominations: nominations.into_portable(),
 							});
 							StakingStage::Nominators(Some(stash))
 						},
@@ -249,14 +249,14 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 							messages.push(PortableStakingMessage::ErasStakersOverview {
 								era,
 								validator: validator.clone(),
-								exposure,
+								exposure: exposure.into_portable(),
 							});
 							StakingStage::ErasStakersOverview(Some((era, validator)))
 						},
 						None => StakingStage::ErasStakersPaged(None),
 					}
 				},
-				StakingStage::ErasStakersPaged(progress) => {
+				/*StakingStage::ErasStakersPaged(progress) => {
 					let mut iter = if let Some(progress) = progress {
 						pallet_staking::ErasStakersPaged::<T>::iter_from(
 							pallet_staking::ErasStakersPaged::<T>::hashed_key_for(progress),

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -438,7 +438,7 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 					match iter.next() {
 						Some((era, validator, slash)) => {
 							pallet_staking::NominatorSlashInEra::<T>::remove(&era, &validator);
-							// Not migrated. TODO @kianenigma review
+							// Not migrated.
 							StakingStage::NominatorSlashInEra(Some((era, validator)))
 						},
 						None => StakingStage::SlashingSpans(None),
@@ -450,7 +450,7 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 					match iter.next() {
 						Some((account, spans)) => {
 							pallet_staking::SlashingSpans::<T>::remove(&account);
-							// Not migrated. TODO @kianenigma review
+							// Not migrated.
 							StakingStage::SlashingSpans(Some(account))
 						},
 						None => StakingStage::SpanSlash(None),
@@ -462,7 +462,7 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 					match iter.next() {
 						Some(((account, span), slash)) => {
 							pallet_staking::SpanSlash::<T>::remove((&account, &span));
-							// Not migrated. TODO @kianenigma review
+							// Not migrated.
 							StakingStage::SpanSlash(Some((account, span)))
 						},
 						None => StakingStage::Finished,

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -17,7 +17,7 @@
 //! Pallet staking migration.
 
 pub use crate::staking::message::PortableStakingMessage;
-use crate::{staking::IntoAh, types::DefensiveTruncateInto, *};
+use crate::{types::DefensiveTruncateInto, *};
 use codec::{EncodeLike, FullCodec, FullEncode, HasCompact};
 use core::fmt::Debug;
 pub use frame_election_provider_support::PageIndex;

--- a/pallets/rc-migrator/src/treasury.md
+++ b/pallets/rc-migrator/src/treasury.md
@@ -23,6 +23,7 @@ and this account will be used for all future spends.
 
 The `Beneficiary` parameter of the spend call has changed from `xcm::Location` to two dimensional
 type:
+
 ``` rust
 struct LocatableBeneficiary {
     // Deposit location.

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -67,11 +67,18 @@ impl<T, U: DefensiveTruncateFrom<T>> DefensiveTruncateInto<U> for T {
 }
 
 /// Translate and truncate the elements of a bounded vector defensively.
-pub fn defensive_vector_translate<V: IntoPortable, As: Get<u32>, Bs: Get<u32>>(vec: BoundedVec<V, As>) -> BoundedVec<V::Portable, Bs> {
-	vec.into_iter().map(|e| e.into_portable()).collect::<Vec<_>>().defensive_truncate_into()
+pub fn defensive_vector_translate<V: IntoPortable, As: Get<u32>, Bs: Get<u32>>(
+	vec: BoundedVec<V, As>,
+) -> BoundedVec<V::Portable, Bs> {
+	vec.into_iter()
+		.map(|e| e.into_portable())
+		.collect::<Vec<_>>()
+		.defensive_truncate_into()
 }
 
-pub fn defensive_vector_truncate<V, As: Get<u32>, Bs: Get<u32>>(vec: BoundedVec<V, As>) -> BoundedVec<V, Bs> {
+pub fn defensive_vector_truncate<V, As: Get<u32>, Bs: Get<u32>>(
+	vec: BoundedVec<V, As>,
+) -> BoundedVec<V, Bs> {
 	vec.into_iter().collect::<Vec<_>>().defensive_truncate_into()
 }
 
@@ -161,7 +168,6 @@ pub enum AhMigratorCall<T: Config> {
 		messages: Vec<staking::delegated_staking::RcDelegatedStakingMessageOf<T>>,
 	},
 	#[codec(index = 30)]
-	#[cfg(feature = "ahm-staking-migration")] // Staking migration not yet enabled
 	ReceiveStakingMessages { messages: Vec<staking::PortableStakingMessage> },
 	#[codec(index = 101)]
 	StartMigration,

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -66,22 +66,6 @@ impl<T, U: DefensiveTruncateFrom<T>> DefensiveTruncateInto<U> for T {
 	}
 }
 
-/// Translate and truncate the elements of a bounded vector defensively.
-pub fn defensive_vector_translate<V: IntoPortable, As: Get<u32>, Bs: Get<u32>>(
-	vec: BoundedVec<V, As>,
-) -> BoundedVec<V::Portable, Bs> {
-	vec.into_iter()
-		.map(|e| e.into_portable())
-		.collect::<Vec<_>>()
-		.defensive_truncate_into()
-}
-
-pub fn defensive_vector_truncate<V, As: Get<u32>, Bs: Get<u32>>(
-	vec: BoundedVec<V, As>,
-) -> BoundedVec<V, Bs> {
-	vec.into_iter().collect::<Vec<_>>().defensive_truncate_into()
-}
-
 /// Generate a default instance for benchmarking purposes.
 pub trait BenchmarkingDefault {
 	/// Default for benchmarking purposes only.

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -36,6 +36,8 @@ impl ToPolkadotSs58 for AccountId32 {
 	}
 }
 
+
+
 /// Convert a type into its portable format.
 ///
 /// The portable format is chain-agnostic. The flow the following: Convert RC object to portable
@@ -51,6 +53,18 @@ impl<Id: IntoPortable, Balance> IntoPortable for IdAmount<Id, Balance> {
 
 	fn into_portable(self) -> Self::Portable {
 		IdAmount { id: self.id.into_portable(), amount: self.amount }
+	}
+}
+
+/// Defensively truncate a value and convert it into its bounded form.
+pub trait DefensiveTruncateInto<T> {
+	/// Defensively truncate a value and convert it into its bounded form.
+	fn defensive_truncate_into(self) -> T;
+}
+
+impl<T, U: DefensiveTruncateFrom<T>> DefensiveTruncateInto<U> for T {
+	fn defensive_truncate_into(self) -> U {
+		U::defensive_truncate_from(self)
 	}
 }
 
@@ -141,7 +155,7 @@ pub enum AhMigratorCall<T: Config> {
 	},
 	#[codec(index = 30)]
 	#[cfg(feature = "ahm-staking-migration")] // Staking migration not yet enabled
-	ReceiveStakingMessages { messages: Vec<staking::RcStakingMessageOf<T>> },
+	ReceiveStakingMessages { messages: Vec<staking::PortableStakingMessage> },
 	#[codec(index = 101)]
 	StartMigration,
 	#[codec(index = 110)]

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -36,8 +36,6 @@ impl ToPolkadotSs58 for AccountId32 {
 	}
 }
 
-
-
 /// Convert a type into its portable format.
 ///
 /// The portable format is chain-agnostic. The flow the following: Convert RC object to portable
@@ -66,6 +64,15 @@ impl<T, U: DefensiveTruncateFrom<T>> DefensiveTruncateInto<U> for T {
 	fn defensive_truncate_into(self) -> U {
 		U::defensive_truncate_from(self)
 	}
+}
+
+/// Translate and truncate the elements of a bounded vector defensively.
+pub fn defensive_vector_translate<V: IntoPortable, As: Get<u32>, Bs: Get<u32>>(vec: BoundedVec<V, As>) -> BoundedVec<V::Portable, Bs> {
+	vec.into_iter().map(|e| e.into_portable()).collect::<Vec<_>>().defensive_truncate_into()
+}
+
+pub fn defensive_vector_truncate<V, As: Get<u32>, Bs: Get<u32>>(vec: BoundedVec<V, As>) -> BoundedVec<V, Bs> {
+	vec.into_iter().collect::<Vec<_>>().defensive_truncate_into()
 }
 
 /// Generate a default instance for benchmarking purposes.

--- a/pallets/rc-migrator/src/vesting.md
+++ b/pallets/rc-migrator/src/vesting.md
@@ -25,7 +25,6 @@ The vesting pallet is not using the proper FRAME version tracking; rather, it tr
 the `StorageVersion` value. It does this incorrectly though, with Asset Hub reporting version 0
 instead of 1. We ignore and correct this by writing 1 to the storage.
 
-
 ## User Impact
 
 This affects users that have vesting schedules on the Relay chain or on Asset Hub. There exists a

--- a/pallets/rc-migrator/src/xcm.md
+++ b/pallets/rc-migrator/src/xcm.md
@@ -1,6 +1,7 @@
 # XCM configuration changes for AHM
 
-## TODOs:
+## TODOs
+
 -[ ] TODO: @acatangiu. Post migration we need to switch all system chains XCM transport fees beneficiary from
 `RelayTreasuryLocation` to the new `AssetHubTreasuryLocation`. Does not necessarily need to be done
 _synchronously during AHM_, so let's do it after the migration ends successfully. Besides the

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -133,9 +133,6 @@ substrate-wasm-builder = { workspace = true, optional = true }
 default = ["std"]
 no_std = []
 paseo = [] # For Paseo AHM
-ahm-staking-migration = [
-	"pallet-rc-migrator/ahm-staking-migration"
-]
 
 std = [
 	"pallet-rc-migrator/std",

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -133,6 +133,10 @@ substrate-wasm-builder = { workspace = true, optional = true }
 default = ["std"]
 no_std = []
 paseo = [] # For Paseo AHM
+ahm-staking-migration = [
+	"pallet-rc-migrator/ahm-staking-migration"
+]
+
 std = [
 	"pallet-rc-migrator/std",
 

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -133,7 +133,6 @@ substrate-wasm-builder = { workspace = true, optional = true }
 default = ["std"]
 no_std = []
 paseo = [] # For Paseo AHM
-
 std = [
 	"pallet-rc-migrator/std",
 

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -141,10 +141,6 @@ substrate-wasm-builder = { optional = true, workspace = true }
 [features]
 default = ["std"]
 paseo = [] # For Paseo AHM
-ahm-staking-migration = [
-	"pallet-ah-migrator/ahm-staking-migration",
-	"pallet-rc-migrator/ahm-staking-migration"
-]
 
 runtime-benchmarks = [
 	"assets-common/runtime-benchmarks",

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -141,7 +141,6 @@ substrate-wasm-builder = { optional = true, workspace = true }
 [features]
 default = ["std"]
 paseo = [] # For Paseo AHM
-
 runtime-benchmarks = [
 	"assets-common/runtime-benchmarks",
 	"bp-asset-hub-kusama/runtime-benchmarks",

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -141,6 +141,11 @@ substrate-wasm-builder = { optional = true, workspace = true }
 [features]
 default = ["std"]
 paseo = [] # For Paseo AHM
+ahm-staking-migration = [
+	"pallet-ah-migrator/ahm-staking-migration",
+	"pallet-rc-migrator/ahm-staking-migration"
+]
+
 runtime-benchmarks = [
 	"assets-common/runtime-benchmarks",
 	"bp-asset-hub-kusama/runtime-benchmarks",


### PR DESCRIPTION
Changes:
- Remove `ahm-staking-migration` feature since its not the default
- Migrate `pallet-staking` to `pallet-staking-async`

Translation works by defining a portable type. The RC types are converted to this portable type, sent over to the AssetHub and then translated to AssetHub types there.  
The portable types do not have generics. This makes it easy to translate them because they do not need a T Config or anything.

TODO:
- [ ] Extend tests
- [ ] Benchmarks