### PR TITLE
[AHM] Max migrated items per block

### DIFF
--- a/pallets/rc-migrator/src/accounts.rs
+++ b/pallets/rc-migrator/src/accounts.rs
@@ -277,6 +277,15 @@ impl<T: Config> PalletMigration for AccountsMigrator<T> {
 				}
 			}
 
+			if batch.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					batch.len()
+				);
+				break;
+			}
+
 			let Some((who, account_info)) = iter.next() else {
 				maybe_last_key = None;
 				break;

--- a/pallets/rc-migrator/src/asset_rate.rs
+++ b/pallets/rc-migrator/src/asset_rate.rs
@@ -55,8 +55,13 @@ impl<T: Config> PalletMigration for AssetRateMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!(target: LOG_TARGET, "Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/bounties.rs
+++ b/pallets/rc-migrator/src/bounties.rs
@@ -97,8 +97,13 @@ impl<T: Config> PalletMigration for BountiesMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!(target: LOG_TARGET, "Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/child_bounties.rs
+++ b/pallets/rc-migrator/src/child_bounties.rs
@@ -126,8 +126,13 @@ where
 					break;
 				}
 			}
-			if messages.len() > 1_000 {
-				log::warn!(target: LOG_TARGET, "Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/claims.rs
+++ b/pallets/rc-migrator/src/claims.rs
@@ -102,8 +102,13 @@ impl<T: Config> PalletMigration for ClaimsMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!("Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/conviction_voting.rs
+++ b/pallets/rc-migrator/src/conviction_voting.rs
@@ -96,10 +96,16 @@ impl<T: Config> PalletMigration for ConvictionVotingMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!(target: LOG_TARGET, "Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
+
 			made_progress = true;
 
 			last_key = match last_key {

--- a/pallets/rc-migrator/src/crowdloan.rs
+++ b/pallets/rc-migrator/src/crowdloan.rs
@@ -145,8 +145,13 @@ impl<T: Config> PalletMigration for CrowdloanMigrator<T>
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!("Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/indices.rs
+++ b/pallets/rc-migrator/src/indices.rs
@@ -80,8 +80,13 @@ impl<T: Config> PalletMigration for IndicesMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!("Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -126,6 +126,12 @@ pub const LOG_TARGET: &str = "runtime::rc-migrator";
 /// everything is confirmed to work.
 pub const MAX_XCM_SIZE: u32 = 50_000;
 
+/// The maximum number of items that can be migrated in a single block.
+///
+/// This serves as an additional safety limit beyond the weight accounting of both the Relay Chain
+/// and Asset Hub.
+pub const MAX_ITEMS_PER_BLOCK: u32 = 1600;
+
 /// Out of weight Error. Can be converted to a pallet error for convenience.
 pub struct OutOfWeightError;
 

--- a/pallets/rc-migrator/src/multisig.rs
+++ b/pallets/rc-migrator/src/multisig.rs
@@ -135,6 +135,15 @@ impl<T: Config> PalletMigration for MultisigMigrator<T> {
 				}
 			}
 
+			if batch.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					batch.len()
+				);
+				break;
+			}
+
 			let kv = iter.next();
 
 			let Some((k1, k2, multisig)) = kv else {

--- a/pallets/rc-migrator/src/preimage/chunks.rs
+++ b/pallets/rc-migrator/src/preimage/chunks.rs
@@ -168,8 +168,13 @@ impl<T: Config> PalletMigration for PreimageChunkMigrator<T> {
 			// set the offset of the next_key
 			next_key = Some((next_key_inner, last_offset));
 
-			// TODO: @muharem weight tracking
-			if batch.len() >= 10 {
+			const MAX_CHUNKS_PER_BLOCK: u32 = 10;
+			if batch.len() >= MAX_CHUNKS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({}) to migrate per block reached, current batch size: {}",
+					MAX_CHUNKS_PER_BLOCK,
+					batch.len()
+				);
 				break next_key;
 			}
 		};

--- a/pallets/rc-migrator/src/preimage/legacy_request_status.rs
+++ b/pallets/rc-migrator/src/preimage/legacy_request_status.rs
@@ -80,6 +80,15 @@ impl<T: Config> PalletMigration for PreimageLegacyRequestStatusMigrator<T> {
 				}
 			}
 
+			if batch.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					batch.len()
+				);
+				break next_key;
+			}
+
 			let next_key_inner = match next_key {
 				Some(key) => key,
 				None => {

--- a/pallets/rc-migrator/src/preimage/request_status.rs
+++ b/pallets/rc-migrator/src/preimage/request_status.rs
@@ -76,6 +76,15 @@ impl<T: Config> PalletMigration for PreimageRequestStatusMigrator<T> {
 				}
 			}
 
+			if batch.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					batch.len()
+				);
+				break next_key;
+			}
+
 			let next_key_inner = match next_key {
 				Some(key) => key,
 				None => {

--- a/pallets/rc-migrator/src/proxy.rs
+++ b/pallets/rc-migrator/src/proxy.rs
@@ -152,6 +152,15 @@ impl<T: Config> ProxyProxiesMigrator<T> {
 			return Err(OutOfWeightError);
 		}
 
+		if batch.len() > MAX_ITEMS_PER_BLOCK {
+			log::info!(
+				"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+				MAX_ITEMS_PER_BLOCK,
+				batch.len()
+			);
+			return Err(OutOfWeightError);
+		}
+
 		let translated_proxies = proxies
 			.into_iter()
 			.map(|proxy| pallet_proxy::ProxyDefinition {
@@ -209,6 +218,15 @@ impl<T: Config> PalletMigration for ProxyAnnouncementMigrator<T> {
 				} else {
 					break;
 				}
+			}
+
+			if batch.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					batch.len()
+				);
+				break;
 			}
 
 			batch.push(RcProxyAnnouncement { depositor: acc.clone(), deposit });

--- a/pallets/rc-migrator/src/referenda.rs
+++ b/pallets/rc-migrator/src/referenda.rs
@@ -146,6 +146,15 @@ impl<T: Config> ReferendaMigrator<T> {
 				}
 			}
 
+			if batch.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					batch.len()
+				);
+				break last_key;
+			}
+
 			let next_key = match last_key {
 				Some(last_key) => {
 					let Some(next_key) = MetadataOf::<T, ()>::iter_keys_from_key(last_key).next()
@@ -203,6 +212,15 @@ impl<T: Config> ReferendaMigrator<T> {
 				} else {
 					break last_key;
 				}
+			}
+
+			if batch.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					batch.len()
+				);
+				break last_key;
 			}
 
 			let next_key = match last_key {

--- a/pallets/rc-migrator/src/scheduler.rs
+++ b/pallets/rc-migrator/src/scheduler.rs
@@ -174,8 +174,13 @@ impl<T: Config> PalletMigration for SchedulerAgendaMigrator<T> {
 					break last_key;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!(target: LOG_TARGET, "Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break last_key;
 			}
 

--- a/pallets/rc-migrator/src/staking/bags_list.rs
+++ b/pallets/rc-migrator/src/staking/bags_list.rs
@@ -94,8 +94,13 @@ impl<T: Config> PalletMigration for BagsListMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!("Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/staking/delegated_staking.rs
+++ b/pallets/rc-migrator/src/staking/delegated_staking.rs
@@ -89,8 +89,13 @@ impl<T: Config> PalletMigration for DelegatedStakingMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!(target: LOG_TARGET, "Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/staking/fast_unstake.rs
+++ b/pallets/rc-migrator/src/staking/fast_unstake.rs
@@ -132,8 +132,13 @@ impl<T: Config> PalletMigration for FastUnstakeMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!("Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/staking/nom_pools.rs
+++ b/pallets/rc-migrator/src/staking/nom_pools.rs
@@ -165,8 +165,13 @@ impl<T: Config> PalletMigration for NomPoolsMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!("Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/staking/staking.rs
+++ b/pallets/rc-migrator/src/staking/staking.rs
@@ -93,8 +93,12 @@ impl<T: Config> PalletMigration for StakingMigrator<T> {
 				}
 			}
 
-			if messages.len() > 500 {
-				log::warn!("Weight allowed very big batch, stopping");
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/treasury.rs
+++ b/pallets/rc-migrator/src/treasury.rs
@@ -115,8 +115,13 @@ impl<T: Config> PalletMigration for TreasuryMigrator<T> {
 					break;
 				}
 			}
-			if messages.len() > 10_000 {
-				log::warn!(target: LOG_TARGET, "Weight allowed very big batch, stopping");
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
 				break;
 			}
 

--- a/pallets/rc-migrator/src/vesting.rs
+++ b/pallets/rc-migrator/src/vesting.rs
@@ -81,6 +81,16 @@ impl<T: Config> PalletMigration for VestingMigrator<T> {
 					break;
 				}
 			}
+
+			if messages.len() > MAX_ITEMS_PER_BLOCK {
+				log::info!(
+					"Maximum number of items ({:?}) to migrate per block reached, current batch size: {}",
+					MAX_ITEMS_PER_BLOCK,
+					messages.len()
+				);
+				break;
+			}
+
 			let mut iter = match inner_key {
 				Some(who) => pallet_vesting::Vesting::<T>::iter_from_key(who),
 				None => pallet_vesting::Vesting::<T>::iter(),

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1736,7 +1736,7 @@ impl pallet_rc_migrator::Config for Runtime {
 	type RcPostMigrationCalls = ahm_phase1::CallsEnabledAfterMigration;
 	type StakingDelegationReason = ahm_phase1::StakingDelegationReason;
 	type OnDemandPalletId = OnDemandPalletId;
-	type UnprocessedMsgBuffer = ConstU32<5>;
+	type UnprocessedMsgBuffer = ConstU32<8>;
 	type XcmResponseTimeout = XcmResponseTimeout;
 	type MessageQueue = MessageQueue;
 	type AhUmpQueuePriorityPattern = AhUmpQueuePriorityPattern;


### PR DESCRIPTION
Max migrated items per block

- max migrated items per block safety guard for all pallets;
- child bounties extraction on RC respects AH weights;
- max unconfirmed msg set to 8