### PR TITLE
[AHM] Fix migration tests for pallet-preimage

### DIFF
--- a/pallets/ah-migrator/src/referenda.rs
+++ b/pallets/ah-migrator/src/referenda.rs
@@ -612,6 +612,9 @@ impl<T: Config> crate::types::AhMigrationCheck for ReferendaMigrator<T> {
 
 		// Assert storage 'Referenda::ReferendumInfoFor::ah_post::correct'
 		for i in 0..current_ah_referenda.len() {
+			// Notice that referendums_equal method may unrequest the referenda preimage if it was
+			// requested. This should not be a problem since preimage migration tests are run before
+			// referenda migration tests.
 			assert!(
 				referendums_equal::<T>(
 					&current_ah_referenda[i].1,


### PR DESCRIPTION
During migration, some preimages may be unrequested and therefore deleted as a side effect. This PR fixes preimage tests to deal with preimage changes performed during migration.

There is also a fix to the method mapping RC calls to AH calls: we now unrequest preimages migrated to Asset Hub if they were unrequested on the Relay Chain. Without this fix, unrequested preimages from RC became requested on AH.