### PR TITLE
[AHM] Record migration timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10200,7 +10200,6 @@ dependencies = [
  "pallet-ah-ops",
  "pallet-balances",
  "pallet-bounties",
- "pallet-fast-unstake",
  "pallet-indices",
  "pallet-message-queue",
  "pallet-multisig",

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -409,6 +409,20 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type Manager<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
 
+	/// The block number at which the migration began and the pallet's extrinsics were locked.
+	///
+	/// This value is set when entering the `WaitingForAh` stage, i.e., when
+	/// `RcMigrationStage::is_ongoing()` becomes `true`.
+	#[pallet::storage]
+	pub type MigrationStartBlock<T: Config> = StorageValue<_, BlockNumberFor<T>, OptionQuery>;
+
+	/// Block number when migration finished and extrinsics were unlocked.
+	///
+	/// This is set when entering the `MigrationDone` stage hence when
+	/// `RcMigrationStage::is_finished()` becomes `true`.
+	#[pallet::storage]
+	pub type MigrationEndBlock<T: Config> = StorageValue<_, BlockNumberFor<T>, OptionQuery>;
+
 	#[pallet::error]
 	pub enum Error<T> {
 		/// Failed to unreserve deposit.
@@ -1092,6 +1106,7 @@ pub mod pallet {
 					old == MigrationStage::Pending,
 					"Data migration can only enter from Pending"
 				);
+				MigrationStartBlock::<T>::put(frame_system::Pallet::<T>::block_number());
 				Self::deposit_event(Event::AssetHubMigrationStarted);
 			}
 			if new == MigrationStage::MigrationDone {
@@ -1099,6 +1114,7 @@ pub mod pallet {
 					old == MigrationStage::DataMigrationOngoing,
 					"MigrationDone can only enter from DataMigrationOngoing"
 				);
+				MigrationEndBlock::<T>::put(frame_system::Pallet::<T>::block_number());
 				Self::deposit_event(Event::AssetHubMigrationFinished);
 			}
 


### PR DESCRIPTION
Record migration timings.

Closes: https://github.com/paritytech/polkadot-sdk/issues/9292

This PR records the start and end times of the migration in dedicated storage items. The start is defined as the moment when the extrinsics of the migrating pallets are locked; the end is when those locks are released.

The PR also updates the trigger for the `AssetHubMigrationStarted` event - it is now emitted upon transitioning to the `WaitingForAh` state instead of `Starting`. This change ensures the event accurately reflects the point at which the extrinsics become locked.