### PR TITLE
CI: Fix check changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,11 +25,12 @@ jobs:
     steps:
       - name: Get Changed Files
         id: changed
-        uses: foodee/pr-includes-file-change@master
+        uses: tj-actions/changed-files@v44
         with:
-          paths: ^CHANGELOG.md
+          files: |
+            CHANGELOG.md
       - name: Set error
-        if: steps.changed.outputs.matched != 'true' && !contains(github.event.pull_request.body, '[x] Does not require a CHANGELOG entry')
+        if: steps.changed.outputs.any_changed != 'true' && !contains(github.event.pull_request.body, '[x] Does not require a CHANGELOG entry')
         run: echo "::error::CHANGELOG.md has not been modified. Either modify the file or check the checkbox in the body" && exit 1
 
   # Job required by "confirmChangelogChecksPassed"


### PR DESCRIPTION
The used github action is not available anymore.

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [x] Does not require a CHANGELOG entry
