### PR TITLE
Simple multisig for cancelling and pausing migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15611,6 +15611,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "hex",
  "hex-literal",
  "kusama-runtime-constants",
  "log",

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -1305,20 +1305,21 @@ pub mod pallet {
 		#[pallet::weight({ Weight::from_parts(10_000_000, 1000) })]
 		pub fn vote_cancel(
 			origin: OriginFor<T>,
-			// payload is only interpreted as "aye"
-			payload: VotePayload,
+			payload: BailVote,
 			_sig: sp_core::sr25519::Signature,
 		) -> DispatchResult {
 			let _ = ensure_none(origin);
 
+			ensure!(CancelRound::<T>::get() == payload.round, "RoundStale");
 			let mut votes = CancelVotes::<T>::get();
-			ensure!(!votes.contains(&payload), "Duplicate");
-			votes.push(payload);
+			ensure!(!votes.contains(&payload.who), "Duplicate");
+			votes.push(payload.who);
 
 			if votes.len() >= 3 {
 				Self::transition(MigrationStage::Pending);
 				Self::deposit_event(Event::MigrationCancelled);
 				CancelVotes::<T>::kill();
+				CancelRound::<T>::mutate(|r| *r += 1);
 			} else {
 				CancelVotes::<T>::put(votes);
 			}
@@ -1330,23 +1331,50 @@ pub mod pallet {
 		#[pallet::weight({ Weight::from_parts(10_000_000, 1000) })]
 		pub fn vote_pause(
 			origin: OriginFor<T>,
-			// payload is only interpreted as "aye"
-			payload: VotePayload,
+			payload: BailVote,
 			_sig: sp_core::sr25519::Signature,
 		) -> DispatchResult {
 			let _ = ensure_none(origin);
 
+			ensure!(PauseRound::<T>::get() == payload.round, "RoundStale");
 			let mut votes = PauseVotes::<T>::get();
-			ensure!(!votes.contains(&payload), "Duplicate");
-			votes.push(payload);
+			ensure!(!votes.contains(&payload.who), "Duplicate");
+			votes.push(payload.who);
 
 			if votes.len() >= 3 {
 				let pause_stage = RcMigrationStage::<T>::get();
 				Self::transition(MigrationStage::MigrationPaused);
 				Self::deposit_event(Event::MigrationPaused { pause_stage });
 				PauseVotes::<T>::kill();
+				PauseRound::<T>::mutate(|r| *r += 1);
 			} else {
 				PauseVotes::<T>::put(votes);
+			}
+
+			Ok(())
+		}
+
+		#[pallet::call_index(15)]
+		#[pallet::weight({ Weight::from_parts(10_000_000, 1000) })]
+		pub fn vote_force_set_stage(
+			origin: OriginFor<T>,
+			payload: Box<ForceSetStageVote<T>>,
+			_sig: sp_core::sr25519::Signature,
+		) -> DispatchResult {
+			let _ = ensure_none(origin);
+
+			ensure!(ForceSetStageRound::<T>::get() == payload.round, "RoundStale");
+			let mut votes_for_stage = ForceSetStageVotes::<T>::get(&payload.stage);
+			ensure!(!votes_for_stage.contains(&payload.who), "Duplicate");
+			votes_for_stage.push(payload.who);
+
+			if votes_for_stage.len() >= 3 {
+				Self::transition(payload.stage);
+				// clear any votes, either in winning or losing stages.
+				let _ = ForceSetStageVotes::<T>::clear(u32::MAX, None);
+				ForceSetStageRound::<T>::mutate(|r| *r += 1);
+			} else {
+				ForceSetStageVotes::<T>::insert(payload.stage, votes_for_stage);
 			}
 
 			Ok(())
@@ -1363,29 +1391,66 @@ pub mod pallet {
 		TypeInfo,
 		sp_core::DecodeWithMemTracking,
 	)]
-	pub struct VotePayload {
+	pub struct BailVote {
 		pub(crate) who: sp_core::sr25519::Public,
+		pub(crate) round: u32,
 	}
 
-	impl VotePayload {
-		pub fn from(who: sp_core::sr25519::Public) -> Self {
-			Self { who }
+	impl BailVote {
+		pub fn from(who: sp_core::sr25519::Public, round: u32) -> Self {
+			Self { round, who }
 		}
-	}
 
-	impl core::convert::AsRef<sp_core::sr25519::Public> for VotePayload {
-		fn as_ref(&self) -> &sp_core::sr25519::Public {
-			&self.who
+		pub fn encode_with_bytes_wrapper(&self) -> Vec<u8> {
+			[b"<Bytes>", &*self.encode(), b"</Bytes>"].concat()
 		}
 	}
 
 	#[pallet::storage]
 	#[pallet::unbounded]
-	pub type CancelVotes<T: Config> = StorageValue<_, Vec<VotePayload>, ValueQuery>;
+	pub type CancelVotes<T: Config> = StorageValue<_, Vec<sp_core::sr25519::Public>, ValueQuery>;
+	#[pallet::storage]
+	pub type CancelRound<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::unbounded]
-	pub type PauseVotes<T: Config> = StorageValue<_, Vec<VotePayload>, ValueQuery>;
+	pub type PauseVotes<T: Config> = StorageValue<_, Vec<sp_core::sr25519::Public>, ValueQuery>;
+	#[pallet::storage]
+	pub type PauseRound<T: Config> = StorageValue<_, u32, ValueQuery>;
+
+	#[derive(
+		Encode,
+		Decode,
+		DebugNoBound,
+		CloneNoBound,
+		PartialEqNoBound,
+		EqNoBound,
+		TypeInfo,
+		sp_core::DecodeWithMemTracking,
+	)]
+	#[scale_info(skip_type_params(T))]
+	pub struct ForceSetStageVote<T: Config> {
+		pub(crate) round: u32,
+		pub(crate) who: sp_core::sr25519::Public,
+		pub(crate) stage: MigrationStageOf<T>,
+	}
+
+	impl<T: Config> ForceSetStageVote<T> {
+		pub fn new(who: sp_core::sr25519::Public, round: u32, stage: MigrationStageOf<T>) -> Self {
+			Self { who, round, stage }
+		}
+
+		pub fn encode_with_bytes_wrapper(&self) -> Vec<u8> {
+			[b"<Bytes>", &*self.encode(), b"</Bytes>"].concat()
+		}
+	}
+
+	#[pallet::storage]
+	pub type ForceSetStageRound<T: Config> = StorageValue<_, u32, ValueQuery>;
+	#[pallet::storage]
+	#[pallet::unbounded]
+	pub type ForceSetStageVotes<T: Config> =
+		StorageMap<_, Twox64Concat, MigrationStageOf<T>, Vec<sp_core::sr25519::Public>, ValueQuery>;
 
 	#[pallet::validate_unsigned]
 	impl<T: Config> ValidateUnsigned for Pallet<T> {
@@ -1396,19 +1461,58 @@ pub mod pallet {
 			match call {
 				// note: payload can be empty, but it is better to ask the signer to revel
 				// themselves, so we don't have to check against all of `MultisigMembers`.
-				Call::vote_cancel { payload, sig } | Call::vote_pause { payload, sig } =>
-					if T::MultisigMembers::get().contains(&payload.who) &&
-						sig.verify(&payload.encode()[..], &payload.who)
-					{
-						ValidTransaction::with_tag_prefix("AhmMultisig")
-							.priority(sp_runtime::traits::Bounded::max_value())
-							.and_provides(vec![("ahm_multi", payload.who).encode()])
-							.propagate(true)
-							.longevity(10)
-							.build()
-					} else {
-						InvalidTransaction::BadProof.into()
-					},
+				Call::vote_cancel { payload, sig } => {
+					if !T::MultisigMembers::get().contains(&payload.who) {
+						return InvalidTransaction::BadSigner.into()
+					}
+					if !sig.verify(&payload.encode_with_bytes_wrapper()[..], &payload.who) {
+						return InvalidTransaction::BadProof.into()
+					}
+					if CancelRound::<T>::get() != payload.round {
+						return InvalidTransaction::Stale.into()
+					}
+					ValidTransaction::with_tag_prefix("AhmMultisig")
+						.priority(sp_runtime::traits::Bounded::max_value())
+						.and_provides(vec![("ahm_multi", payload.who).encode()])
+						.propagate(true)
+						.longevity(30)
+						.build()
+				},
+				Call::vote_pause { payload, sig } => {
+					if !T::MultisigMembers::get().contains(&payload.who) {
+						return InvalidTransaction::BadSigner.into()
+					}
+					if !sig.verify(&payload.encode_with_bytes_wrapper()[..], &payload.who) {
+						return InvalidTransaction::BadProof.into()
+					}
+					if PauseRound::<T>::get() != payload.round {
+						return InvalidTransaction::Stale.into()
+					}
+
+					ValidTransaction::with_tag_prefix("AhmMultisig")
+						.priority(sp_runtime::traits::Bounded::max_value())
+						.and_provides(vec![("ahm_multi", payload.who).encode()])
+						.propagate(true)
+						.longevity(30)
+						.build()
+				},
+				Call::vote_force_set_stage { payload, sig } => {
+					if !T::MultisigMembers::get().contains(&payload.who) {
+						return InvalidTransaction::BadSigner.into()
+					}
+					if !sig.verify(&payload.encode_with_bytes_wrapper()[..], &payload.who) {
+						return InvalidTransaction::BadProof.into()
+					}
+					if ForceSetStageRound::<T>::get() != payload.round {
+						return InvalidTransaction::Stale.into()
+					}
+					ValidTransaction::with_tag_prefix("AhmMultisig")
+						.priority(sp_runtime::traits::Bounded::max_value())
+						.and_provides(vec![("ahm_multi", payload.who).encode()])
+						.propagate(true)
+						.longevity(30)
+						.build()
+				},
 				_ => return InvalidTransaction::Call.into(),
 			}
 		}

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -77,7 +77,7 @@ use frame_support::{
 		schedule::DispatchTime,
 		tokens::{Fortitude, Pay, Precision, Preservation},
 		Contains, Defensive, DefensiveTruncateFrom, EnqueueMessage, LockableCurrency,
-		ReservableCurrency, VariantCount,
+		ReservableCurrency, UnfilteredDispatchable, VariantCount,
 	},
 	weights::{Weight, WeightMeter},
 	PalletId,
@@ -500,9 +500,14 @@ pub mod pallet {
 	{
 		/// The overall runtime origin type.
 		type RuntimeOrigin: Into<Result<pallet_xcm::Origin, <Self as Config>::RuntimeOrigin>>
-			+ IsType<<Self as frame_system::Config>::RuntimeOrigin>;
+			+ IsType<<Self as frame_system::Config>::RuntimeOrigin>
+			+ From<frame_system::RawOrigin<Self::AccountId>>;
 		/// The overall runtime call type.
-		type RuntimeCall: From<Call<Self>> + IsType<<Self as pallet_xcm::Config>::RuntimeCall>;
+		type RuntimeCall: From<Call<Self>>
+			+ IsType<<Self as pallet_xcm::Config>::RuntimeCall>
+			+ UnfilteredDispatchable<RuntimeOrigin = <Self as Config>::RuntimeOrigin>
+			+ Member
+			+ Parameter;
 		/// The runtime hold reasons.
 		type RuntimeHoldReason: Parameter
 			+ VariantCount
@@ -622,7 +627,11 @@ pub mod pallet {
 		/// This configuration can be overridden by a storage item [`AhUmpQueuePriorityConfig`].
 		type AhUmpQueuePriorityPattern: Get<(BlockNumberFor<Self>, BlockNumberFor<Self>)>;
 
+		/// Members of an multisig that can be submit unsigned txs and act as the manager.
 		type MultisigMembers: Get<Vec<sp_core::sr25519::Public>>;
+
+		/// Threshold of `MultisigMembers`.
+		type MultisigThreshold: Get<u32>;
 	}
 
 	#[pallet::error]
@@ -766,6 +775,8 @@ pub mod pallet {
 			/// The number of indexed pure accounts.
 			num_pure_accounts: u32,
 		},
+		/// The manager multisig dispatched something
+		ManagerMultisigDispatched { res: DispatchResult },
 	}
 
 	/// The Relay Chain migration state.
@@ -1303,120 +1314,42 @@ pub mod pallet {
 
 		#[pallet::call_index(13)]
 		#[pallet::weight({ Weight::from_parts(10_000_000, 1000) })]
-		pub fn vote_cancel(
+		pub fn vote_manager_multisig(
 			origin: OriginFor<T>,
-			payload: BailVote,
+			payload: Box<ManagerMultisigVote<T>>,
 			_sig: sp_core::sr25519::Signature,
 		) -> DispatchResult {
 			let _ = ensure_none(origin);
 
-			ensure!(CancelRound::<T>::get() == payload.round, "RoundStale");
-			let mut votes = CancelVotes::<T>::get();
-			ensure!(!votes.contains(&payload.who), "Duplicate");
-			votes.push(payload.who);
+			ensure!(ManagerMultisigRound::<T>::get() == payload.round, "RoundStale");
+			let mut votes_for_call = ManagerMultisigs::<T>::get(&payload.call);
+			ensure!(!votes_for_call.contains(&payload.who), "Duplicate");
+			votes_for_call.push(payload.who.clone());
 
-			if votes.len() >= 3 {
-				Self::transition(MigrationStage::Pending);
-				Self::deposit_event(Event::MigrationCancelled);
-				CancelVotes::<T>::kill();
-				CancelRound::<T>::mutate(|r| *r += 1);
+			if votes_for_call.len() >= T::MultisigThreshold::get() as usize {
+				let origin: <T as Config>::RuntimeOrigin =
+					frame_system::RawOrigin::Signed(Self::manager_multisig_id()).into();
+				let call = payload.call.clone();
+				let res = call.dispatch_bypass_filter(origin);
+				let _ = ManagerMultisigs::<T>::clear(u32::MAX, None);
+				Self::deposit_event(Event::ManagerMultisigDispatched {
+					res: res.map(|_| ()).map_err(|e| e.error),
+				});
+				ManagerMultisigRound::<T>::mutate(|r| *r += 1);
 			} else {
-				CancelVotes::<T>::put(votes);
-			}
-
-			Ok(())
-		}
-
-		#[pallet::call_index(14)]
-		#[pallet::weight({ Weight::from_parts(10_000_000, 1000) })]
-		pub fn vote_pause(
-			origin: OriginFor<T>,
-			payload: BailVote,
-			_sig: sp_core::sr25519::Signature,
-		) -> DispatchResult {
-			let _ = ensure_none(origin);
-
-			ensure!(PauseRound::<T>::get() == payload.round, "RoundStale");
-			let mut votes = PauseVotes::<T>::get();
-			ensure!(!votes.contains(&payload.who), "Duplicate");
-			votes.push(payload.who);
-
-			if votes.len() >= 3 {
-				let pause_stage = RcMigrationStage::<T>::get();
-				Self::transition(MigrationStage::MigrationPaused);
-				Self::deposit_event(Event::MigrationPaused { pause_stage });
-				PauseVotes::<T>::kill();
-				PauseRound::<T>::mutate(|r| *r += 1);
-			} else {
-				PauseVotes::<T>::put(votes);
-			}
-
-			Ok(())
-		}
-
-		#[pallet::call_index(15)]
-		#[pallet::weight({ Weight::from_parts(10_000_000, 1000) })]
-		pub fn vote_force_set_stage(
-			origin: OriginFor<T>,
-			payload: Box<ForceSetStageVote<T>>,
-			_sig: sp_core::sr25519::Signature,
-		) -> DispatchResult {
-			let _ = ensure_none(origin);
-
-			ensure!(ForceSetStageRound::<T>::get() == payload.round, "RoundStale");
-			let mut votes_for_stage = ForceSetStageVotes::<T>::get(&payload.stage);
-			ensure!(!votes_for_stage.contains(&payload.who), "Duplicate");
-			votes_for_stage.push(payload.who);
-
-			if votes_for_stage.len() >= 3 {
-				Self::transition(payload.stage);
-				// clear any votes, either in winning or losing stages.
-				let _ = ForceSetStageVotes::<T>::clear(u32::MAX, None);
-				ForceSetStageRound::<T>::mutate(|r| *r += 1);
-			} else {
-				ForceSetStageVotes::<T>::insert(payload.stage, votes_for_stage);
+				ManagerMultisigs::<T>::insert(payload.call, votes_for_call);
 			}
 
 			Ok(())
 		}
 	}
 
-	#[derive(
-		Encode,
-		Decode,
-		DebugNoBound,
-		CloneNoBound,
-		PartialEqNoBound,
-		EqNoBound,
-		TypeInfo,
-		sp_core::DecodeWithMemTracking,
-	)]
-	pub struct BailVote {
-		pub(crate) who: sp_core::sr25519::Public,
-		pub(crate) round: u32,
-	}
-
-	impl BailVote {
-		pub fn from(who: sp_core::sr25519::Public, round: u32) -> Self {
-			Self { round, who }
-		}
-
-		pub fn encode_with_bytes_wrapper(&self) -> Vec<u8> {
-			[b"<Bytes>", &*self.encode(), b"</Bytes>"].concat()
+	impl<T: Config> Pallet<T> {
+		fn manager_multisig_id() -> T::AccountId {
+			let pallet_id = PalletId(*b"rcmigmts");
+			pallet_id.into_account_truncating()
 		}
 	}
-
-	#[pallet::storage]
-	#[pallet::unbounded]
-	pub type CancelVotes<T: Config> = StorageValue<_, Vec<sp_core::sr25519::Public>, ValueQuery>;
-	#[pallet::storage]
-	pub type CancelRound<T: Config> = StorageValue<_, u32, ValueQuery>;
-
-	#[pallet::storage]
-	#[pallet::unbounded]
-	pub type PauseVotes<T: Config> = StorageValue<_, Vec<sp_core::sr25519::Public>, ValueQuery>;
-	#[pallet::storage]
-	pub type PauseRound<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	#[derive(
 		Encode,
@@ -1429,15 +1362,19 @@ pub mod pallet {
 		sp_core::DecodeWithMemTracking,
 	)]
 	#[scale_info(skip_type_params(T))]
-	pub struct ForceSetStageVote<T: Config> {
-		pub(crate) round: u32,
-		pub(crate) who: sp_core::sr25519::Public,
-		pub(crate) stage: MigrationStageOf<T>,
+	pub struct ManagerMultisigVote<T: Config> {
+		who: sp_core::sr25519::Public,
+		call: <T as Config>::RuntimeCall,
+		round: u32,
 	}
 
-	impl<T: Config> ForceSetStageVote<T> {
-		pub fn new(who: sp_core::sr25519::Public, round: u32, stage: MigrationStageOf<T>) -> Self {
-			Self { who, round, stage }
+	impl<T: Config> ManagerMultisigVote<T> {
+		pub fn new(
+			who: sp_core::sr25519::Public,
+			call: <T as Config>::RuntimeCall,
+			round: u32,
+		) -> Self {
+			Self { who, call, round }
 		}
 
 		pub fn encode_with_bytes_wrapper(&self) -> Vec<u8> {
@@ -1446,11 +1383,16 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	pub type ForceSetStageRound<T: Config> = StorageValue<_, u32, ValueQuery>;
-	#[pallet::storage]
 	#[pallet::unbounded]
-	pub type ForceSetStageVotes<T: Config> =
-		StorageMap<_, Twox64Concat, MigrationStageOf<T>, Vec<sp_core::sr25519::Public>, ValueQuery>;
+	pub type ManagerMultisigs<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		<T as Config>::RuntimeCall,
+		Vec<sp_core::sr25519::Public>,
+		ValueQuery,
+	>;
+	#[pallet::storage]
+	pub type ManagerMultisigRound<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	#[pallet::validate_unsigned]
 	impl<T: Config> ValidateUnsigned for Pallet<T> {
@@ -1459,51 +1401,14 @@ pub mod pallet {
 		fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
 			use sp_runtime::traits::Verify;
 			match call {
-				// note: payload can be empty, but it is better to ask the signer to revel
-				// themselves, so we don't have to check against all of `MultisigMembers`.
-				Call::vote_cancel { payload, sig } => {
+				Call::vote_manager_multisig { payload, sig } => {
 					if !T::MultisigMembers::get().contains(&payload.who) {
 						return InvalidTransaction::BadSigner.into()
 					}
 					if !sig.verify(&payload.encode_with_bytes_wrapper()[..], &payload.who) {
 						return InvalidTransaction::BadProof.into()
 					}
-					if CancelRound::<T>::get() != payload.round {
-						return InvalidTransaction::Stale.into()
-					}
-					ValidTransaction::with_tag_prefix("AhmMultisig")
-						.priority(sp_runtime::traits::Bounded::max_value())
-						.and_provides(vec![("ahm_multi", payload.who).encode()])
-						.propagate(true)
-						.longevity(30)
-						.build()
-				},
-				Call::vote_pause { payload, sig } => {
-					if !T::MultisigMembers::get().contains(&payload.who) {
-						return InvalidTransaction::BadSigner.into()
-					}
-					if !sig.verify(&payload.encode_with_bytes_wrapper()[..], &payload.who) {
-						return InvalidTransaction::BadProof.into()
-					}
-					if PauseRound::<T>::get() != payload.round {
-						return InvalidTransaction::Stale.into()
-					}
-
-					ValidTransaction::with_tag_prefix("AhmMultisig")
-						.priority(sp_runtime::traits::Bounded::max_value())
-						.and_provides(vec![("ahm_multi", payload.who).encode()])
-						.propagate(true)
-						.longevity(30)
-						.build()
-				},
-				Call::vote_force_set_stage { payload, sig } => {
-					if !T::MultisigMembers::get().contains(&payload.who) {
-						return InvalidTransaction::BadSigner.into()
-					}
-					if !sig.verify(&payload.encode_with_bytes_wrapper()[..], &payload.who) {
-						return InvalidTransaction::BadProof.into()
-					}
-					if ForceSetStageRound::<T>::get() != payload.round {
+					if ManagerMultisigRound::<T>::get() != payload.round {
 						return InvalidTransaction::Stale.into()
 					}
 					ValidTransaction::with_tag_prefix("AhmMultisig")
@@ -2480,6 +2385,9 @@ pub mod pallet {
 				if Manager::<T>::get().is_some_and(|manager_id| manager_id == account_id) {
 					return Ok(());
 				}
+				if account_id == Self::manager_multisig_id() {
+					return Ok(());
+				}
 			}
 			<T as Config>::AdminOrigin::ensure_origin(origin)?;
 			Ok(())
@@ -2490,6 +2398,9 @@ pub mod pallet {
 		fn ensure_privileged_origin(origin: OriginFor<T>) -> DispatchResult {
 			if let Ok(account_id) = ensure_signed(origin.clone()) {
 				if Manager::<T>::get().is_some_and(|manager_id| manager_id == account_id) {
+					return Ok(());
+				}
+				if account_id == Self::manager_multisig_id() {
 					return Ok(());
 				}
 				if Canceller::<T>::get().is_some_and(|canceller_id| canceller_id == account_id) {

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -775,8 +775,10 @@ pub mod pallet {
 			/// The number of indexed pure accounts.
 			num_pure_accounts: u32,
 		},
-		/// The manager multisig dispatched something
+		/// The manager multisig dispatched something.
 		ManagerMultisigDispatched { res: DispatchResult },
+		/// The manager multisig received a vote.
+		ManagerMultisigVoted { votes: u32 },
 	}
 
 	/// The Relay Chain migration state.
@@ -1346,6 +1348,9 @@ pub mod pallet {
 				});
 				ManagerMultisigRound::<T>::mutate(|r| *r += 1);
 			} else {
+				Self::deposit_event(Event::ManagerMultisigVoted {
+					votes: votes_for_call.len() as u32,
+				});
 				ManagerMultisigs::<T>::insert(payload.call, votes_for_call);
 			}
 

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -1324,7 +1324,7 @@ pub mod pallet {
 			ensure!(ManagerMultisigRound::<T>::get() == payload.round, "RoundStale");
 			let mut votes_for_call = ManagerMultisigs::<T>::get(&payload.call);
 			ensure!(!votes_for_call.contains(&payload.who), "Duplicate");
-			votes_for_call.push(payload.who.clone());
+			votes_for_call.push(payload.who);
 
 			if votes_for_call.len() >= T::MultisigThreshold::get() as usize {
 				let origin: <T as Config>::RuntimeOrigin =
@@ -1418,7 +1418,7 @@ pub mod pallet {
 						.longevity(30)
 						.build()
 				},
-				_ => return InvalidTransaction::Call.into(),
+				_ => InvalidTransaction::Call.into(),
 			}
 		}
 	}

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -122,7 +122,7 @@ remote-externalities = { workspace = true }
 tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 ss58-registry = { workspace = true }
-hex = { workspace = true }
+hex = { workspace = true, default-features = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }
@@ -146,6 +146,7 @@ std = [
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
 	"frame-try-runtime/std",
+	"hex/std",
 	"kusama-runtime-constants/std",
 	"log/std",
 	"pallet-asset-rate/std",

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -122,6 +122,7 @@ remote-externalities = { workspace = true }
 tokio = { features = ["macros"], workspace = true }
 sp-tracing = { workspace = true }
 ss58-registry = { workspace = true }
+hex = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1922,16 +1922,13 @@ fn multisig_members() -> Vec<sp_core::sr25519::Public> {
 		vec![
 			"FFFF3gBSSDFSvK2HBq4qgLH75DHqXWPHeCnR1BSksAMacBs", // basti
 			"FcxNWVy5RESDsErjwyZmPCW6Z8Y3fbfLzmou34YZTrbcraL", // gav
-			"EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo", // shawn
-			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian/ksm
-			"G5MVrgFmBaYei8N6t6DnDrb8JE53wKDkazLv5f46wVpi14y", // alex
+			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian
 			"Ea6jhP5gF4r7NqhkEoAXJDgSgYpNQNaTYU6gPsrEGfctaKR", // oliver
 			"GcDZZCVPwkPqoWxx8vfLb4Yfpz9yQ1f4XEyqngSH8ygsL9p", // joe
 			"12HWjfYxi7xt7EvpTxUis7JoNWF7YCqa19JXmuiwizfwJZY2", // muharem
-			"129EYiTbv2J4LkYqRNssUfMuxNLYN8TW2LgfG1Gqyj8wCcs7", // cisco
 			"121dd6J26VUnBZ8BqLGjANWkEAXSb9mWq1SB7LsS9QNTGFvz", // adrian
-			"14DsLzVyTUTDMm2eP3czwPbH53KgqnQRp3CJJZS9GR7yxGDP", // brayn
 			"12pRzYaysQz6Tr1e78sRmu9FGB8gu8yTek9x6xwVFFAwXTM8", // robK
+			"FcJnhk4i1bfuN9E2B6yMnL8h97ogtuL7e4ZpqnYgvj9moQy", // donal
 		]
 	};
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1922,7 +1922,7 @@ fn multisig_members() -> Vec<sp_core::sr25519::Public> {
 		vec![
 			"FFFF3gBSSDFSvK2HBq4qgLH75DHqXWPHeCnR1BSksAMacBs", // basti
 			"FcxNWVy5RESDsErjwyZmPCW6Z8Y3fbfLzmou34YZTrbcraL", // gav
-			"EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo", // sahwn
+			"EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo", // shawn
 			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian/ksm
 			"G5MVrgFmBaYei8N6t6DnDrb8JE53wKDkazLv5f46wVpi14y", // alex
 			"Ea6jhP5gF4r7NqhkEoAXJDgSgYpNQNaTYU6gPsrEGfctaKR", // oliver

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1911,7 +1911,7 @@ fn multisig_members() -> Vec<sp_core::sr25519::Public> {
 	use sp_core::{crypto::Ss58Codec, ByteArray};
 	let addresses = if cfg!(test) {
 		vec![
-			"HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F", // Alive
+			"HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F", // Alice
 			"FoQJpPyadYccjavVdTWxpxU7rUEaYhfLCPwXgkfD6Zat9QP", // Bob
 			"Fr4NzY1udSFFLzb2R3qxVQkwz9cZraWkyfH4h3mVVk7BK7P", // Charlie
 			"DfnTB4z7eUvYRqcGtTpFsLC69o6tvBSC1pEv8vWPZFtCkaK", // Dave
@@ -1924,6 +1924,13 @@ fn multisig_members() -> Vec<sp_core::sr25519::Public> {
 			"EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo", // sahwn
 			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian
 			"G5MVrgFmBaYei8N6t6DnDrb8JE53wKDkazLv5f46wVpi14y", // alex
+			"Ea6jhP5gF4r7NqhkEoAXJDgSgYpNQNaTYU6gPsrEGfctaKR", // oliver
+			"GcDZZCVPwkPqoWxx8vfLb4Yfpz9yQ1f4XEyqngSH8ygsL9p", // joe
+			"12HWjfYxi7xt7EvpTxUis7JoNWF7YCqa19JXmuiwizfwJZY2", // muharem
+			"129EYiTbv2J4LkYqRNssUfMuxNLYN8TW2LgfG1Gqyj8wCcs7", // cisco
+			"121dd6J26VUnBZ8BqLGjANWkEAXSb9mWq1SB7LsS9QNTGFvz", // adrian
+			"14DsLzVyTUTDMm2eP3czwPbH53KgqnQRp3CJJZS9GR7yxGDP", // brayn
+			"12pRzYaysQz6Tr1e78sRmu9FGB8gu8yTek9x6xwVFFAwXTM8", // robK
 		]
 	};
 
@@ -3181,33 +3188,11 @@ sp_api::impl_runtime_apis! {
 
 #[cfg(test)]
 mod ahm_multisig {
-	use pallet_rc_migrator::VotePayload;
+	use super::*;
+	use pallet_rc_migrator::{BailVote, ForceSetStageVote};
 	use sp_core::Pair;
 	use sp_io::TestExternalities;
 	use sp_runtime::traits::{Dispatchable, ValidateUnsigned};
-
-	use super::*;
-
-	#[test]
-	fn test_calls() {
-		let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-		let payload = VotePayload::from(alice.public());
-		let sig = alice.sign(payload.as_ref());
-		println!("alice payload: 0x{:?}", hex::encode(payload.as_ref()));
-		println!("alice sig: 0x{:?}", hex::encode(sig.0));
-
-		let bob = sp_keyring::Sr25519Keyring::Bob.pair();
-		let payload = VotePayload::from(bob.public());
-		let sig = bob.sign(payload.as_ref());
-		println!("bob payload: 0x{:?}", hex::encode(payload.as_ref()));
-		println!("bob sig: 0x{:?}", hex::encode(sig.0));
-
-		let charlie = sp_keyring::Sr25519Keyring::Charlie.pair();
-		let payload = VotePayload::from(charlie.public());
-		let sig = charlie.sign(payload.as_ref());
-		println!("charlie payload: 0x{:?}", hex::encode(payload.as_ref()));
-		println!("charlie sig: 0x{:?}", hex::encode(sig.0));
-	}
 
 	#[test]
 	fn multisig_cancel_works() {
@@ -3217,11 +3202,11 @@ mod ahm_multisig {
 			);
 
 			{
-				// Ferdie is not in the multisig, will get rejected
+				// Ferdie is not in the multisig, will get rejected on validate
 				let ferdie = sp_keyring::Sr25519Keyring::Ferdie.pair();
 
-				let payload = VotePayload::from(ferdie.public());
-				let sig = ferdie.sign(payload.as_ref());
+				let payload = BailVote::from(ferdie.public(), 0);
+				let sig = ferdie.sign(payload.encode_with_bytes_wrapper().as_ref());
 				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
@@ -3235,8 +3220,8 @@ mod ahm_multisig {
 				// Alice signs a wrong message, rejected
 				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
 
-				let payload = VotePayload::from(sp_keyring::Sr25519Keyring::Bob.pair().public());
-				let sig = alice.sign(payload.as_ref());
+				let payload = BailVote::from(sp_keyring::Sr25519Keyring::Bob.pair().public(), 0);
+				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
 				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
@@ -3246,12 +3231,13 @@ mod ahm_multisig {
 				.is_err());
 			}
 
-			{
+			let first_valid_sig_from_alice = {
 				// Alice signs, not cancelled yet
 				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-				let payload = VotePayload::from(alice.public());
-				let sig = alice.sign(payload.as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
+				let payload = BailVote::from(alice.public(), 0);
+				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
+				let call =
+					pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig: sig.clone() };
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
 					TransactionSource::External,
@@ -3265,13 +3251,14 @@ mod ahm_multisig {
 					pallet_rc_migrator::MigrationStage::Starting
 				);
 				assert_eq!(pallet_rc_migrator::CancelVotes::<Runtime>::get().len(), 1);
-			}
+				sig
+			};
 
 			{
 				// Alice signs again, rejected, not cancelled yet
 				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-				let payload = VotePayload::from(alice.public());
-				let sig = alice.sign(payload.as_ref());
+				let payload = BailVote::from(alice.public(), 0);
+				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
 				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
@@ -3289,8 +3276,8 @@ mod ahm_multisig {
 			{
 				// Bob signs, not cancelled yet
 				let bob = sp_keyring::Sr25519Keyring::Bob.pair();
-				let payload = VotePayload::from(bob.public());
-				let sig = bob.sign(payload.as_ref());
+				let payload = BailVote::from(bob.public(), 0);
+				let sig = bob.sign(payload.encode_with_bytes_wrapper().as_ref());
 				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
@@ -3304,13 +3291,14 @@ mod ahm_multisig {
 					pallet_rc_migrator::MigrationStage::Starting
 				);
 				assert_eq!(pallet_rc_migrator::CancelVotes::<Runtime>::get().len(), 2);
+				assert_eq!(pallet_rc_migrator::CancelRound::<Runtime>::get(), 0);
 			}
 
 			{
 				// Charlie signs, cancelled
 				let charlie = sp_keyring::Sr25519Keyring::Charlie.pair();
-				let payload = VotePayload::from(charlie.public());
-				let sig = charlie.sign(payload.as_ref());
+				let payload = BailVote::from(charlie.public(), 0);
+				let sig = charlie.sign(payload.encode_with_bytes_wrapper().as_ref());
 				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
@@ -3324,6 +3312,155 @@ mod ahm_multisig {
 					pallet_rc_migrator::MigrationStage::Pending
 				);
 				assert_eq!(pallet_rc_migrator::CancelVotes::<Runtime>::get().len(), 0);
+				assert_eq!(pallet_rc_migrator::CancelRound::<Runtime>::get(), 1);
+			}
+
+			{
+				// Valid alice signature from round 0 can no longer be used.
+				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
+				let payload = BailVote::from(alice.public(), 0);
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel {
+					payload,
+					sig: first_valid_sig_from_alice,
+				};
+
+				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
+					TransactionSource::External,
+					&call
+				)
+				.is_err());
+			}
+		})
+	}
+
+	#[test]
+	fn force_set_stage_works() {
+		TestExternalities::default().execute_with(|| {
+			let consensus_stage = pallet_rc_migrator::MigrationStage::MigrationPaused;
+			let other_stage = pallet_rc_migrator::MigrationStage::WaitingForAh;
+
+			{
+				// Alice signs on the winning stage
+				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
+				let payload = ForceSetStageVote::new(alice.public(), 0, consensus_stage.clone());
+				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
+					payload: Box::new(payload),
+					sig,
+				};
+
+				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
+					TransactionSource::External,
+					&call
+				)
+				.is_ok());
+
+				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
+				assert_eq!(
+					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
+					// default value
+					pallet_rc_migrator::MigrationStage::Pending
+				);
+				assert_eq!(
+					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(consensus_stage.clone())
+						.len(),
+					1
+				);
+				assert_eq!(
+					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(other_stage.clone())
+						.len(),
+					0
+				);
+			}
+
+			{
+				// Alice signs on the other stage
+				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
+				let payload = ForceSetStageVote::new(alice.public(), 0, other_stage.clone());
+				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
+					payload: Box::new(payload),
+					sig,
+				};
+
+				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
+					TransactionSource::External,
+					&call
+				)
+				.is_ok());
+
+				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
+				assert_eq!(
+					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
+					// default value
+					pallet_rc_migrator::MigrationStage::Pending
+				);
+				assert_eq!(
+					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(other_stage.clone())
+						.len(),
+					1
+				);
+				assert_eq!(
+					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(consensus_stage.clone())
+						.len(),
+					1
+				);
+			}
+
+			{
+				// Bob signs on consensus state
+				let bob = sp_keyring::Sr25519Keyring::Bob.pair();
+				let payload = ForceSetStageVote::new(bob.public(), 0, consensus_stage.clone());
+				let sig = bob.sign(payload.encode_with_bytes_wrapper().as_ref());
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
+					payload: Box::new(payload),
+					sig,
+				};
+
+				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
+					TransactionSource::External,
+					&call
+				)
+				.is_ok());
+
+				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
+				assert_eq!(
+					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(other_stage.clone())
+						.len(),
+					1
+				);
+				assert_eq!(
+					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(consensus_stage.clone())
+						.len(),
+					2
+				);
+			}
+
+			{
+				// charlie signs on consensus state, passed, all data deleted, round incremented
+				let charlie = sp_keyring::Sr25519Keyring::Charlie.pair();
+				let payload = ForceSetStageVote::new(charlie.public(), 0, consensus_stage.clone());
+				let sig = charlie.sign(payload.encode_with_bytes_wrapper().as_ref());
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
+					payload: Box::new(payload),
+					sig,
+				};
+
+				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
+					TransactionSource::External,
+					&call
+				)
+				.is_ok());
+
+				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
+				assert_eq!(
+					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
+					consensus_stage.clone()
+				);
+				assert_eq!(
+					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::iter().count(),
+					0
+				);
 			}
 		})
 	}

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -3266,7 +3266,7 @@ mod ahm_multisig {
 				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
 				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
 					payload: Box::new(payload),
-					sig: sig.clone(),
+					sig,
 				};
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1367,7 +1367,8 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType {
 				matches!(
 					c,
 					RuntimeCall::Staking(..) |
-						RuntimeCall::Session(..) | RuntimeCall::Utility(..) |
+						RuntimeCall::Session(..) |
+						RuntimeCall::Utility(..) |
 						RuntimeCall::FastUnstake(..) |
 						RuntimeCall::VoterList(..) |
 						RuntimeCall::NominationPools(..)
@@ -1923,10 +1924,6 @@ fn multisig_members() -> Vec<sp_core::sr25519::Public> {
 			"FcxNWVy5RESDsErjwyZmPCW6Z8Y3fbfLzmou34YZTrbcraL", // gav
 			"EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo", // sahwn
 			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian/ksm
-			// for testing CI-FAIL
-			"157piwLd54nU9FeZAqifPkW2eaXeGJkTYTxdG1JtXGTgkk9q", // kian/gov
-			"1eTPAR2TuqLyidmPT9rMmuycHVm9s9czu78sePqg2KHMDrE",  // kian/dot
-			// for testing
 			"G5MVrgFmBaYei8N6t6DnDrb8JE53wKDkazLv5f46wVpi14y", // alex
 			"Ea6jhP5gF4r7NqhkEoAXJDgSgYpNQNaTYU6gPsrEGfctaKR", // oliver
 			"GcDZZCVPwkPqoWxx8vfLb4Yfpz9yQ1f4XEyqngSH8ygsL9p", // joe

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1922,7 +1922,11 @@ fn multisig_members() -> Vec<sp_core::sr25519::Public> {
 			"FFFF3gBSSDFSvK2HBq4qgLH75DHqXWPHeCnR1BSksAMacBs", // basti
 			"FcxNWVy5RESDsErjwyZmPCW6Z8Y3fbfLzmou34YZTrbcraL", // gav
 			"EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo", // sahwn
-			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian
+			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian/ksm
+			// for testing CI-FAIL
+			"157piwLd54nU9FeZAqifPkW2eaXeGJkTYTxdG1JtXGTgkk9q", // kian/gov
+			"1eTPAR2TuqLyidmPT9rMmuycHVm9s9czu78sePqg2KHMDrE",  // kian/dot
+			// for testing
 			"G5MVrgFmBaYei8N6t6DnDrb8JE53wKDkazLv5f46wVpi14y", // alex
 			"Ea6jhP5gF4r7NqhkEoAXJDgSgYpNQNaTYU6gPsrEGfctaKR", // oliver
 			"GcDZZCVPwkPqoWxx8vfLb4Yfpz9yQ1f4XEyqngSH8ygsL9p", // joe
@@ -1998,6 +2002,7 @@ impl pallet_rc_migrator::Config for Runtime {
 	#[cfg(feature = "kusama-ahm")]
 	type RecoveryBlockNumberProvider = System;
 	type MultisigMembers = MultisigMembers;
+	type MultisigThreshold = ConstU32<3>;
 }
 
 construct_runtime! {
@@ -3189,26 +3194,35 @@ sp_api::impl_runtime_apis! {
 #[cfg(test)]
 mod ahm_multisig {
 	use super::*;
-	use pallet_rc_migrator::{BailVote, ForceSetStageVote};
+	use pallet_rc_migrator::ManagerMultisigVote;
 	use sp_core::Pair;
 	use sp_io::TestExternalities;
 	use sp_runtime::traits::{Dispatchable, ValidateUnsigned};
 
 	#[test]
-	fn multisig_cancel_works() {
+	fn unsigned_manager_multisig_works() {
 		TestExternalities::default().execute_with(|| {
-			pallet_rc_migrator::RcMigrationStage::<Runtime>::put(
-				pallet_rc_migrator::MigrationStage::Starting,
-			);
+			let call = pallet_rc_migrator::Call::<Runtime>::force_set_stage {
+				stage: Box::new(pallet_rc_migrator::MigrationStage::Starting),
+			};
+			let runtime_call = RuntimeCall::from(call.clone());
+			let other_call = pallet_rc_migrator::Call::<Runtime>::force_set_stage {
+				stage: Box::new(pallet_rc_migrator::MigrationStage::SchedulerMigrationInit),
+			};
+			let other_runtime_call = RuntimeCall::from(other_call.clone());
+
+			// initial round is zero
+			assert_eq!(pallet_rc_migrator::ManagerMultisigRound::<Runtime>::get(), 0);
 
 			{
-				// Ferdie is not in the multisig, will get rejected on validate
+				// Ferdie is not part of the multisig, will get rejected on validate
 				let ferdie = sp_keyring::Sr25519Keyring::Ferdie.pair();
-
-				let payload = BailVote::from(ferdie.public(), 0);
+				let payload = ManagerMultisigVote::new(ferdie.public(), runtime_call.clone(), 0);
 				let sig = ferdie.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
-
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
+					payload: Box::new(payload),
+					sig,
+				};
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
 					TransactionSource::External,
 					&call
@@ -3219,11 +3233,16 @@ mod ahm_multisig {
 			{
 				// Alice signs a wrong message, rejected
 				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-
-				let payload = BailVote::from(sp_keyring::Sr25519Keyring::Bob.pair().public(), 0);
+				let payload = ManagerMultisigVote::new(
+					sp_keyring::Sr25519Keyring::Bob.pair().public(),
+					runtime_call.clone(),
+					0,
+				);
 				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
-
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
+					payload: Box::new(payload),
+					sig,
+				};
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
 					TransactionSource::External,
 					&call
@@ -3231,236 +3250,127 @@ mod ahm_multisig {
 				.is_err());
 			}
 
-			let first_valid_sig_from_alice = {
-				// Alice signs, not cancelled yet
+			let alice_sig_for_first_round = {
+				// Alice signs, not executed yet
 				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-				let payload = BailVote::from(alice.public(), 0);
+				let payload = ManagerMultisigVote::new(alice.public(), runtime_call.clone(), 0);
 				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call =
-					pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig: sig.clone() };
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
+					payload: Box::new(payload),
+					sig: sig.clone(),
+				};
 
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
 					TransactionSource::External,
 					&call
 				)
 				.is_ok());
-
 				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
 				assert_eq!(
-					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
-					pallet_rc_migrator::MigrationStage::Starting
+					pallet_rc_migrator::ManagerMultisigs::<Runtime>::get(runtime_call.clone())
+						.len(),
+					1
 				);
-				assert_eq!(pallet_rc_migrator::CancelVotes::<Runtime>::get().len(), 1);
+
 				sig
 			};
 
 			{
-				// Alice signs again, rejected, not cancelled yet
-				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-				let payload = BailVote::from(alice.public(), 0);
-				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
-
-				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
-					TransactionSource::External,
-					&call
-				)
-				.is_ok());
-
-				assert_eq!(
-					RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).unwrap_err(),
-					sp_runtime::DispatchError::Other("Duplicate").into()
-				);
-			}
-
-			{
-				// Bob signs, not cancelled yet
+				// Bob signs, still waiting
 				let bob = sp_keyring::Sr25519Keyring::Bob.pair();
-				let payload = BailVote::from(bob.public(), 0);
+				let payload = ManagerMultisigVote::new(bob.public(), runtime_call.clone(), 0);
 				let sig = bob.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
-
-				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
-					TransactionSource::External,
-					&call
-				)
-				.is_ok());
-				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
-				assert_eq!(
-					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
-					pallet_rc_migrator::MigrationStage::Starting
-				);
-				assert_eq!(pallet_rc_migrator::CancelVotes::<Runtime>::get().len(), 2);
-				assert_eq!(pallet_rc_migrator::CancelRound::<Runtime>::get(), 0);
-			}
-
-			{
-				// Charlie signs, cancelled
-				let charlie = sp_keyring::Sr25519Keyring::Charlie.pair();
-				let payload = BailVote::from(charlie.public(), 0);
-				let sig = charlie.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel { payload, sig };
-
-				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
-					TransactionSource::External,
-					&call
-				)
-				.is_ok());
-				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
-				assert_eq!(
-					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
-					pallet_rc_migrator::MigrationStage::Pending
-				);
-				assert_eq!(pallet_rc_migrator::CancelVotes::<Runtime>::get().len(), 0);
-				assert_eq!(pallet_rc_migrator::CancelRound::<Runtime>::get(), 1);
-			}
-
-			{
-				// Valid alice signature from round 0 can no longer be used.
-				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-				let payload = BailVote::from(alice.public(), 0);
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_cancel {
-					payload,
-					sig: first_valid_sig_from_alice,
-				};
-
-				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
-					TransactionSource::External,
-					&call
-				)
-				.is_err());
-			}
-		})
-	}
-
-	#[test]
-	fn force_set_stage_works() {
-		TestExternalities::default().execute_with(|| {
-			let consensus_stage = pallet_rc_migrator::MigrationStage::MigrationPaused;
-			let other_stage = pallet_rc_migrator::MigrationStage::WaitingForAh;
-
-			{
-				// Alice signs on the winning stage
-				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-				let payload = ForceSetStageVote::new(alice.public(), 0, consensus_stage.clone());
-				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
 					payload: Box::new(payload),
 					sig,
 				};
-
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
 					TransactionSource::External,
 					&call
 				)
 				.is_ok());
-
 				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
 				assert_eq!(
-					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
-					// default value
-					pallet_rc_migrator::MigrationStage::Pending
-				);
-				assert_eq!(
-					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(consensus_stage.clone())
-						.len(),
-					1
-				);
-				assert_eq!(
-					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(other_stage.clone())
-						.len(),
-					0
-				);
-			}
-
-			{
-				// Alice signs on the other stage
-				let alice = sp_keyring::Sr25519Keyring::Alice.pair();
-				let payload = ForceSetStageVote::new(alice.public(), 0, other_stage.clone());
-				let sig = alice.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
-					payload: Box::new(payload),
-					sig,
-				};
-
-				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
-					TransactionSource::External,
-					&call
-				)
-				.is_ok());
-
-				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
-				assert_eq!(
-					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
-					// default value
-					pallet_rc_migrator::MigrationStage::Pending
-				);
-				assert_eq!(
-					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(other_stage.clone())
-						.len(),
-					1
-				);
-				assert_eq!(
-					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(consensus_stage.clone())
-						.len(),
-					1
-				);
-			}
-
-			{
-				// Bob signs on consensus state
-				let bob = sp_keyring::Sr25519Keyring::Bob.pair();
-				let payload = ForceSetStageVote::new(bob.public(), 0, consensus_stage.clone());
-				let sig = bob.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
-					payload: Box::new(payload),
-					sig,
-				};
-
-				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
-					TransactionSource::External,
-					&call
-				)
-				.is_ok());
-
-				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
-				assert_eq!(
-					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(other_stage.clone())
-						.len(),
-					1
-				);
-				assert_eq!(
-					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::get(consensus_stage.clone())
+					pallet_rc_migrator::ManagerMultisigs::<Runtime>::get(runtime_call.clone())
 						.len(),
 					2
 				);
 			}
 
 			{
-				// charlie signs on consensus state, passed, all data deleted, round incremented
+				// charlie signs something else, stored but not used.
 				let charlie = sp_keyring::Sr25519Keyring::Charlie.pair();
-				let payload = ForceSetStageVote::new(charlie.public(), 0, consensus_stage.clone());
+				let payload =
+					ManagerMultisigVote::new(charlie.public(), other_runtime_call.clone(), 0);
 				let sig = charlie.sign(payload.encode_with_bytes_wrapper().as_ref());
-				let call = pallet_rc_migrator::Call::<Runtime>::vote_force_set_stage {
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
 					payload: Box::new(payload),
 					sig,
 				};
-
 				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
 					TransactionSource::External,
 					&call
 				)
 				.is_ok());
-
 				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
+				// 1 vote for the new one
+				assert_eq!(
+					pallet_rc_migrator::ManagerMultisigs::<Runtime>::get(
+						other_runtime_call.clone()
+					)
+					.len(),
+					1
+				);
+				// still 2 votes for this
+				assert_eq!(
+					pallet_rc_migrator::ManagerMultisigs::<Runtime>::get(runtime_call.clone())
+						.len(),
+					2
+				);
+			}
+
+			{
+				// eve signs, dispatched
+				let eve = sp_keyring::Sr25519Keyring::Eve.pair();
+				let payload = ManagerMultisigVote::new(eve.public(), runtime_call.clone(), 0);
+				let sig = eve.sign(payload.encode_with_bytes_wrapper().as_ref());
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
+					payload: Box::new(payload),
+					sig,
+				};
+				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
+					TransactionSource::External,
+					&call
+				)
+				.is_ok());
+				assert!(RuntimeCall::from(call).dispatch(RuntimeOrigin::none()).is_ok());
+				// executed, so no more votes
 				assert_eq!(
 					pallet_rc_migrator::RcMigrationStage::<Runtime>::get(),
-					consensus_stage.clone()
+					pallet_rc_migrator::MigrationStage::Starting
 				);
