### PR TITLE
Add migration for updating Kusama hrmpChannelMaxCapacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- update hrmpChannelMaxCapacity to 25 on Kusama ([polkadot-fellows/runtimes/pull/874](https://github.com/polkadot-fellows/runtimes/pull/874))
+
 ## [1.7.1] 28.08.2025
 
 ### Fixed

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1973,8 +1973,25 @@ pub type Migrations = (migrations::Unreleased, migrations::Permanent);
 pub mod migrations {
 	use super::*;
 
+	/// Update `hrmp_channel_max_capacity` for the active `HostConfiguration`.
+	///
+	/// This value is used by default when opening a new HRMP channel.
+	/// The channels that are already opened won't be affected.
+	pub struct UpdateDefaultHrmpChannelMaxCapacity;
+	impl frame_support::traits::OnRuntimeUpgrade for UpdateDefaultHrmpChannelMaxCapacity {
+		fn on_runtime_upgrade() -> Weight {
+			use runtime_parachains::configuration::WeightInfo;
+
+			let _ = Configuration::set_hrmp_channel_max_capacity(
+				RawOrigin::Root.into(),
+				25,
+			);
+			weights::runtime_parachains_configuration::WeightInfo::<Runtime>::set_config_with_u32()
+		}
+	}
+
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = ();
+	pub type Unreleased = UpdateDefaultHrmpChannelMaxCapacity;
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>;


### PR DESCRIPTION
Equivalent of Polkadot referenda https://polkadot.subsquare.io/referenda/1740

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [ ] Does not require a CHANGELOG entry
