### PR TITLE
Release 1.6.2 (Polkadot only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - [#9564](https://github.com/paritytech/polkadot-sdk/pull/9564) Correctly map group indices to vote indices when filtering backing statements.
+- Upgrade to Polkadot-SDK `stable2503-9` patch release:
+  - [#9137](https://github.com/paritytech/polkadot-sdk/pull/9137): Pallet XCM - transfer_assets pre-ahm patch
+    🚨 Pallet XCM's `transfer_assets` extrinsic now returns an error when it determines that a reserve transfer of DOT has to be done.
+    This is a safeguard in preparation for the Asset Hub Migration (AHM), where the reserve of DOT will change from the Relay Chain to Asset Hub.
+    After the migration, another patch will remove this error case and use the correct reserve.
+    🚨 For DOT cross-chain transfers please use `transfer_assets_using_type_and_then` or `execute`.
 
 ## [1.6.1] 24.06.2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.6.2] 28.08.2025
+
+### Fixed
+
+- [#9564](https://github.com/paritytech/polkadot-sdk/pull/9564) Correctly map group indices to vote indices when filtering backing statements.
+
 ## [1.6.1] 24.06.2025
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - [#9564](https://github.com/paritytech/polkadot-sdk/pull/9564) Correctly map group indices to vote indices when filtering backing statements.
-- Upgrade to Polkadot-SDK `stable2503-9` patch release:
-  - [#9137](https://github.com/paritytech/polkadot-sdk/pull/9137): Pallet XCM - transfer_assets pre-ahm patch
-    🚨 Pallet XCM's `transfer_assets` extrinsic now returns an error when it determines that a reserve transfer of DOT has to be done.
-    This is a safeguard in preparation for the Asset Hub Migration (AHM), where the reserve of DOT will change from the Relay Chain to Asset Hub.
-    After the migration, another patch will remove this error case and use the correct reserve.
-    🚨 For DOT cross-chain transfers please use `transfer_assets_using_type_and_then` or `execute`.
 
 ## [1.6.1] 24.06.2025
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4417,7 +4417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4688,9 +4688,9 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.2.0"
+version = "40.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9e5fcdb30bb83b2d97d7e718127230e0fbbad82b9c32dedf63971f08709def"
+checksum = "e223b9cbb4e6d3f742b33c104037155c91315e97fe495406ba946f9823b432f0"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4926,9 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "40.1.0"
+version = "40.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc20d95c35bad22eb8b8d7ef91197a439483458237b176e621d9210f2fbff15"
+checksum = "d1e700f225f5cfe5d89f564ab23b6c609c144228d4d9871956ef209b20c9df98"
 dependencies = [
  "cfg-if",
  "docify",
@@ -6216,7 +6216,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8335,9 +8335,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "41.1.0"
+version = "41.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd7bf033312c976e0c044a80b4cd8b88471d7371baae6fea67b3f42eba288b"
+checksum = "58e04ed6c01cd829731ec7bcec0de4e49cd806195ca2448a1887c5493efd8262"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10777,9 +10777,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "19.2.0"
+version = "19.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fc49c2a9a7d13fbd1d97d448366ad5b7197d7684ec9013271d99c015d13d6"
+checksum = "b966d48417bd4a9d87efd41b37bb6dd21f5b311dfaa6949f4771cc4cff9847af"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -11493,7 +11493,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12043,7 +12043,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12056,7 +12056,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12156,7 +12156,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14973,9 +14973,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "19.1.2"
+version = "19.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9bc315e8c7018fcfe0371ce4b7e726fb699e37b2acc3e5effb87a7d131a3ff"
+checksum = "604ccc5e603cc6ec323928b1ef95897d97f495f5a7f4355953f0d51f48a4f567"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15501,7 +15501,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16835,7 +16835,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ polkadot-system-emulated-network = { path = "integration-tests/emulated/networks
 primitive-types = { version = "0.12.2", default-features = false }
 frame-metadata-hash-extension = { version = "0.8.0", default-features = false }
 remote-externalities = { version = "0.50.0", package = "frame-remote-externalities" }
-runtime-parachains = { version = "19.2.0", default-features = false, package = "polkadot-runtime-parachains" }
+runtime-parachains = { version = "19.2.1", default-features = false, package = "polkadot-runtime-parachains" }
 sc-chain-spec = { version = "42.0.0" }
 sc-network = { version = "0.49.2" }
 scale-info = { version = "2.10.0", default-features = false }

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -168,7 +168,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("polkadot"),
 	impl_name: alloc::borrow::Cow::Borrowed("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 1_006_001,
+	spec_version: 1_006_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 26,


### PR DESCRIPTION
This is release targeting only the Polkadot RC, so I am not bumping spec versions for anything else.

Changes:
- Bump `polkadot-runtime-parachains` to 19.2.1 (includes [#9564](https://github.com/paritytech/polkadot-sdk/pull/9564))
- Updated CHANGELOG
- Bumped Polkadot RC runtime spec versions to `1_006_002`

I've also checked the diff of PRs since Polkdot-SDK `2503-7-rc1` @ [b9ac350](https://github.com/paritytech/polkadot-sdk/commit/b9ac350397e8cedbd13f659dbcc49dd74308064e) relevant to the minor/patch bumps for dependencies of  `polkadot-runtime-parachains v19.2.1`:
- frame-benchmarking v40.2.0 -> v40.2.1 
- frame-system v40.1.0 -> v40.2.0
- pallet-balances v41.1.0 -> v41.1.1
- staging-xcm-executor v19.1.2 -> v19.1.3 

There is no need to do any further changes (weights, migrations, etc) for this Polkadot RC release, but please review and double check.