-				assert_eq!(
-					pallet_rc_migrator::ForceSetStageVotes::<Runtime>::iter().count(),
-					0
-				);
+				// votes erased
+				assert!(pallet_rc_migrator::ManagerMultisigs::<Runtime>::get(runtime_call.clone())
+					.is_empty(),);
+				// round incremented
+				assert_eq!(pallet_rc_migrator::ManagerMultisigRound::<Runtime>::get(), 1);
+			}
+
+			{
+				// Alice's signature from first round cannot be re-used
+				let call = pallet_rc_migrator::Call::<Runtime>::vote_manager_multisig {
+					payload: Box::new(ManagerMultisigVote::new(
+						sp_keyring::Sr25519Keyring::Alice.pair().public(),
+						runtime_call.clone(),
+						0,
+					)),
+					sig: alice_sig_for_first_round,
+				};
+				assert!(pallet_rc_migrator::Pallet::<Runtime>::validate_unsigned(
+					TransactionSource::External,
+					&call
+				)
+				.is_err());
 			}
 		})
 	}

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1917,6 +1917,15 @@ fn multisig_members() -> Vec<sp_core::sr25519::Public> {
 			"Fr4NzY1udSFFLzb2R3qxVQkwz9cZraWkyfH4h3mVVk7BK7P", // Charlie
 			"DfnTB4z7eUvYRqcGtTpFsLC69o6tvBSC1pEv8vWPZFtCkaK", // Dave
 			"HnMAUz7r2G8G3hB27SYNyit5aJmh2a5P4eMdDtACtMFDbam", // Eve
+			"FFFF3gBSSDFSvK2HBq4qgLH75DHqXWPHeCnR1BSksAMacBs", // basti
+			"FcxNWVy5RESDsErjwyZmPCW6Z8Y3fbfLzmou34YZTrbcraL", // gav
+			"HL8bEp8YicBdrUmJocCAWVLKUaR2dd1y6jnD934pbre3un1", // kian
+			"F2jgWXy7X8GQ2ykf1UGrsCXRERZvjEcd2aDf39fMf3BWVy6", // oliver
+			"GcDZZCVPwkPqoWxx8vfLb4Yfpz9yQ1f4XEyqngSH8ygsL9p", // joe
+			"12HWjfYxi7xt7EvpTxUis7JoNWF7YCqa19JXmuiwizfwJZY2", // muharem
+			"121dd6J26VUnBZ8BqLGjANWkEAXSb9mWq1SB7LsS9QNTGFvz", // adrian
+			"12pRzYaysQz6Tr1e78sRmu9FGB8gu8yTek9x6xwVFFAwXTM8", // robK
+			"FcJnhk4i1bfuN9E2B6yMnL8h97ogtuL7e4ZpqnYgvj9moQy", // donal
 		]
 	} else {
 		vec![
@@ -3192,6 +3201,12 @@ mod ahm_multisig {
 	use sp_core::Pair;
 	use sp_io::TestExternalities;
 	use sp_runtime::traits::{Dispatchable, ValidateUnsigned};
+
+	#[test]
+	fn all_ss58s_decode() {
+		// ensure all non-dev account ids we have are valid ss58s
+		assert_eq!(MultisigMembers::get().len(), 14);
+	}
 
 	#[test]
 	fn unsigned_manager_multisig_works() {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1147,8 +1147,7 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 				matches!(
 					c,
 					RuntimeCall::Staking(..) |
-						RuntimeCall::Session(..) |
-						RuntimeCall::Utility(..) |
+						RuntimeCall::Session(..) | RuntimeCall::Utility(..) |
 						RuntimeCall::FastUnstake(..) |
 						RuntimeCall::VoterList(..) |
 						RuntimeCall::NominationPools(..)
@@ -1771,6 +1770,8 @@ impl pallet_rc_migrator::Config for Runtime {
 	type XcmResponseTimeout = XcmResponseTimeout;
 	type MessageQueue = MessageQueue;
 	type AhUmpQueuePriorityPattern = AhUmpQueuePriorityPattern;
+	type MultisigMembers = ();
+	type MultisigThreshold = ConstU32<{ u32::MAX }>;
 }
 
 construct_runtime! {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1147,7 +1147,8 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 				matches!(
 					c,
 					RuntimeCall::Staking(..) |
-						RuntimeCall::Session(..) | RuntimeCall::Utility(..) |
+						RuntimeCall::Session(..) |
+						RuntimeCall::Utility(..) |
 						RuntimeCall::FastUnstake(..) |
 						RuntimeCall::VoterList(..) |
 						RuntimeCall::NominationPools(..)


### PR DESCRIPTION
- Uses unsigned txs (suggestion by @ggwpez) in case any of the signers don't have funds (or any other limitation imposed mid migration). 
- Allows anything that was guarded by `Manager` account to be dispatched, using a keyless account that is been artificially fed into `RuntimeOrigin::Signed` (suggestion by @muharem)
- Signing + submission can easily happen via PJS. Will test with a live dev chain to confirm.

Test: 

* first, edit the code so that the we use the testing keyring for live chain as well.
* Then: 

```
cargo br -p staging-kusama-runtime
chain-spec-builder create --para-id 777 --relay-chain kusama -t development  --runtime ./target/release/wbuild/staging-kusama-runtime/staging_kusama_runtime.wasm  named-preset development
polkadot --chain chain_spec.json --tmp --force-authoring --alice --unsafe-force-node-key-generation
```

- [x] Does not require a CHANGELOG entry
 