### PR TITLE
Fix: change encointer-runtime's blocktime to 6s in runtime-matrix

### DIFF
--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -156,7 +156,7 @@
     "path": "system-parachains/encointer",
     "uri": "wss://kusama.api.encointer.org:443",
     "is_relay": false,
-    "blocktime": 12000,
+    "blocktime": 6000,
     "extra_args": "--disable-mbm-checks",
     "benchmarks_templates": {
       "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",


### PR DESCRIPTION
Encointer has been running on 6 seconds since a long time already. :)

- [x] Does not require a CHANGELOG entry
