### PR TITLE
Bump pallet-balances to 43.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8708,9 +8708,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c624f9a10bf1931e9347f0e0a5e8dec4a8813a8290939aefa9f185e8f2d0d252"
+checksum = "54e1d878d53272e0b47d4a55170ea6966b97ccc6f83107cf6173407c6407c730"
 dependencies = [
  "docify",
  "frame-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ pallet-authority-discovery = { version = "42.0.0", default-features = false }
 pallet-authorship = { version = "42.0.0", default-features = false }
 pallet-babe = { version = "42.0.0", default-features = false }
 pallet-bags-list = { version = "41.0.0", default-features = false }
-pallet-balances = { version = "43.0.0", default-features = false }
+pallet-balances = { version = "43.0.1", default-features = false }
 pallet-beefy = { version = "43.0.0", default-features = false }
 pallet-beefy-mmr = { version = "43.0.0", default-features = false }
 pallet-bounties = { version = "41.0.0", default-features = false }


### PR DESCRIPTION
Bump pallet-balances to include SDK PR [#9789](https://github.com/paritytech/polkadot-sdk/pull/9789).
