### PR TITLE
[AHM] Unused benchmarks cleanup to get compile

### DIFF
--- a/.github/scripts/cmd/cmd.py
+++ b/.github/scripts/cmd/cmd.py
@@ -90,15 +90,7 @@ if args.command == 'bench':
     # loop over remaining runtimes to collect available pallets
     for runtime in runtimesMatrix.values():
         print(f'-- compiling the runtime {runtime["name"]}')
-        features = "runtime-benchmarks"
-        # TODO: temporary hack for AHM - start...
-        if runtime["name"] in ["kusama", "asset-hub-kusama"]:
-            features += ",kusama-ahm"
-        if runtime["name"] in ["polkadot", "asset-hub-polkadot"]:
-            features += ",polkadot-ahm"
-        # ...end
-        print(f'-- with features {features}')
-        os.system(f"cargo build -p {runtime['package']} --profile {profile} -q --features {features}")
+        os.system(f"cargo build -p {runtime['package']} --profile {profile} -q --features runtime-benchmarks")
         print(f'-- listing pallets for benchmark for {runtime["name"]}')
         wasm_file = f"target/{profile}/wbuild/{runtime['package']}/{runtime['package'].replace('-', '_')}.wasm"
         output = os.popen(

--- a/.github/scripts/cmd/cmd.py
+++ b/.github/scripts/cmd/cmd.py
@@ -90,7 +90,15 @@ if args.command == 'bench':
     # loop over remaining runtimes to collect available pallets
     for runtime in runtimesMatrix.values():
         print(f'-- compiling the runtime {runtime["name"]}')
-        os.system(f"cargo build -p {runtime['package']} --profile {profile} -q --features runtime-benchmarks")
+        features = "runtime-benchmarks"
+        # TODO: temporary hack for AHM - start...
+        if runtime["name"] in ["kusama", "asset-hub-kusama"]:
+            features += ",kusama-ahm"
+        if runtime["name"] in ["polkadot", "asset-hub-polkadot"]:
+            features += ",polkadot-ahm"
+        # ...end
+        print(f'-- with features {features}')
+        os.system(f"cargo build -p {runtime['package']} --profile {profile} -q --features {features}")
         print(f'-- listing pallets for benchmark for {runtime["name"]}')
         wasm_file = f"target/{profile}/wbuild/{runtime['package']}/{runtime['package'].replace('-', '_')}.wasm"
         output = os.popen(

--- a/integration-tests/emulated/tests/people/people-kusama/src/tests/governance.rs
+++ b/integration-tests/emulated/tests/people/people-kusama/src/tests/governance.rs
@@ -100,7 +100,9 @@ fn asset_hub_commands_add_registrar() {
 				});
 
 			let xcm_message = RuntimeCall::PolkadotXcm(pallet_xcm::Call::<Runtime>::send {
-				dest: bx!(VersionedLocation::from(AssetHubKusama::sibling_location_of(PeopleKusama::para_id()))),
+				dest: bx!(VersionedLocation::from(AssetHubKusama::sibling_location_of(
+					PeopleKusama::para_id()
+				))),
 				message: bx!(VersionedXcm::from(Xcm(vec![
 					UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 					Transact {

--- a/integration-tests/emulated/tests/people/people-polkadot/src/tests/governance.rs
+++ b/integration-tests/emulated/tests/people/people-polkadot/src/tests/governance.rs
@@ -100,7 +100,9 @@ fn asset_hub_commands_add_registrar() {
 				});
 
 			let xcm_message = RuntimeCall::PolkadotXcm(pallet_xcm::Call::<Runtime>::send {
-				dest: bx!(VersionedLocation::from(AssetHubPolkadot::sibling_location_of(PeoplePolkadot::para_id()))),
+				dest: bx!(VersionedLocation::from(AssetHubPolkadot::sibling_location_of(
+					PeoplePolkadot::para_id()
+				))),
 				message: bx!(VersionedXcm::from(Xcm(vec![
 					UnpaidExecution { weight_limit: Unlimited, check_origin: None },
 					Transact {

--- a/pallets/rc-migrator/src/weights_ah.rs
+++ b/pallets/rc-migrator/src/weights_ah.rs
@@ -80,7 +80,6 @@ pub trait WeightInfo {
 	fn receive_preimage_chunk(m: u32, ) -> Weight;
 	fn receive_child_bounties_messages(n: u32, ) -> Weight;
 	fn receive_staking_messages(n: u32, ) -> Weight;
-	fn receive_recovery_messages(n: u32, ) -> Weight;
 	fn force_set_stage() -> Weight;
 	fn start_migration() -> Weight;
 	fn finish_migration() -> Weight;
@@ -508,19 +507,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(5_192_578, 0)
 			// Standard Error: 7_826
 			.saturating_add(Weight::from_parts(5_919_220, 0).saturating_mul(n.into()))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-	}
-	/// Storage: `Recovery::ActiveRecoveries` (r:0 w:255)
-	/// Proof: `Recovery::ActiveRecoveries` (`max_values`: None, `max_size`: Some(389), added: 2864, mode: `MaxEncodedLen`)
-	/// The range of component `n` is `[1, 255]`.
-	fn receive_recovery_messages(n: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 6_000_000 picoseconds.
-		Weight::from_parts(7_000_000, 0)
-			// Standard Error: 4_879
-			.saturating_add(Weight::from_parts(1_674_577, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
 	}
 	/// Storage: `AhMigrator::AhMigrationStage` (r:1 w:1)
@@ -1033,19 +1019,6 @@ impl WeightInfo for () {
 		Weight::from_parts(5_192_578, 0)
 			// Standard Error: 7_826
 			.saturating_add(Weight::from_parts(5_919_220, 0).saturating_mul(n.into()))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(n.into())))
-	}
-	/// Storage: `Recovery::ActiveRecoveries` (r:0 w:255)
-	/// Proof: `Recovery::ActiveRecoveries` (`max_values`: None, `max_size`: Some(389), added: 2864, mode: `MaxEncodedLen`)
-	/// The range of component `n` is `[1, 255]`.
-	fn receive_recovery_messages(n: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 6_000_000 picoseconds.
-		Weight::from_parts(7_000_000, 0)
-			// Standard Error: 4_879
-			.saturating_add(Weight::from_parts(1_674_577, 0).saturating_mul(n.into()))
 			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(n.into())))
 	}
 	/// Storage: `AhMigrator::AhMigrationStage` (r:1 w:1)

--- a/relay/kusama/src/weights/pallet_ah_migrator.rs
+++ b/relay/kusama/src/weights/pallet_ah_migrator.rs
@@ -496,20 +496,6 @@ impl<T: crate::ah_migration::weights::DbConfig> pallet_rc_migrator::weights_ah::
 			.saturating_add(Weight::from_parts(6_227_744, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
 	}
-	/// Storage: `Recovery::ActiveRecoveries` (r:0 w:255)
-	/// Proof: `Recovery::ActiveRecoveries` (`max_values`: None, `max_size`: Some(389), added: 2864, mode: `MaxEncodedLen`)
-	/// The range of component `n` is `[1, 255]`.
-	fn receive_recovery_messages(n: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 6_000_000 picoseconds.
-		Weight::from_parts(7_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 0))
-			// Standard Error: 3_916
-			.saturating_add(Weight::from_parts(1_712_344, 0).saturating_mul(n.into()))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-	}
 	/// Storage: `AhMigrator::AhMigrationStage` (r:1 w:1)
 	/// Proof: `AhMigrator::AhMigrationStage` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
 	/// Storage: `AhMigrator::MigrationStartBlock` (r:0 w:1)

--- a/relay/polkadot/src/weights/pallet_ah_migrator.rs
+++ b/relay/polkadot/src/weights/pallet_ah_migrator.rs
@@ -67,9 +67,6 @@ impl<T: crate::ah_migration::weights::DbConfig> pallet_rc_migrator::weights_ah::
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
 			.saturating_add(Weight::from_parts(0, 2603).saturating_mul(n.into()))
 	}
-	fn receive_recovery_messages(n: u32, ) -> Weight {
-		Weight::MAX // not used on Polkadot
-	}
 	/// Storage: `System::Account` (r:255 w:255)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Holds` (r:255 w:255)

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/weights/pallet_ah_migrator.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/weights/pallet_ah_migrator.rs
@@ -470,19 +470,6 @@ impl<T: frame_system::Config> pallet_ah_migrator::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(5_959_007, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
 	}
-	/// Storage: `Recovery::ActiveRecoveries` (r:0 w:255)
-	/// Proof: `Recovery::ActiveRecoveries` (`max_values`: None, `max_size`: Some(389), added: 2864, mode: `MaxEncodedLen`)
-	/// The range of component `n` is `[1, 255]`.
-	fn receive_recovery_messages(n: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 6_000_000 picoseconds.
-		Weight::from_parts(1_430_963, 0)
-			// Standard Error: 3_829
-			.saturating_add(Weight::from_parts(1_705_136, 0).saturating_mul(n.into()))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-	}
 	/// Storage: `AhMigrator::AhMigrationStage` (r:1 w:1)
 	/// Proof: `AhMigrator::AhMigrationStage` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
 	/// Storage: `AhMigrator::MigrationStartBlock` (r:0 w:1)

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_ah_migrator.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_ah_migrator.rs
@@ -470,19 +470,6 @@ impl<T: frame_system::Config> pallet_ah_migrator::WeightInfo for WeightInfo<T> {
 			.saturating_add(Weight::from_parts(5_950_971, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
 	}
-	/// Storage: `Recovery::ActiveRecoveries` (r:0 w:255)
-	/// Proof: `Recovery::ActiveRecoveries` (`max_values`: None, `max_size`: Some(389), added: 2864, mode: `MaxEncodedLen`)
-	/// The range of component `n` is `[1, 255]`.
-	fn receive_recovery_messages(n: u32, ) -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 6_000_000 picoseconds.
-		Weight::from_parts(7_000_000, 0)
-			// Standard Error: 4_338
-			.saturating_add(Weight::from_parts(1_723_522, 0).saturating_mul(n.into()))
-			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-	}
 	/// Storage: `AhMigrator::AhMigrationStage` (r:1 w:1)
 	/// Proof: `AhMigrator::AhMigrationStage` (`max_values`: Some(1), `max_size`: Some(1), added: 496, mode: `MaxEncodedLen`)
 	/// Storage: `AhMigrator::MigrationStartBlock` (r:0 w:1)


### PR DESCRIPTION
Fresh rc-migrator weights do not compile here: https://github.com/polkadot-fellows/runtimes/pull/887