### PR TITLE
Support Snowbridge bridge reward payouts on AssetHub

### DIFF
--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod snowbridge_v2_inbound_to_kusama;
 mod snowbridge_v2_outbound;
 mod snowbridge_v2_outbound_edge_case;
 mod snowbridge_v2_outbound_from_kusama;
+mod snowbridge_v2_rewards;
 mod teleport;
 
 pub(crate) fn asset_hub_kusama_location() -> Location {

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_rewards.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_rewards.rs
@@ -1,0 +1,153 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+	tests::snowbridge_common::{eth_location, set_up_eth_and_dot_pool_on_polkadot_asset_hub},
+	*,
+};
+use bridge_hub_polkadot_runtime::bridge_common_config::{BridgeReward, BridgeRewardBeneficiaries};
+use pallet_bridge_relayers::{Error::FailedToPayReward, RewardLedger};
+
+const INITIAL_FUND: u128 = 5_000_000_000_000;
+
+#[test]
+fn claim_rewards_works() {
+	let assethub_location = BridgeHubPolkadot::sibling_location_of(AssetHubPolkadot::para_id());
+	let assethub_sovereign = BridgeHubPolkadot::sovereign_account_id_of(assethub_location);
+
+	let relayer_account = BridgeHubPolkadotSender::get();
+	let reward_address = AssetHubPolkadotReceiver::get();
+
+	BridgeHubPolkadot::fund_accounts(vec![
+		(assethub_sovereign.clone(), INITIAL_FUND),
+		(relayer_account.clone(), INITIAL_FUND),
+	]);
+	set_up_eth_and_dot_pool_on_polkadot_asset_hub();
+
+	BridgeHubPolkadot::execute_with(|| {
+		type RuntimeEvent = <BridgeHubPolkadot as Chain>::RuntimeEvent;
+		type RuntimeOrigin = <BridgeHubPolkadot as Chain>::RuntimeOrigin;
+		let reward_amount = MIN_ETHER_BALANCE * 2; // Reward should be more than Ether min balance
+
+		type BridgeRelayers = <BridgeHubPolkadot as BridgeHubPolkadotPallet>::BridgeRelayers;
+		BridgeRelayers::register_reward(
+			(&relayer_account.clone()).into(),
+			BridgeReward::Snowbridge,
+			reward_amount,
+		);
+
+		// Check that the reward was registered.
+		assert_expected_events!(
+			BridgeHubPolkadot,
+			vec![
+				RuntimeEvent::BridgeRelayers(pallet_bridge_relayers::Event::RewardRegistered { relayer, reward_kind, reward_balance }) => {
+					relayer: *relayer == relayer_account,
+					reward_kind: *reward_kind == BridgeReward::Snowbridge,
+					reward_balance: *reward_balance == reward_amount,
+				},
+			]
+		);
+
+		let relayer_location = Location::new(
+			0,
+			[Junction::AccountId32 { id: reward_address.clone().into(), network: None }],
+		);
+		let reward_beneficiary = BridgeRewardBeneficiaries::AssetHubLocation(Box::new(
+			VersionedLocation::V5(relayer_location),
+		));
+		let result = BridgeRelayers::claim_rewards_to(
+			RuntimeOrigin::signed(relayer_account.clone()),
+			BridgeReward::Snowbridge,
+			reward_beneficiary.clone(),
+		);
+		assert_ok!(result);
+
+		assert_expected_events!(
+			BridgeHubPolkadot,
+			vec![
+				// Check that the pay reward event was emitted on BH
+				RuntimeEvent::BridgeRelayers(pallet_bridge_relayers::Event::RewardPaid { relayer, reward_kind, reward_balance, beneficiary }) => {
+					relayer: *relayer == relayer_account,
+					reward_kind: *reward_kind == BridgeReward::Snowbridge,
+					reward_balance: *reward_balance == reward_amount,
+					beneficiary: *beneficiary == reward_beneficiary,
+				},
+			]
+		);
+	});
+
+	AssetHubPolkadot::execute_with(|| {
+		type RuntimeEvent = <AssetHubPolkadot as Chain>::RuntimeEvent;
+		assert_expected_events!(
+			AssetHubPolkadot,
+			vec![
+				// Check that the reward was paid on AH
+				RuntimeEvent::ForeignAssets(pallet_assets::Event::Issued { asset_id, owner, .. }) => {
+					asset_id: *asset_id == eth_location(),
+					owner: *owner == reward_address.clone().into(),
+				},
+			]
+		);
+	})
+}
+
+#[test]
+fn claim_snowbridge_rewards_to_local_account_fails() {
+	let assethub_location = BridgeHubPolkadot::sibling_location_of(AssetHubPolkadot::para_id());
+	let assethub_sovereign = BridgeHubPolkadot::sovereign_account_id_of(assethub_location);
+
+	let relayer_account = BridgeHubPolkadotSender::get();
+	let reward_address = AssetHubPolkadotReceiver::get();
+
+	BridgeHubPolkadot::fund_accounts(vec![
+		(assethub_sovereign.clone(), INITIAL_FUND),
+		(relayer_account.clone(), INITIAL_FUND),
+	]);
+	set_up_eth_and_dot_pool_on_polkadot_asset_hub();
+
+	BridgeHubPolkadot::execute_with(|| {
+		type Runtime = <BridgeHubPolkadot as Chain>::Runtime;
+		type RuntimeEvent = <BridgeHubPolkadot as Chain>::RuntimeEvent;
+		type RuntimeOrigin = <BridgeHubPolkadot as Chain>::RuntimeOrigin;
+		let reward_amount = MIN_ETHER_BALANCE * 2; // Reward should be more than Ether min balance
+
+		type BridgeRelayers = <BridgeHubPolkadot as BridgeHubPolkadotPallet>::BridgeRelayers;
+		BridgeRelayers::register_reward(
+			(&relayer_account.clone()).into(),
+			BridgeReward::Snowbridge,
+			reward_amount,
+		);
+
+		// Check that the reward was registered.
+		assert_expected_events!(
+			BridgeHubPolkadot,
+			vec![
+				RuntimeEvent::BridgeRelayers(pallet_bridge_relayers::Event::RewardRegistered { relayer, reward_kind, reward_balance }) => {
+					relayer: *relayer == relayer_account,
+					reward_kind: *reward_kind == BridgeReward::Snowbridge,
+					reward_balance: *reward_balance == reward_amount,
+				},
+			]
+		);
+
+		let reward_beneficiary = BridgeRewardBeneficiaries::LocalAccount(reward_address);
+		let result = BridgeRelayers::claim_rewards_to(
+			RuntimeOrigin::signed(relayer_account.clone()),
+			BridgeReward::Snowbridge,
+			reward_beneficiary.clone(),
+		);
+		assert_err!(result, FailedToPayReward::<Runtime, ()>);
+	})
+}

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/tests.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/tests/tests.rs
@@ -17,8 +17,12 @@
 use bp_bridge_hub_kusama::Perbill;
 use bp_messages::LegacyLaneId;
 use bp_polkadot_core::Signature;
