### PR TITLE
Bump pallet-staking-async to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10024,9 +10024,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-async"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793c01c58d02da9e0a45085e16c4073cdaee5db5d0eb99f8604ca1bec06942dd"
+checksum = "e5d5c8a8b7fe985017cba08e074e1f0c55ecc9bb93950a8478396eea4f93c634"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ pallet-ah-migrator = { path = "pallets/ah-migrator", default-features = false }
 pallet-rc-migrator = { path = "pallets/rc-migrator", default-features = false }
 pallet-ah-ops = { path = "pallets/ah-ops", default-features = false }
 pallet-election-provider-multi-block = { version = "0.3.0", default-features = false }
-pallet-staking-async = { version = "0.4.0", default-features = false }
+pallet-staking-async = { version = "0.4.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 rand = { version = "0.9.2" }
 impl-trait-for-tuples = { version = "0.2.3", default-features = false }


### PR DESCRIPTION
Bumping pallet-staking-async from version 0.4.0 to 0.4.1

This change updates the dependency version in the root Cargo.toml file.