### PR TITLE
Update Kusama submission deposit as per ref#558

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Update Kusama submission deposit to 3.333KSM as per ref#558
+
 ## [1.7.0] 22.08.2025
 
 ### Fixed

--- a/relay/kusama/src/governance/mod.rs
+++ b/relay/kusama/src/governance/mod.rs
@@ -53,7 +53,7 @@ impl pallet_conviction_voting::Config for Runtime {
 
 parameter_types! {
 	pub const AlarmInterval: BlockNumber = 1;
-	pub const SubmissionDeposit: Balance = QUID;
+	pub const SubmissionDeposit: Balance = 100 * QUID;
 	pub const UndecidingTimeout: BlockNumber = 14 * DAYS;
 }
 


### PR DESCRIPTION
A recent [WFC](https://kusama.subsquare.io/referenda/558) passed to adjust submission deposit to prevent spams specially on the WFC track. 

A missing part of the WFC is to add a new extrinsic to the PolkadotSDK to "collect submission deposits", a permissionless extrinsic that would enable transferring the reserved deposit of failed or timed out referenda to a well-known account as the deposits are blocked forever in the user's account, kind of like a limbo state.