+use bp_relayers::{PayRewardFromAccount, RewardsAccountOwner, RewardsAccountParams};
 use bridge_hub_polkadot_runtime::{
-	bridge_common_config::{BridgeRelayersInstance, RequiredStakeForStakeAndSlash},
+	bridge_common_config::{
+		BridgeRelayersInstance, BridgeReward, BridgeRewardBeneficiaries,
+		RequiredStakeForStakeAndSlash,
+	},
 	bridge_to_kusama_config::{
 		BridgeGrandpaKusamaInstance, BridgeHubKusamaLocation, BridgeParachainKusamaInstance,
 		DeliveryRewardInBalance, KusamaGlobalConsensusNetwork,
@@ -29,20 +33,30 @@ use bridge_hub_polkadot_runtime::{
 		DotRelayLocation, GovernanceLocation, LocationToAccountId, RelayNetwork,
 		RelayTreasuryLocation, RelayTreasuryPalletAccount, XcmConfig,
 	},
-	AllPalletsWithoutSystem, Block, BridgeRejectObsoleteHeadersAndMessages, Executive,
-	ExistentialDeposit, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
-	RuntimeOrigin, SessionKeys, TransactionPayment, TxExtension, UncheckedExtrinsic, SLOT_DURATION,
+	AllPalletsWithoutSystem, Balances, Block, BridgeRejectObsoleteHeadersAndMessages,
+	BridgeRelayers, Executive, ExistentialDeposit, ParachainSystem, PolkadotXcm, Runtime,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, SessionKeys, TransactionPayment, TxExtension,
+	UncheckedExtrinsic, SLOT_DURATION,
 };
-use bridge_hub_test_utils::{test_cases::from_parachain, GovernanceOrigin, SlotDurations};
+use bridge_hub_test_utils::{
+	test_cases::{from_parachain, run_test},
+	GovernanceOrigin, SlotDurations,
+};
 use codec::{Decode, Encode};
 use cumulus_primitives_core::UpwardMessageSender;
 use frame_support::{
-	assert_err, assert_ok, dispatch::GetDispatchInfo, parameter_types, traits::ConstU8,
+	assert_err, assert_ok,
+	dispatch::GetDispatchInfo,
+	parameter_types,
+	traits::{
+		fungible::{Inspect, Mutate},
+		ConstU8,
+	},
 };
 use parachains_common::{AccountId, AuraId, Balance};
 use sp_consensus_aura::SlotDuration;
 use sp_core::crypto::Ss58Codec;
-use sp_keyring::Sr25519Keyring::Alice;
+use sp_keyring::Sr25519Keyring::{Alice, Bob};
 use sp_runtime::{
 	generic::{Era, SignedPayload},
 	AccountId32, Either,
@@ -50,7 +64,7 @@ use sp_runtime::{
 use system_parachains_constants::polkadot::{
 	consensus::RELAY_CHAIN_SLOT_DURATION_MILLIS, fee::WeightToFee,
 };
-use xcm::latest::prelude::*;
+use xcm::{latest::prelude::*, VersionedLocation};
 use xcm_executor::traits::ConvertLocation;
 use xcm_runtime_apis::conversions::LocationToAccountHelper;
 
@@ -567,6 +581,103 @@ fn xcm_payment_api_works() {
 		Block,
 		WeightToFee,
 	>();
+}
+
+#[test]
+pub fn bridge_rewards_works() {
+	run_test::<Runtime, _>(
+		collator_session_keys(),
+		bp_bridge_hub_polkadot::BRIDGE_HUB_POLKADOT_PARACHAIN_ID,
+		vec![],
+		|| {
+			// reward in DOT
+			let reward1: u128 = 2_000_000_000;
+			// reward in ETH
+			let reward2: u128 = 3_000_000_000;
+
+			// prepare accounts
+			let account1 = AccountId32::from(Alice);
+			let account2 = AccountId32::from(Bob);
+			let reward1_for = RewardsAccountParams::new(
+				LegacyLaneId([1; 4]),
+				*b"test",
+				RewardsAccountOwner::ThisChain,
+			);
+			let expected_reward1_account =
+				PayRewardFromAccount::<(), AccountId, LegacyLaneId, ()>::rewards_account(
+					reward1_for,
+				);
+			assert_ok!(Balances::mint_into(&expected_reward1_account, ExistentialDeposit::get()));
+			assert_ok!(Balances::mint_into(&expected_reward1_account, reward1.into()));
+			assert_ok!(Balances::mint_into(&account1, ExistentialDeposit::get()));
+
+			// register rewards
+			use bp_relayers::RewardLedger;
+			BridgeRelayers::register_reward(&account1, BridgeReward::from(reward1_for), reward1);
+			BridgeRelayers::register_reward(&account2, BridgeReward::Snowbridge, reward2);
+
+			// check stored rewards
+			assert_eq!(
+				BridgeRelayers::relayer_reward(&account1, BridgeReward::from(reward1_for)),
+				Some(reward1)
+			);
+			assert_eq!(BridgeRelayers::relayer_reward(&account1, BridgeReward::Snowbridge), None,);
+			assert_eq!(
+				BridgeRelayers::relayer_reward(&account2, BridgeReward::Snowbridge),
+				Some(reward2),
+			);
+			assert_eq!(
+				BridgeRelayers::relayer_reward(&account2, BridgeReward::from(reward1_for)),
+				None,
+			);
+
+			// claim rewards
+			assert_ok!(BridgeRelayers::claim_rewards(
+				RuntimeOrigin::signed(account1.clone()),
+				reward1_for.into()
+			));
+			assert_eq!(Balances::total_balance(&account1), ExistentialDeposit::get() + reward1);
+			assert_eq!(
+				BridgeRelayers::relayer_reward(&account1, BridgeReward::from(reward1_for)),
+				None,
+			);
+
+			// already claimed
+			assert_err!(
+				BridgeRelayers::claim_rewards(
+					RuntimeOrigin::signed(account1.clone()),
+					reward1_for.into()
+				),
+				pallet_bridge_relayers::Error::<Runtime, BridgeRelayersInstance>::NoRewardForRelayer
+			);
+
+			// Local account claiming is not supported for Snowbridge
+			assert_err!(
+				BridgeRelayers::claim_rewards(
+					RuntimeOrigin::signed(account2.clone()),
+					BridgeReward::Snowbridge
+				),
+				pallet_bridge_relayers::Error::<Runtime, BridgeRelayersInstance>::FailedToPayReward
+			);
+
+			let claim_location = VersionedLocation::V5(Location::new(
+				1,
+				[
+					Parachain(bp_asset_hub_polkadot::ASSET_HUB_POLKADOT_PARACHAIN_ID),
+					Junction::AccountId32 { id: account2.clone().into(), network: None },
+				],
+			));
+			// Without proper HRMP channel setup, the claim will fail at XCM sending.
+			assert_err!(
+				BridgeRelayers::claim_rewards_to(
+					RuntimeOrigin::signed(account2.clone()),
+					BridgeReward::Snowbridge,
+					BridgeRewardBeneficiaries::AssetHubLocation(Box::new(claim_location))
+				),
+				pallet_bridge_relayers::Error::<Runtime, BridgeRelayersInstance>::FailedToPayReward
+			);
+		},
+	);
 }
 
 #[test]


### PR DESCRIPTION
Adds handling Snowbridge relayer payouts on AssetHub, since relayer rewards are accumulated on BridgeHub in ether.