### PR TITLE
[AHM] Multisig test and storage_alias cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10207,6 +10207,8 @@ dependencies = [
  "pallet-preimage",
  "pallet-proxy",
  "pallet-rc-migrator",
+ "pallet-referenda",
+ "pallet-staking-async",
  "pallet-timestamp",
  "pallet-whitelist",
  "pallet-xcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7979,6 +7979,7 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
+ "system-parachains-common",
 ]
 
 [[package]]

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -56,6 +56,8 @@ pallet-xcm = { workspace = true, default-features = true }
 frame-benchmarking = { workspace = true }
 rand = { workspace = true }
 pallet-preimage = { workspace = true, default-features = true }
+pallet-staking-async = { workspace = true, default-features = true }
+pallet-referenda = { workspace = true, default-features = true }
 
 [features]
 default = ["std"]

--- a/integration-tests/ahm/Cargo.toml
+++ b/integration-tests/ahm/Cargo.toml
@@ -86,6 +86,8 @@ runtime-benchmarks = [
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-proxy/runtime-benchmarks",
 	"pallet-rc-migrator/runtime-benchmarks",
+	"pallet-referenda/runtime-benchmarks",
+	"pallet-staking-async/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-whitelist/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",

--- a/integration-tests/ahm/src/multisig_still_work.rs
+++ b/integration-tests/ahm/src/multisig_still_work.rs
@@ -45,7 +45,6 @@ impl RcMigrationCheck for MultisigStillWork {
 	fn pre_check() -> Self::RcPrePayload {
 		// We generate 100 multisigs consisting of between 1 and 10 signatories.
 		// Just use the first 1000 accs to make the generation a bit faster.
-		// TODO @ggwpez finish
 		let accounts = frame_system::Account::<RelayRuntime>::iter()
 			.take(1000)
 			.map(|(id, _)| id)

--- a/integration-tests/ahm/src/multisig_still_work.rs
+++ b/integration-tests/ahm/src/multisig_still_work.rs
@@ -16,8 +16,14 @@
 
 //! Test that Multisig Account IDs result in the same IDs and they can still dispatch calls.
 
+use frame_support::{
+	dispatch::GetDispatchInfo, hypothetically, pallet_prelude::Weight, traits::Currency,
+};
 use pallet_ah_migrator::types::AhMigrationCheck;
 use pallet_rc_migrator::types::RcMigrationCheck;
+use rand::{prelude::SliceRandom, Rng};
+use sp_core::Get;
+use sp_runtime::{traits::StaticLookup, AccountId32};
 
 type RelayRuntime = polkadot_runtime::Runtime;
 type AssetHubRuntime = asset_hub_polkadot_runtime::Runtime;
@@ -27,7 +33,7 @@ pub struct MultisigStillWork;
 #[derive(Clone)]
 pub struct Multisig<AccountId> {
 	pub signatories: Vec<AccountId>,
-	pub threshold: usize,
+	pub threshold: u16,
 	pub pure: AccountId,
 }
 
@@ -40,22 +46,116 @@ impl RcMigrationCheck for MultisigStillWork {
 		// We generate 100 multisigs consisting of between 1 and 10 signatories.
 		// Just use the first 1000 accs to make the generation a bit faster.
 		// TODO @ggwpez finish
-		let _accounts = frame_system::Account::<RelayRuntime>::iter()
+		let accounts = frame_system::Account::<RelayRuntime>::iter()
 			.take(1000)
-			.map(|(_id, a)| a.data)
+			.map(|(id, _)| id)
 			.collect::<Vec<_>>();
-		let multisigs = Vec::new();
-		//let mut rng = rand::rng();
+		let mut multisigs = Vec::new();
+		let mut rng = rand::thread_rng();
 
 		for _i in 0..100 {
-			//let num_signatories = rng.gen_range(1..=10);
-			//let signatories = TODO @ggwpez
+			// Threshold must be at least 2, otherwise it's not really a multisig and the TX fails.
+			// We can use `as_multi_1` if we really want to test this as well
+			let num_signatories = rng.gen_range(2..=10);
+			// pick num_signatories random accounts
+			let mut signatories =
+				accounts.choose_multiple(&mut rng, num_signatories).cloned().collect::<Vec<_>>();
+			signatories.sort();
+
+			let threshold = rng.gen_range(2..=num_signatories) as u16;
+			let pure =
+				pallet_multisig::Pallet::<RelayRuntime>::multi_account_id(&signatories, threshold);
+			let multisig = Multisig { signatories, threshold, pure };
+
+			// Check that it would work
+			multisig_works::<
+				RelayRuntime,
+				polkadot_runtime::RuntimeCall,
+				polkadot_runtime::RuntimeOrigin,
+			>(&multisig);
+
+			multisigs.push(multisig.clone());
 		}
 
+		log::error!("multisigs num: {:?}", multisigs.len());
 		multisigs
 	}
 
 	fn post_check(_: Self::RcPrePayload) {}
+}
+
+fn fund_account<T: pallet_balances::Config<Balance = u128>>(account: &T::AccountId) {
+	let amount = pure_balance::<T>();
+	let _ = pallet_balances::Pallet::<T>::deposit_creating(&account.clone(), amount);
+}
+
+fn pure_balance<T: pallet_balances::Config<Balance = u128>>() -> u128 {
+	let ed = <T as pallet_balances::Config>::ExistentialDeposit::get();
+	ed * 100_000_000_000u128
+}
+
+fn multisig_works<
+	T: pallet_multisig::Config<RuntimeCall = RuntimeCall>
+		+ pallet_balances::Config<Balance = u128>
+		+ frame_system::Config<AccountId = AccountId32, RuntimeOrigin = RuntimeOrigin>,
+	RuntimeCall: From<pallet_balances::Call<T>> + codec::Encode + GetDispatchInfo,
+	RuntimeOrigin: frame_support::traits::OriginTrait<AccountId = AccountId32>,
+>(
+	multisig: &MultisigOf<T>,
+) {
+	// Have to fund again since the pre_checks cannot modify storage
+	for signatory in multisig.signatories.iter() {
+		fund_account::<AssetHubRuntime>(signatory);
+	}
+	fund_account::<AssetHubRuntime>(&multisig.pure);
+
+	// Send some funds to Alice
+	let ed = <T as pallet_balances::Config>::ExistentialDeposit::get();
+	let value = ed * 10;
+	let alice = AccountId32::from([1u8; 32]);
+	let call: RuntimeCall = pallet_balances::Call::transfer_allow_death {
+		dest: <<T as frame_system::Config>::Lookup as StaticLookup>::unlookup(alice.clone()),
+		value,
+	}
+	.into();
+	let call_hash = call.using_encoded(&sp_core::hashing::blake2_256);
+	let call_weight = call.get_dispatch_info().call_weight;
+
+	// All other signatories approve
+	let timepoint = pallet_multisig::Pallet::<T>::timepoint();
+	for (i, signatory) in multisig.signatories[1..]
+		.iter()
+		.take(multisig.threshold as usize - 1)
+		.enumerate()
+	{
+		let other_signatories = multisig
+			.signatories
+			.iter()
+			.cloned()
+			.filter(|s| s != signatory)
+			.collect::<Vec<_>>();
+		let timepoint = if i == 0 { None } else { Some(timepoint) };
+
+		pallet_multisig::Pallet::<T>::approve_as_multi(
+			RuntimeOrigin::signed(signatory.clone()),
+			multisig.threshold,
+			other_signatories,
+			timepoint,
+			call_hash,
+			Weight::zero(),
+		)
+		.unwrap();
+	}
+	// Last one executes
+	pallet_multisig::Pallet::<T>::as_multi(
+		RuntimeOrigin::signed(multisig.signatories[0].clone()),
+		multisig.threshold,
+		multisig.signatories[1..].to_vec(),
+		Some(timepoint),
+		Box::new(call),
+		call_weight,
+	)
+	.unwrap();
 }
 
 impl AhMigrationCheck for MultisigStillWork {
@@ -63,5 +163,20 @@ impl AhMigrationCheck for MultisigStillWork {
 	type AhPrePayload = ();
 
 	fn pre_check(_: Self::RcPrePayload) -> Self::AhPrePayload {}
-	fn post_check(_rc_pre: Self::RcPrePayload, _: Self::AhPrePayload) {}
+	fn post_check(multisigs: Self::RcPrePayload, _: Self::AhPrePayload) {
+		for multisig in multisigs {
+			let ah_multisig = pallet_multisig::Pallet::<AssetHubRuntime>::multi_account_id(
+				&multisig.signatories,
+				multisig.threshold,
+			);
+			// sanity check
+			assert_eq!(multisig.pure, ah_multisig, "multisig pure account id should be the same");
+
+			multisig_works::<
+				AssetHubRuntime,
+				asset_hub_polkadot_runtime::RuntimeCall,
+				asset_hub_polkadot_runtime::RuntimeOrigin,
+			>(&multisig);
+		}
+	}
 }

--- a/integration-tests/ahm/src/proxy/basic_still_works.rs
+++ b/integration-tests/ahm/src/proxy/basic_still_works.rs
@@ -25,13 +25,19 @@
 
 use super::Permission;
 
-use frame_support::{pallet_prelude::*, traits::Currency};
-use frame_system::pallet_prelude::*;
+use frame_support::{
+	pallet_prelude::*,
+	traits::{schedule::DispatchTime, Currency, StorePreimage},
+};
+use frame_system::{pallet_prelude::*, RawOrigin};
 use pallet_ah_migrator::types::AhMigrationCheck;
 use pallet_rc_migrator::types::{RcMigrationCheck, ToPolkadotSs58};
+use pallet_staking_async::RewardDestination;
 use sp_runtime::{
 	traits::{Dispatchable, TryConvert},
 	AccountId32,
+	DispatchError::Module,
+	ModuleError,
 };
 use std::{collections::BTreeMap, str::FromStr};
 
@@ -162,7 +168,6 @@ impl ProxyBasicWorks {
 		}
 
 		let allowed_transfer = permissions.contains(&Permission::Any);
-
 		if allowed_transfer {
 			assert!(Self::can_transfer(delegatee, delegator, true), "`Any` can transfer");
 		} else {
@@ -170,7 +175,7 @@ impl ProxyBasicWorks {
 		}
 
 		let allowed_governance = permissions.contains(&Permission::Any) ||
-			permissions.contains(&Permission::NonTransfer) ||
+			// NonTransfer is not allowed to do governance
 			permissions.contains(&Permission::Governance);
 		if allowed_governance {
 			assert!(
@@ -184,12 +189,24 @@ impl ProxyBasicWorks {
 			);
 		}
 
-		// TODO: @ggwpez add staking etc
+		let allowed_staking = permissions.contains(&Permission::Any) ||
+			permissions.contains(&Permission::NonTransfer) ||
+			permissions.contains(&Permission::Staking);
+		if allowed_staking {
+			assert!(Self::can_stake(delegatee, delegator, true), "`Any` or `Staking` can stake");
+		} else {
+			assert!(
+				!Self::can_stake(delegatee, delegator, false),
+				"Only `Any` or `Staking` can stake"
+			);
+		}
 
 		// Alice cannot transfer
 		assert!(!Self::can_transfer(&alice, delegator, false), "Alice cannot transfer");
 		// Alice cannot do governance
 		assert!(!Self::can_governance(&alice, delegator, false), "Alice cannot do governance");
+		// Alice cannot stake
+		assert!(!Self::can_stake(&alice, delegator, false), "Alice cannot stake");
 	}
 
 	/// Check that the `delegatee` can transfer balances on behalf of the `delegator`.
@@ -235,8 +252,17 @@ impl ProxyBasicWorks {
 			Self::fund_accounts(delegatee, delegator);
 
 			let value = <AssetHubRuntime as pallet_bounties::Config>::BountyValueMinimum::get() * 2;
-			let call: asset_hub_polkadot_runtime::RuntimeCall =
+			let proposal_call =
 				pallet_bounties::Call::propose_bounty { value, description: vec![] }.into();
+			let proposal =
+				<pallet_preimage::Pallet<AssetHubRuntime> as StorePreimage>::bound(proposal_call)
+					.unwrap();
+			let call: asset_hub_polkadot_runtime::RuntimeCall = pallet_referenda::Call::submit {
+				proposal_origin: Box::new(RawOrigin::Root.into()),
+				proposal: proposal.into(),
+				enactment_moment: DispatchTime::At(0),
+			}
+			.into();
 
 			let proxy_call: asset_hub_polkadot_runtime::RuntimeCall = pallet_proxy::Call::proxy {
 				real: delegator.clone().into(),
@@ -258,7 +284,48 @@ impl ProxyBasicWorks {
 			let _ = proxy_call
 				.dispatch(asset_hub_polkadot_runtime::RuntimeOrigin::signed(delegatee.clone()));
 
-			Self::find_bounty_event()
+			Self::find_referenda_submitted_event()
+		})
+	}
+
+	/// Check that the `delegatee` can do staking on behalf of the `delegator`.
+	///
+	/// Uses the `bond` call
+	fn can_stake(delegatee: &AccountId32, delegator: &AccountId32, hint: bool) -> bool {
+		frame_support::hypothetically!({
+			// Migration should have finished
+			assert!(
+				pallet_ah_migrator::AhMigrationStage::<AssetHubRuntime>::get() ==
+					pallet_ah_migrator::MigrationStage::MigrationDone,
+				"Migration should have finished"
+			);
+			Self::fund_accounts(delegatee, delegator);
+
+			let call: asset_hub_polkadot_runtime::RuntimeCall =
+				pallet_staking_async::Call::set_payee { payee: RewardDestination::Staked }.into();
+
+			// The proxy pallet is stupid and does not work when there are multiple delegations for
+			// the same account. So we need to force and try which it is...
+			frame_system::Pallet::<AssetHubRuntime>::reset_events();
+			for force_proxy_type in [
+				None,
+				Some(asset_hub_polkadot_runtime::ProxyType::Staking),
+				Some(asset_hub_polkadot_runtime::ProxyType::Any),
+				Some(asset_hub_polkadot_runtime::ProxyType::NonTransfer),
+			] {
+				let proxy_call: asset_hub_polkadot_runtime::RuntimeCall =
+					pallet_proxy::Call::proxy {
+						real: delegator.clone().into(),
+						force_proxy_type,
+						call: Box::new(call.clone()),
+					}
+					.into();
+
+				let _ = proxy_call
+					.dispatch(asset_hub_polkadot_runtime::RuntimeOrigin::signed(delegatee.clone()));
+			}
+
+			Self::find_proxy_executed_event()
 		})
 	}
 
@@ -295,14 +362,37 @@ impl ProxyBasicWorks {
 		false
 	}
 
-	/// Check if there is a `BountyProposed` event.
-	fn find_bounty_event() -> bool {
+	/// Check if there is a `ReferendaSubmitted` event.
+	fn find_referenda_submitted_event() -> bool {
 		for event in frame_system::Pallet::<AssetHubRuntime>::events() {
-			if let asset_hub_polkadot_runtime::RuntimeEvent::Bounties(
-				pallet_bounties::Event::BountyProposed { .. },
+			if let asset_hub_polkadot_runtime::RuntimeEvent::Referenda(
+				pallet_referenda::Event::Submitted { .. },
 			) = event.event
 			{
 				return true
+			}
+		}
+
+		false
+	}
+
+	/// Check that the proxy call was executed.
+	///
+	/// Some operations of a pallet do not emit an event themselves so we rely on the Proxy pallet.
+	fn find_proxy_executed_event() -> bool {
+		for event in frame_system::Pallet::<AssetHubRuntime>::events() {
+			match event.event {
+				asset_hub_polkadot_runtime::RuntimeEvent::Proxy(
+					pallet_proxy::Event::ProxyExecuted { result: Ok(()) },
+				) => return true,
+				// Pallet 89 is the staking pallet, if it fails in there then that means that the
+				// proxy already succeeded.
+				asset_hub_polkadot_runtime::RuntimeEvent::Proxy(
+					pallet_proxy::Event::ProxyExecuted {
+						result: Err(Module(ModuleError { index: 89, .. })),
+					},
+				) => return true,
+				_ => (),
 			}
 		}
 

--- a/integration-tests/ahm/src/proxy/mod.rs
+++ b/integration-tests/ahm/src/proxy/mod.rs
@@ -82,8 +82,8 @@ impl TryConvert<asset_hub_polkadot_runtime::ProxyType, Permission> for Permissio
 			ProxyType::Governance => Permission::Governance,
 			ProxyType::NominationPools => Permission::NominationPools,
 			ProxyType::NonTransfer => Permission::NonTransfer,
-			ProxyType::OldAuction => Permission::Old,
-			ProxyType::OldParaRegistration => Permission::Old,
+			ProxyType::Auction => Permission::Old,
+			ProxyType::ParaRegistration => Permission::Old,
 			ProxyType::Staking => Permission::Staking,
 		})
 	}

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -60,6 +60,7 @@ xcm = { workspace = true }
 xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 pallet-ah-ops = { workspace = true }
+system-parachains-common = { workspace = true }
 
 # [dev-dependencies]
 # asset-hub-polkadot-runtime = { workspace = true, default-features = true }

--- a/pallets/ah-migrator/Cargo.toml
+++ b/pallets/ah-migrator/Cargo.toml
@@ -117,6 +117,7 @@ std = [
 	"sp-runtime/std",
 	"sp-staking/std",
 	"sp-std/std",
+	"system-parachains-common/std",
 	"xcm-builder/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
@@ -163,6 +164,7 @@ runtime-benchmarks = [
 	"runtime-parachains/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"sp-staking/runtime-benchmarks",
+	"system-parachains-common/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm/runtime-benchmarks",
@@ -199,4 +201,5 @@ try-runtime = [
 	"polkadot-runtime-common/try-runtime",
 	"runtime-parachains/try-runtime",
 	"sp-runtime/try-runtime",
+	"system-parachains-common/try-runtime",
 ]

--- a/pallets/ah-migrator/src/benchmarking.rs
+++ b/pallets/ah-migrator/src/benchmarking.rs
@@ -46,11 +46,10 @@ use pallet_rc_migrator::{
 		message::PortableUnappliedSlash,
 		nom_pools_alias::{SubPools, UnbondPool},
 	},
-	treasury::{alias::SpendStatus, PortableTreasuryMessage},
+	treasury::{PortablePaymentState, PortableSpendStatus, PortableTreasuryMessage},
 	types::{BenchmarkingDefault, DefensiveTruncateInto},
 };
 use pallet_referenda::{Deposit, ReferendumInfo, ReferendumStatus, TallyOf, TracksInfo};
-use pallet_treasury::PaymentState;
 use polkadot_runtime_common::claims::EthereumAddress;
 use scheduler::RcScheduledOf;
 use sp_runtime::traits::Hash;
@@ -723,10 +722,10 @@ pub mod benchmarks {
 
 	#[benchmark]
 	fn receive_treasury_messages(n: Linear<1, 255>) {
-		let create_treasury = |n: u8| -> RcTreasuryMessageOf<T> {
+		let create_treasury = |n: u8| -> PortableTreasuryMessage {
 			PortableTreasuryMessage::Spends {
 				id: n.into(),
-				status: SpendStatus {
+				status: PortableSpendStatus {
 					asset_kind: VersionedLocatableAsset::V4 {
 						location: Location::new(0, [xcm::v4::Junction::Parachain(1000)]),
 						asset_id: Location::new(
@@ -745,7 +744,7 @@ pub mod benchmarks {
 					)),
 					valid_from: n.into(),
 					expire_at: n.into(),
-					status: PaymentState::Pending,
+					status: PortablePaymentState::Pending,
 				},
 			}
 		};

--- a/pallets/ah-migrator/src/benchmarking.rs
+++ b/pallets/ah-migrator/src/benchmarking.rs
@@ -46,7 +46,7 @@ use pallet_rc_migrator::{
 		message::PortableUnappliedSlash,
 		nom_pools_alias::{SubPools, UnbondPool},
 	},
-	treasury::{alias::SpendStatus, RcTreasuryMessage},
+	treasury::{alias::SpendStatus, PortableTreasuryMessage},
 	types::{BenchmarkingDefault, DefensiveTruncateInto},
 };
 use pallet_referenda::{Deposit, ReferendumInfo, ReferendumStatus, TallyOf, TracksInfo};
@@ -724,7 +724,7 @@ pub mod benchmarks {
 	#[benchmark]
 	fn receive_treasury_messages(n: Linear<1, 255>) {
 		let create_treasury = |n: u8| -> RcTreasuryMessageOf<T> {
-			RcTreasuryMessage::Spends {
+			PortableTreasuryMessage::Spends {
 				id: n.into(),
 				status: SpendStatus {
 					asset_kind: VersionedLocatableAsset::V4 {

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -83,7 +83,7 @@ use pallet_balances::{AccountData, Reasons as LockReasons};
 use pallet_rc_migrator::{
 	bounties::RcBountiesMessageOf, child_bounties::PortableChildBountiesMessage,
 	claims::RcClaimsMessageOf, crowdloan::RcCrowdloanMessageOf, staking::PortableStakingMessage,
-	treasury::RcTreasuryMessage, types::MigrationStatus,
+	treasury::PortableTreasuryMessage, types::MigrationStatus,
 };
 
 use cumulus_primitives_core::AggregateMessageOrigin;
@@ -126,7 +126,7 @@ type RcAccountFor<T> = RcAccount<
 	<T as Config>::PortableHoldReason,
 	<T as Config>::PortableFreezeReason,
 >;
-pub type RcTreasuryMessageOf<T> = RcTreasuryMessage<
+pub type RcTreasuryMessageOf<T> = PortableTreasuryMessage<
 	<T as frame_system::Config>::AccountId,
 	pallet_treasury::BalanceOf<T, ()>,
 	pallet_treasury::AssetBalanceOf<T, ()>,

--- a/pallets/ah-migrator/src/lib.rs
+++ b/pallets/ah-migrator/src/lib.rs
@@ -85,6 +85,7 @@ use pallet_rc_migrator::{
 	claims::RcClaimsMessageOf, crowdloan::RcCrowdloanMessageOf, staking::PortableStakingMessage,
 	treasury::PortableTreasuryMessage, types::MigrationStatus,
 };
+use system_parachains_common::pay::VersionedLocatableAccount;
 
 use cumulus_primitives_core::AggregateMessageOrigin;
 use frame_support::traits::EnqueueMessage;
@@ -125,16 +126,6 @@ type RcAccountFor<T> = RcAccount<
 	<T as pallet_balances::Config>::Balance,
 	<T as Config>::PortableHoldReason,
 	<T as Config>::PortableFreezeReason,
->;
-pub type RcTreasuryMessageOf<T> = PortableTreasuryMessage<
-	<T as frame_system::Config>::AccountId,
-	pallet_treasury::BalanceOf<T, ()>,
-	pallet_treasury::AssetBalanceOf<T, ()>,
-	BlockNumberFor<T>,
-	VersionedLocatableAsset,
-	VersionedLocation,
-	<<T as pallet_treasury::Config>::Paymaster as Pay>::Id,
-	<<T as pallet_treasury::Config>::BlockNumberProvider as BlockNumberProvider>::BlockNumber,
 >;
 
 #[derive(
@@ -272,6 +263,9 @@ pub mod pallet {
 		+ pallet_treasury::Config<
 			Currency = pallet_balances::Pallet<Self>,
 			BlockNumberProvider = Self::TreasuryBlockNumberProvider,
+			Paymaster = Self::TreasuryPaymaster,
+			AssetKind = VersionedLocatableAsset,
+			Beneficiary = VersionedLocatableAccount,
 		> + pallet_delegated_staking::Config<Currency = pallet_balances::Pallet<Self>>
 		+ pallet_staking_async::Config<CurrencyBalance = u128>
 	{
@@ -319,6 +313,12 @@ pub mod pallet {
 		/// code since they all depend on the treasury provided block number. The compiler checks
 		/// that this is configured correctly.
 		type TreasuryBlockNumberProvider: BlockNumberProvider<BlockNumber = u32>;
+		type TreasuryPaymaster: Pay<
+			Id = u64,
+			Balance = u128,
+			Beneficiary = VersionedLocatableAccount,
+			AssetKind = VersionedLocatableAsset,
+		>;
 		/// Some part of the Relay Chain origins used in Governance.
 		///
 		/// Additionally requires the `Default` implementation for the benchmarking mocks.
@@ -866,7 +866,7 @@ pub mod pallet {
 		#[pallet::weight(T::AhWeightInfo::receive_treasury_messages(messages.len() as u32))]
 		pub fn receive_treasury_messages(
 			origin: OriginFor<T>,
-			messages: Vec<RcTreasuryMessageOf<T>>,
+			messages: Vec<PortableTreasuryMessage>,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -87,6 +87,7 @@ use polkadot_parachain_primitives::primitives::Id as ParaId;
 use polkadot_runtime_common::{
 	claims as pallet_claims, crowdloan as pallet_crowdloan, paras_registrar, slots as pallet_slots,
 };
+use polkadot_runtime_common::impls::VersionedLocatableAsset;
 use preimage::{
 	PreimageChunkMigrator, PreimageLegacyRequestStatusMigrator, PreimageRequestStatusMigrator,
 };
@@ -469,6 +470,9 @@ pub mod pallet {
 		+ pallet_treasury::Config<
 			Currency = pallet_balances::Pallet<Self>,
 			BlockNumberProvider = Self::TreasuryBlockNumberProvider,
+			Paymaster = Self::TreasuryPaymaster,
+			AssetKind = VersionedLocatableAsset,
+			Beneficiary = VersionedLocation,
 		> + pallet_delegated_staking::Config<Currency = pallet_balances::Pallet<Self>>
 		+ pallet_xcm::Config
 		+ pallet_staking_async_ah_client::Config
@@ -489,6 +493,7 @@ pub mod pallet {
 		/// code since they all depend on the treasury provided block number. The compiler checks
 		/// that this is configured correctly.
 		type TreasuryBlockNumberProvider: BlockNumberProvider<BlockNumber = u32>;
+		type TreasuryPaymaster: Pay<Id = u64, Balance = u128, Beneficiary = VersionedLocation, AssetKind = VersionedLocatableAsset>;
 
 		/// The runtime freeze reasons.
 		type RuntimeFreezeReason: Parameter

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -85,9 +85,9 @@ use pallet_balances::AccountData;
 use pallet_message_queue::ForceSetHead;
 use polkadot_parachain_primitives::primitives::Id as ParaId;
 use polkadot_runtime_common::{
-	claims as pallet_claims, crowdloan as pallet_crowdloan, paras_registrar, slots as pallet_slots,
+	claims as pallet_claims, crowdloan as pallet_crowdloan, impls::VersionedLocatableAsset,
+	paras_registrar, slots as pallet_slots,
 };
-use polkadot_runtime_common::impls::VersionedLocatableAsset;
 use preimage::{
 	PreimageChunkMigrator, PreimageLegacyRequestStatusMigrator, PreimageRequestStatusMigrator,
 };
@@ -493,7 +493,12 @@ pub mod pallet {
 		/// code since they all depend on the treasury provided block number. The compiler checks
 		/// that this is configured correctly.
 		type TreasuryBlockNumberProvider: BlockNumberProvider<BlockNumber = u32>;
-		type TreasuryPaymaster: Pay<Id = u64, Balance = u128, Beneficiary = VersionedLocation, AssetKind = VersionedLocatableAsset>;
+		type TreasuryPaymaster: Pay<
+			Id = u64,
+			Balance = u128,
+			Beneficiary = VersionedLocation,
+			AssetKind = VersionedLocatableAsset,
+		>;
 
 		/// The runtime freeze reasons.
 		type RuntimeFreezeReason: Parameter

--- a/pallets/rc-migrator/src/types.rs
+++ b/pallets/rc-migrator/src/types.rs
@@ -140,7 +140,7 @@ pub enum AhMigratorCall<T: Config> {
 	#[codec(index = 20)]
 	ReceiveReferendaMetadata { metadata: Vec<(u32, <T as frame_system::Config>::Hash)> },
 	#[codec(index = 21)]
-	ReceiveTreasuryMessages { messages: Vec<treasury::RcTreasuryMessageOf<T>> },
+	ReceiveTreasuryMessages { messages: Vec<treasury::PortableTreasuryMessage> },
 	#[codec(index = 22)]
 	ReceiveSchedulerAgendaMessages {
 		messages: Vec<(

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -788,6 +788,17 @@ parameter_types! {
 	pub const CouncilSpendOriginMaxAmount: Balance = Balance::MAX;
 }
 
+pub type TreasuryPaymaster = PayOverXcm<
+	TreasuryInteriorLocation,
+	crate::xcm_config::XcmRouter,
+	crate::XcmPallet,
+	ConstU32<{ 6 * HOURS }>,
+	<Runtime as pallet_treasury::Config>::Beneficiary,
+	<Runtime as pallet_treasury::Config>::AssetKind,
+	LocatableAssetConverter,
+	VersionedLocationConverter,
+>;
+
 impl pallet_treasury::Config for Runtime {
 	type PalletId = TreasuryPalletId;
 	type Currency = Balances;
@@ -804,16 +815,7 @@ impl pallet_treasury::Config for Runtime {
 	type AssetKind = VersionedLocatableAsset;
 	type Beneficiary = VersionedLocation;
 	type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
-	type Paymaster = PayOverXcm<
-		TreasuryInteriorLocation,
-		crate::xcm_config::XcmRouter,
-		crate::XcmPallet,
-		ConstU32<{ 6 * HOURS }>,
-		Self::Beneficiary,
-		Self::AssetKind,
-		LocatableAssetConverter,
-		VersionedLocationConverter,
-	>;
+	type Paymaster = TreasuryPaymaster;
 	type BalanceConverter = AssetRateWithNative;
 	type PayoutPeriod = PayoutSpendPeriod;
 	type BlockNumberProvider = System;
@@ -1727,6 +1729,7 @@ impl pallet_rc_migrator::Config for Runtime {
 	type Currency = Balances;
 	type CheckingAccount = xcm_config::CheckAccount;
 	type TreasuryBlockNumberProvider = System;
+	type TreasuryPaymaster = TreasuryPaymaster;
 	type SendXcm = xcm_config::XcmRouterWithoutException;
 	type MaxRcWeight = RcMigratorMaxWeight;
 	type MaxAhWeight = AhMigratorMaxWeight;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs
@@ -118,9 +118,9 @@ impl TryConvert<RcProxyType, ProxyType> for RcToProxyType {
 			Governance => Ok(ProxyType::Governance),
 			Staking => Ok(ProxyType::Staking),
 			CancelProxy => Ok(ProxyType::CancelProxy),
-			Auction => Ok(ProxyType::OldAuction),
+			Auction => Ok(ProxyType::Auction),
 			NominationPools => Ok(ProxyType::NominationPools),
-			ParaRegistration => Ok(ProxyType::OldParaRegistration),
+			ParaRegistration => Ok(ProxyType::ParaRegistration),
 		}
 	}
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/ah_migration/mod.rs
@@ -365,9 +365,8 @@ impl
 	> for RcToAhTreasurySpend
 {
 	fn convert(
-		rc: (VersionedLocatableAsset, VersionedLocation),
+		(asset_kind, beneficiary): (VersionedLocatableAsset, VersionedLocation),
 	) -> Result<(VersionedLocatableAsset, VersionedLocatableAccount), ()> {
-		let (asset_kind, beneficiary) = rc;
 		let asset_kind = LocatableAssetConverter::try_convert(asset_kind).map_err(|_| {
 			log::error!(target: LOG_TARGET, "Failed to convert RC asset kind to latest version");
 		})?;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -560,7 +560,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Uniques { .. } |
 					RuntimeCall::Scheduler(..) |
 					RuntimeCall::Treasury(..) |
-					//RuntimeCall::Bounties(..) | # TODO: @ggwpez more
+					RuntimeCall::Bounties(..) |
 					RuntimeCall::ChildBounties(..) |
 					// We allow calling `vest` and merging vesting schedules, but obviously not
 					// vested transfers.
@@ -655,9 +655,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::Utility { .. } |
 					RuntimeCall::Multisig { .. }
 			),
-
 			// New variants introduced by the Asset Hub Migration from the Relay Chain.
-			// TODO: @ggwpez Uncomment once all these pallets are deployed.
 			ProxyType::Governance => matches!(
 				c,
 				RuntimeCall::Treasury(..) |
@@ -671,16 +669,16 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			ProxyType::Staking => {
 				matches!(
 					c,
-					//RuntimeCall::Staking(..) |
-					RuntimeCall::Session(..) |
+					RuntimeCall::Staking(..) |
+						RuntimeCall::Session(..) |
 						RuntimeCall::Utility(..) |
-						RuntimeCall::NominationPools(..) /*RuntimeCall::FastUnstake(..) |
-					                                   *RuntimeCall::VoterList(..)
-					                                   */
+						RuntimeCall::NominationPools(..) |
+						RuntimeCall::FastUnstake(..) |
+						RuntimeCall::VoterList(..)
 				)
 			},
 			ProxyType::NominationPools => {
-				matches!(c, /* RuntimeCall::NominationPools(..) | */ RuntimeCall::Utility(..))
+				matches!(c, RuntimeCall::NominationPools(..) | RuntimeCall::Utility(..))
 			},
 		}
 	}

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -532,14 +532,14 @@ pub enum ProxyType {
 	///
 	/// Contains the `NominationPools` and `Utility` pallets.
 	NominationPools,
-	/// Placeholder variant for old migrated `Auction` proxy type from the Relay chain.
+	/// To be used with the remote proxy pallet to manage parachain lease auctions on the relay.
 	///
-	/// Cannot do anything.
-	OldAuction,
-	/// Placeholder variant for old migrated `ParaRegistration` proxy type from the Relay chain.
+	/// This variant cannot do anything on Asset Hub itself.
+	Auction,
+	/// To be used with the remote proxy pallet to manage parachain registration on the relay.
 	///
-	/// Cannot do anything.
-	OldParaRegistration,
+	/// This variant cannot do anything on Asset Hub itself.
+	ParaRegistration,
 }
 impl Default for ProxyType {
 	fn default() -> Self {
@@ -551,7 +551,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::OldAuction | ProxyType::OldParaRegistration => false,
+			ProxyType::Auction | ProxyType::ParaRegistration => false,
 			ProxyType::NonTransfer => !matches!(
 				c,
 				RuntimeCall::Balances { .. } |

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1185,6 +1185,7 @@ impl pallet_ah_migrator::Config for Runtime {
 	>;
 	type Currency = Balances;
 	type TreasuryBlockNumberProvider = RelaychainDataProvider<Runtime>;
+	type TreasuryPaymaster = treasury::TreasuryPaymaster;
 	type Assets = NativeAndAssets;
 	type CheckingAccount = xcm_config::CheckingAccount;
 	type RcProxyType = ah_migration::RcProxyType;

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/treasury.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/treasury.rs
@@ -29,6 +29,12 @@ parameter_types! {
 	pub TreasuryAccount: AccountId = Treasury::account_id();
 }
 
+pub type TreasuryPaymaster = system_parachains_common::pay::LocalPay<
+	NativeAndAssets,
+	TreasuryAccount,
+	xcm_config::LocationToAccountId,
+>;
+
 impl pallet_treasury::Config for Runtime {
 	type PalletId = TreasuryPalletId;
 	type Currency = Balances;
@@ -44,11 +50,7 @@ impl pallet_treasury::Config for Runtime {
 	type AssetKind = VersionedLocatableAsset;
 	type Beneficiary = VersionedLocatableAccount;
 	type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
-	type Paymaster = system_parachains_common::pay::LocalPay<
-		NativeAndAssets,
-		TreasuryAccount,
-		xcm_config::LocationToAccountId,
-	>;
+	type Paymaster = TreasuryPaymaster;
 	type BalanceConverter = AssetRateWithNative;
 	type PayoutPeriod = PayoutSpendPeriod;
 	#[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
Changes:
- Remove treasury storage_alias
- Finish multisig pure tests (Pure MS works on AH as it worked on RC)
- Rename `Old*` proxy variants to normal naming. This was done since they will be usable with remote proxy.
- Fix proxies filter (there were some pallets missing)
- Add proxy tests