### PR TITLE
Update pallet-xcm to 22.0.1 (latest unstable2507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+-  Pallet XCM - Disable reserve_asset_transfer for DOT|KSM ([polkadot-fellows/runtimes/pull/880](https://github.com/polkadot-fellows/runtimes/pull/880))
+  🚨 Pallet XCM's `limited_reserve_transfer_assets` and `reserve_transfer_assets` extrinsics now returns an error when it determines that a reserve transfer of DOT|KSM has to be done.
+  This is a safeguard in preparation for the Asset Hub Migration (AHM), where the reserve of DOT|KSM will change from the Relay Chain to Asset Hub.
+  After the migration, another patch will remove this error case and use the correct reserve.
+  🚨 For DOT|KSM cross-chain transfers please use `transfer_assets_using_type_and_then` or `execute`.
+
 ## [1.7.1] 28.08.2025
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   This is a safeguard in preparation for the Asset Hub Migration (AHM), where the reserve of DOT|KSM will change from the Relay Chain to Asset Hub.
   After the migration, another patch will remove this error case and use the correct reserve.
   🚨 For DOT|KSM cross-chain transfers please use `transfer_assets_using_type_and_then` or `execute`.
-  Follow to the [Polkadot forum post](https://forum.polkadot.network/t/mandatory-action-guide-for-ahm-broken-native-crosschain-transfers/) for more details regarding this topic
+  Please see this [Polkadot forum post](https://forum.polkadot.network/t/mandatory-action-guide-for-ahm-broken-native-crosschain-transfers/) for more details.
 
 ## [1.7.1] 28.08.2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   This is a safeguard in preparation for the Asset Hub Migration (AHM), where the reserve of DOT|KSM will change from the Relay Chain to Asset Hub.
   After the migration, another patch will remove this error case and use the correct reserve.
   🚨 For DOT|KSM cross-chain transfers please use `transfer_assets_using_type_and_then` or `execute`.
+  Follow to the [Polkadot forum post](https://forum.polkadot.network/t/mandatory-action-guide-for-ahm-broken-native-crosschain-transfers/) for more details regarding this topic
 
 ## [1.7.1] 28.08.2025
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "asset-test-utils"
-version = "26.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dac7cc5b0e8dc3660a66183aed75b5ea7b5e8fc74b88155a6af01fb5cd80069"
+checksum = "898d74874dfa06cad51722d4c7c69dae3bbb1f17d69aa3e740be7230b9b288c2"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -3419,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fcec23bacb8d5a20af7f20dbadf133a81686a4a98864228ae7489023318bf3"
+checksum = "be6f97fba4804477d5c720a2ed4a30083336022157e6f5f2659236b84f0ebe57"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -10005,9 +10005,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65504a059ba2a54c221a7a0fe681ae347fd085dbd932c69df3ccb268e97febf"
+checksum = "84831f49e34014a04f5ff97872c8d3409788981ee5d49b79dffbe80f7d22c98e"
 dependencies = [
  "bounded-collections 0.3.2",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ asset-hub-kusama-emulated-chain = { path = "integration-tests/emulated/chains/pa
 asset-hub-kusama-runtime = { path = "system-parachains/asset-hubs/asset-hub-kusama" }
 asset-hub-polkadot-emulated-chain = { path = "integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot" }
 asset-hub-polkadot-runtime = { path = "system-parachains/asset-hubs/asset-hub-polkadot" }
-asset-test-utils = { version = "26.0.0" }
+asset-test-utils = { version = "26.0.1" }
 assets-common = { version = "0.24.0", default-features = false }
 authority-discovery-primitives = { version = "38.0.0", default-features = false, package = "sp-authority-discovery" }
 babe-primitives = { version = "0.44.0", default-features = false, package = "sp-consensus-babe" }
@@ -170,7 +170,7 @@ pallet-uniques = { version = "42.0.0", default-features = false }
 pallet-utility = { version = "42.0.0", default-features = false }
 pallet-vesting = { version = "42.0.0", default-features = false }
 pallet-whitelist = { version = "41.0.0", default-features = false }
-pallet-xcm = { version = "22.0.0", default-features = false }
+pallet-xcm = { version = "22.0.1", default-features = false }
 pallet-xcm-benchmarks = { version = "22.0.0", default-features = false }
 pallet-xcm-bridge-hub = { version = "0.18.0", default-features = false }
 pallet-xcm-bridge-hub-router = { version = "0.20.0", default-features = false }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -374,46 +374,113 @@ fn relay_to_para_reserve_transfer_assets(t: RelayToParaTest) -> DispatchResult {
 	let Parachain(para_id) = *t.args.dest.chain_location().last().unwrap() else {
 		unimplemented!("Destination is not a parachain?")
 	};
+	type Runtime = <Kusama as Chain>::Runtime;
+	let remote_fee_id: AssetId = t
+		.args
+		.assets
+		.clone()
+		.into_inner()
+		.get(t.args.fee_asset_item as usize)
+		.ok_or(pallet_xcm::Error::<Runtime>::Empty)?
+		.clone()
+		.id;
 	Dmp::make_parachain_reachable(para_id);
-	<Kusama as KusamaPallet>::XcmPallet::limited_reserve_transfer_assets(
+	<Kusama as KusamaPallet>::XcmPallet::transfer_assets_using_type_and_then(
 		t.signed_origin,
 		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
 		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
+		bx!(TransferType::LocalReserve),
+		bx!(remote_fee_id.into()),
+		bx!(TransferType::LocalReserve),
+		bx!(VersionedXcm::from(
+			Xcm::<()>::builder_unsafe()
+				.deposit_asset(AllCounted(1), t.args.beneficiary)
+				.build()
+		)),
 		t.args.weight_limit,
 	)
 }
 
 fn para_to_relay_reserve_transfer_assets(t: ParaToRelayTest) -> DispatchResult {
-	<PenpalA as PenpalAPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+	type Runtime = <PenpalA as Chain>::Runtime;
+	let remote_fee_id: AssetId = t
+		.args
+		.assets
+		.clone()
+		.into_inner()
+		.get(t.args.fee_asset_item as usize)
+		.ok_or(pallet_xcm::Error::<Runtime>::Empty)?
+		.clone()
+		.id;
+
+	<PenpalA as PenpalAPallet>::PolkadotXcm::transfer_assets_using_type_and_then(
 		t.signed_origin,
 		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
 		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
+		bx!(TransferType::DestinationReserve),
+		bx!(remote_fee_id.into()),
+		bx!(TransferType::DestinationReserve),
+		bx!(VersionedXcm::from(
+			Xcm::<()>::builder_unsafe()
+				.deposit_asset(AllCounted(1), t.args.beneficiary)
+				.build()
+		)),
 		t.args.weight_limit,
 	)
 }
 
 fn system_para_to_para_reserve_transfer_assets(t: SystemParaToParaTest) -> DispatchResult {
-	<AssetHubKusama as AssetHubKusamaPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+	type Runtime = <AssetHubKusama as Chain>::Runtime;
+	let remote_fee_id: AssetId = t
+		.args
+		.assets
+		.clone()
+		.into_inner()
+		.get(t.args.fee_asset_item as usize)
+		.ok_or(pallet_xcm::Error::<Runtime>::Empty)?
+		.clone()
+		.id;
+
+	<AssetHubKusama as AssetHubKusamaPallet>::PolkadotXcm::transfer_assets_using_type_and_then(
 		t.signed_origin,
 		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
 		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
+		bx!(TransferType::LocalReserve),
+		bx!(remote_fee_id.into()),
+		bx!(TransferType::LocalReserve),
+		bx!(VersionedXcm::from(
+			Xcm::<()>::builder_unsafe()
+				.deposit_asset(AllCounted(2), t.args.beneficiary)
+				.build()
+		)),
 		t.args.weight_limit,
 	)
 }
 
 fn para_to_system_para_reserve_transfer_assets(t: ParaToSystemParaTest) -> DispatchResult {
-	<PenpalA as PenpalAPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+	type Runtime = <PenpalA as Chain>::Runtime;
+	let remote_fee_id: AssetId = t
+		.args
+		.assets
+		.clone()
+		.into_inner()
+		.get(t.args.fee_asset_item as usize)
+		.ok_or(pallet_xcm::Error::<Runtime>::Empty)?
+		.clone()
+		.id;
+
+	<PenpalA as PenpalAPallet>::PolkadotXcm::transfer_assets_using_type_and_then(
 		t.signed_origin,
 		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
 		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
+		bx!(TransferType::DestinationReserve),
+		bx!(remote_fee_id.into()),
+		bx!(TransferType::DestinationReserve),
+		bx!(VersionedXcm::from(
+			Xcm::<()>::builder_unsafe()
+				.deposit_asset(AllCounted(2), t.args.beneficiary)
+				.build()
+		)),
 		t.args.weight_limit,
 	)
 }
@@ -424,15 +491,33 @@ fn para_to_para_through_relay_limited_reserve_transfer_assets(
 	let Parachain(para_id) = *t.args.dest.chain_location().last().unwrap() else {
 		unimplemented!("Destination is not a parachain?")
 	};
+	type Runtime = <PenpalB as Chain>::Runtime;
+	let remote_fee_id: AssetId = t
+		.args
+		.assets
+		.clone()
+		.into_inner()
+		.get(t.args.fee_asset_item as usize)
+		.ok_or(pallet_xcm::Error::<Runtime>::Empty)?
+		.clone()
+		.id;
+
+	let relay_location = VersionedLocation::from(Location::parent());
 	Kusama::ext_wrapper(|| {
 		Dmp::make_parachain_reachable(para_id);
 	});
-	<PenpalA as PenpalAPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+	<PenpalA as PenpalAPallet>::PolkadotXcm::transfer_assets_using_type_and_then(
 		t.signed_origin,
 		bx!(t.args.dest.into()),
-		bx!(t.args.beneficiary.into()),
 		bx!(t.args.assets.into()),
-		t.args.fee_asset_item,
+		bx!(TransferType::RemoteReserve(relay_location.clone())),
+		bx!(remote_fee_id.into()),
+		bx!(TransferType::RemoteReserve(relay_location)),
+		bx!(VersionedXcm::from(
+			Xcm::<()>::builder_unsafe()
+				.deposit_asset(AllCounted(1), t.args.beneficiary)
+				.build()
+		)),
 		t.args.weight_limit,
 	)
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
@@ -110,7 +110,9 @@ fn send_ksm_from_asset_hub_kusama_to_asset_hub_polkadot() {
 		let destination = asset_hub_polkadot_location();
 		let assets: Assets = (ksm_at_ah_kusama_latest, amount).into();
 		let fee_idx = 0;
-		assert_ok!(send_assets_from_asset_hub_kusama(destination, assets, fee_idx));
+		let transfer_type = TransferType::LocalReserve;
+
+		assert_ok!(send_assets_from_asset_hub_kusama(destination, assets, fee_idx, transfer_type));
 	});
 
 	// verify expected events on final destination
@@ -189,7 +191,9 @@ fn send_back_dot_usdt_and_weth_from_asset_hub_kusama_to_asset_hub_polkadot() {
 		let destination = asset_hub_polkadot_location();
 		let assets: Assets = (bridged_dot_at_ah_kusama_latest, amount_to_send).into();
 		let fee_idx = 0;
-		assert_ok!(send_assets_from_asset_hub_kusama(destination, assets, fee_idx));
+		let transfer_type = TransferType::DestinationReserve;
+
+		assert_ok!(send_assets_from_asset_hub_kusama(destination, assets, fee_idx, transfer_type));
 	});
 
 	AssetHubPolkadot::execute_with(|| {

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
@@ -164,19 +164,36 @@ pub(crate) fn send_assets_from_asset_hub_kusama(
 	destination: Location,
 	assets: Assets,
 	fee_idx: u32,
+	// For knowing what reserve to pick.
+	// We only allow using the same transfer type for assets and fees right now.
+	// And only `LocalReserve` or `DestinationReserve`.
+	transfer_type: TransferType,
 ) -> DispatchResult {
 	let signed_origin =
 		<AssetHubKusama as Chain>::RuntimeOrigin::signed(AssetHubKusamaSender::get());
 	let beneficiary: Location =
 		AccountId32Junction { network: None, id: AssetHubPolkadotReceiver::get().into() }.into();
 
+	type Runtime = <AssetHubPolkadot as Chain>::Runtime;
+	let remote_fee_id: AssetId = assets
+		.clone()
+		.into_inner()
+		.get(fee_idx as usize)
+		.ok_or(pallet_xcm::Error::<Runtime>::Empty)?
+		.clone()
+		.id;
+
 	AssetHubKusama::execute_with(|| {
-		<AssetHubKusama as AssetHubKusamaPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+		<AssetHubKusama as AssetHubKusamaPallet>::PolkadotXcm::transfer_assets_using_type_and_then(
 			signed_origin,
 			bx!(destination.into()),
-			bx!(beneficiary.into()),
 			bx!(assets.into()),
-			fee_idx,
+			bx!(transfer_type.clone()),
+			bx!(remote_fee_id.into()),
+			bx!(transfer_type),
+			bx!(VersionedXcm::from(
+				Xcm::<()>::builder_unsafe().deposit_asset(AllCounted(1), beneficiary).build()
+			)),
 			WeightLimit::Unlimited,
 		)
 	})

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/send_xcm.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/send_xcm.rs
@@ -85,7 +85,8 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 		send_assets_from_asset_hub_kusama(
 			destination.clone(),
 			(native_token.clone(), amount).into(),
-			0
+			0,
+			TransferType::LocalReserve
 		),
 		DispatchError::Module(sp_runtime::ModuleError {
 			index: 31,
@@ -106,7 +107,8 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	assert_ok!(send_assets_from_asset_hub_kusama(
 		destination.clone(),
 		(native_token.clone(), amount).into(),
-		0
+		0,
+		TransferType::LocalReserve
 	));
 
 	// `ExportMessage` on local BridgeHub - fails - remote BridgeHub version not known
@@ -124,7 +126,8 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	assert_ok!(send_assets_from_asset_hub_kusama(
 		destination.clone(),
 		(native_token.clone(), amount).into(),
-		0
+		0,
+		TransferType::LocalReserve
 	));
 	assert_bridge_hub_kusama_message_accepted(true);
 	assert_bridge_hub_polkadot_message_received();

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
@@ -125,7 +125,14 @@ fn send_dot_usdt_and_weth_from_asset_hub_polkadot_to_asset_hub_kusama() {
 		let destination = asset_hub_kusama_location();
 		let assets: Assets = (dot_at_asset_hub_polkadot_latest, amount).into();
 		let fee_idx = 0;
-		assert_ok!(send_assets_from_asset_hub_polkadot(destination, assets, fee_idx));
+		let transfer_type = TransferType::LocalReserve;
+
+		assert_ok!(send_assets_from_asset_hub_polkadot(
+			destination,
+			assets,
+			fee_idx,
+			transfer_type
+		));
 	});
 
 	// verify expected events on final destination
@@ -286,7 +293,14 @@ fn send_back_ksm_from_asset_hub_polkadot_to_asset_hub_kusama() {
 		let assets: Assets =
 			(bridged_ksm_at_asset_hub_polkadot_latest.clone(), amount_to_send).into();
 		let fee_idx = 0;
-		assert_ok!(send_assets_from_asset_hub_polkadot(destination, assets, fee_idx));
+		let transfer_type = TransferType::DestinationReserve;
+
+		assert_ok!(send_assets_from_asset_hub_polkadot(
+			destination,
+			assets,
+			fee_idx,
+			transfer_type
+		));
 	});
 
 	AssetHubKusama::execute_with(|| {

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -111,19 +111,36 @@ pub(crate) fn send_assets_from_asset_hub_polkadot(
 	destination: Location,
 	assets: Assets,
 	fee_idx: u32,
+	// For knowing what reserve to pick.
+	// We only allow using the same transfer type for assets and fees right now.
+	// And only `LocalReserve` or `DestinationReserve`.
+	transfer_type: TransferType,
 ) -> DispatchResult {
 	let signed_origin =
 		<AssetHubPolkadot as Chain>::RuntimeOrigin::signed(AssetHubPolkadotSender::get());
 	let beneficiary: Location =
 		AccountId32Junction { network: None, id: AssetHubKusamaReceiver::get().into() }.into();
 
+	type Runtime = <AssetHubPolkadot as Chain>::Runtime;
+	let remote_fee_id: AssetId = assets
+		.clone()
+		.into_inner()
+		.get(fee_idx as usize)
+		.ok_or(pallet_xcm::Error::<Runtime>::Empty)?
+		.clone()
+		.id;
+
 	AssetHubPolkadot::execute_with(|| {
-		<AssetHubPolkadot as AssetHubPolkadotPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+		<AssetHubPolkadot as AssetHubPolkadotPallet>::PolkadotXcm::transfer_assets_using_type_and_then(
 			signed_origin,
 			bx!(destination.into()),
-			bx!(beneficiary.into()),
 			bx!(assets.into()),
-			fee_idx,
+			bx!(transfer_type.clone()),
+			bx!(remote_fee_id.into()),
+			bx!(transfer_type),
+			bx!(VersionedXcm::from(
+				Xcm::<()>::builder_unsafe().deposit_asset(AllCounted(1), beneficiary).build()
+			)),
 			WeightLimit::Unlimited,
 		)
 	})

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/send_xcm.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/send_xcm.rs
@@ -85,7 +85,8 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 		send_assets_from_asset_hub_polkadot(
 			destination.clone(),
 			(native_token.clone(), amount).into(),
-			0
+			0,
+			TransferType::LocalReserve
 		),
 		DispatchError::Module(sp_runtime::ModuleError {
 			index: 31,
@@ -106,7 +107,8 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	assert_ok!(send_assets_from_asset_hub_polkadot(
 		destination.clone(),
 		(native_token.clone(), amount).into(),
-		0
+		0,
+		TransferType::LocalReserve
 	));
 
 	// `ExportMessage` on local BridgeHub - fails - remote BridgeHub version not known
@@ -124,7 +126,8 @@ fn send_xcm_through_opened_lane_with_different_xcm_version_on_hops_works() {
 	assert_ok!(send_assets_from_asset_hub_polkadot(
 		destination.clone(),
 		(native_token.clone(), amount).into(),
-		0
+		0,
+		TransferType::LocalReserve
 	));
 	assert_bridge_hub_polkadot_message_accepted(true);
 	assert_bridge_hub_kusama_message_received();

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge.rs
@@ -823,17 +823,21 @@ fn transfer_relay_token() {
 			[GlobalConsensus(Ethereum { chain_id: CHAIN_ID })],
 		));
 
-		let beneficiary = VersionedLocation::V5(Location::new(
-			0,
-			[AccountKey20 { network: None, key: ETHEREUM_DESTINATION_ADDRESS }],
-		));
+		let beneficiary =
+			Location::new(0, [AccountKey20 { network: None, key: ETHEREUM_DESTINATION_ADDRESS }]);
 
-		assert_ok!(<AssetHubPolkadot as AssetHubPolkadotPallet>::PolkadotXcm::limited_reserve_transfer_assets(
+		assert_ok!(<AssetHubPolkadot as AssetHubPolkadotPallet>::PolkadotXcm::transfer_assets_using_type_and_then(
 			RuntimeOrigin::signed(AssetHubPolkadotSender::get()),
 			Box::new(destination),
-			Box::new(beneficiary),
 			Box::new(versioned_assets),
-			0,
+			Box::new(TransferType::LocalReserve),
+			Box::new(VersionedAssetId::from(AssetId(Location::parent()))),
+			Box::new(TransferType::LocalReserve),
+			Box::new(VersionedXcm::from(
+				Xcm::<()>::builder_unsafe()
+					.deposit_asset(AllCounted(1), beneficiary)
+					.build()
+			)),
 			Unlimited,
 		));
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -2111,11 +2111,7 @@ mod benches {
 		}
 
 		fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
-			// Relay can reserve transfer native token to some random parachain.
-			Some((
-				Asset { fun: Fungible(ExistentialDeposit::get()), id: AssetId(Here.into()) },
-				Parachain(RandomParaId::get().into()).into(),
-			))
+			None
 		}
 
 		fn set_up_complex_asset_transfer(

--- a/relay/kusama/src/weights/pallet_xcm.rs
+++ b/relay/kusama/src/weights/pallet_xcm.rs
@@ -92,29 +92,15 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: `XcmPallet::ShouldRecordXcm` (r:1 w:0)
-	/// Proof: `XcmPallet::ShouldRecordXcm` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `System::Account` (r:1 w:1)
-	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
-	/// Storage: `Dmp::DeliveryFeeFactor` (r:1 w:0)
-	/// Proof: `Dmp::DeliveryFeeFactor` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `XcmPallet::SupportedVersion` (r:1 w:0)
-	/// Proof: `XcmPallet::SupportedVersion` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Dmp::DownwardMessageQueues` (r:1 w:1)
-	/// Proof: `Dmp::DownwardMessageQueues` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Paras::Heads` (r:1 w:0)
-	/// Proof: `Paras::Heads` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Dmp::DownwardMessageQueueHeads` (r:1 w:1)
-	/// Proof: `Dmp::DownwardMessageQueueHeads` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Benchmark::Override` (r:0 w:0)
+	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn reserve_transfer_assets() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `197`
-		//  Estimated: `3662`
-		// Minimum execution time: 178_990_000 picoseconds.
-		Weight::from_parts(182_750_000, 0)
-			.saturating_add(Weight::from_parts(0, 3662))
-			.saturating_add(T::DbWeight::get().reads(7))
-			.saturating_add(T::DbWeight::get().writes(3))
+			// Proof Size summary in bytes:
+			//  Measured:  `0`
+			//  Estimated: `0`
+			// Minimum execution time: 18_446_744_073_709_551_000 picoseconds.
+			Weight::from_parts(18_446_744_073_709_551_000, 0)
+					.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: `System::Account` (r:1 w:1)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1878,11 +1878,7 @@ mod benches {
 		}
 
 		fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
-			// Relay can reserve transfer native token to some random parachain.
-			Some((
-				Asset { fun: Fungible(ExistentialDeposit::get()), id: AssetId(Here.into()) },
-				Parachain(RandomParaId::get().into()).into(),
-			))
+			None
 		}
 
 		fn set_up_complex_asset_transfer(

--- a/relay/polkadot/src/weights/pallet_xcm.rs
+++ b/relay/polkadot/src/weights/pallet_xcm.rs
@@ -92,29 +92,15 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
-	/// Storage: `XcmPallet::ShouldRecordXcm` (r:1 w:0)
-	/// Proof: `XcmPallet::ShouldRecordXcm` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `System::Account` (r:1 w:1)
-	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
-	/// Storage: `Dmp::DeliveryFeeFactor` (r:1 w:0)
-	/// Proof: `Dmp::DeliveryFeeFactor` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `XcmPallet::SupportedVersion` (r:1 w:0)
-	/// Proof: `XcmPallet::SupportedVersion` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Dmp::DownwardMessageQueues` (r:1 w:1)
-	/// Proof: `Dmp::DownwardMessageQueues` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Paras::Heads` (r:1 w:0)
-	/// Proof: `Paras::Heads` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `Dmp::DownwardMessageQueueHeads` (r:1 w:1)
-	/// Proof: `Dmp::DownwardMessageQueueHeads` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `Benchmark::Override` (r:0 w:0)
+	/// Proof: `Benchmark::Override` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn reserve_transfer_assets() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `231`
-		//  Estimated: `3696`
-		// Minimum execution time: 175_259_000 picoseconds.
-		Weight::from_parts(182_670_000, 0)
-			.saturating_add(Weight::from_parts(0, 3696))
-			.saturating_add(T::DbWeight::get().reads(7))
-			.saturating_add(T::DbWeight::get().writes(3))
+			// Proof Size summary in bytes:
+			//  Measured:  `0`
+			//  Estimated: `0`
+			// Minimum execution time: 18_446_744_073_709_551_000 picoseconds.
+			Weight::from_parts(18_446_744_073_709_551_000, 0)
+					.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: `System::Account` (r:1 w:1)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -1396,9 +1396,28 @@ mod benches {
 		}
 
 		fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
-			// AH can reserve transfer native token to some random parachain.
+			// We get an account to create USDT and give it enough WND to exist.
+			let account = frame_benchmarking::whitelisted_caller();
+			assert_ok!(<Balances as fungible::Mutate<_>>::mint_into(
+				&account,
+				ExistentialDeposit::get() + (1_000 * UNITS)
+			));
+
+			// We then create USDT.
+			let usdt_id = 1984u32;
+			let usdt_location =
+				Location::new(0, [PalletInstance(50), GeneralIndex(usdt_id.into())]);
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				usdt_id.into(),
+				account.clone().into(),
+				true,
+				1
+			));
+
+			// And return USDT as the reserve transferable asset.
 			Some((
-				Asset { fun: Fungible(ExistentialDeposit::get()), id: AssetId(Parent.into()) },
+				Asset { fun: Fungible(ExistentialDeposit::get()), id: AssetId(usdt_location) },
 				ParentThen(Parachain(RandomParaId::get().into()).into()).into(),
 			))
 		}

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1283,9 +1283,28 @@ mod benches {
 		}
 
 		fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
-			// AH can reserve transfer native token to some random parachain.
+			// We get an account to create USDT and give it enough WND to exist.
+			let account = frame_benchmarking::whitelisted_caller();
+			assert_ok!(<Balances as fungible::Mutate<_>>::mint_into(
+				&account,
+				ExistentialDeposit::get() + (1_000 * UNITS)
+			));
+
+			// We then create USDT.
+			let usdt_id = 1984u32;
+			let usdt_location =
+				Location::new(0, [PalletInstance(50), GeneralIndex(usdt_id.into())]);
+			assert_ok!(Assets::force_create(
+				RuntimeOrigin::root(),
+				usdt_id.into(),
+				account.clone().into(),
+				true,
+				1
+			));
+
+			// And return USDT as the reserve transferable asset.
 			Some((
-				Asset { fun: Fungible(ExistentialDeposit::get()), id: AssetId(Parent.into()) },
+				Asset { fun: Fungible(ExistentialDeposit::get()), id: AssetId(usdt_location) },
 				ParentThen(Parachain(RandomParaId::get().into()).into()).into(),
 			))
 		}


### PR DESCRIPTION
Update of pallet-xcm in order integrate changes from https://github.com/paritytech/polkadot-sdk/pull/9544

New version of `pallet-xcm` was published from `unstable2507` (https://github.com/paritytech/polkadot-sdk/pull/9643)

TODO:
- [x] migrate tests using `reserve_transfer_assets`,  `limited_reserve_transfer_assets` to `transfer_assets_using_type_and_then`
- [x] fix `reserve_transferable_asset_and_dest` benchmarks to use USDT instead of DOT
- [x] update `reserve_transfer_assets` weights to `Weight::MAX` for relays
- [x] add changelog entry