### PR TITLE
[AHM] Schedule migration on runtime upgrade

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -2194,20 +2194,20 @@ pub mod migrations {
 	use pallet_rc_migrator::{MigrationStage, MigrationStartBlock, RcMigrationStage};
 
 	/// Unreleased migrations. Add new ones here:
-	pub type Unreleased = (KickoffAhm<Runtime>,);
+	pub type Unreleased = (KickOffAhm<Runtime>,);
 
 	/// Migrations/checks that do not need to be versioned and can run on every update.
 	pub type Permanent = pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>;
 
-	/// Kickoff the Asset Hub Migration.
-	pub struct KickoffAhm<T>(pub core::marker::PhantomData<T>);
-	impl<T: pallet_rc_migrator::Config> OnRuntimeUpgrade for KickoffAhm<T> {
+	/// Kick off the Asset Hub Migration.
+	pub struct KickOffAhm<T>(pub core::marker::PhantomData<T>);
+	impl<T: pallet_rc_migrator::Config> OnRuntimeUpgrade for KickOffAhm<T> {
 		fn on_runtime_upgrade() -> Weight {
 			if MigrationStartBlock::<T>::exists() ||
 				RcMigrationStage::<T>::get() != MigrationStage::Pending
 			{
 				// Already started or scheduled
-				log::info!("KickoffAhm: Asset Hub Migration already started or scheduled");
+				log::info!("KickOffAhm: Asset Hub Migration already started or scheduled");
 				return T::DbWeight::get().reads(2)
 			}
 
@@ -2219,9 +2219,9 @@ pub mod migrations {
 				Default::default(),
 			);
 			if let Err(e) = result {
-				log::error!("KickoffAhm: Failed to schedule Asset Hub Migration: {:?}", e);
+				log::error!("KickOffAhm: Failed to schedule Asset Hub Migration: {:?}", e);
 			} else {
-				log::info!("KickoffAhm: Scheduled Asset Hub Migration");
+				log::info!("KickOffAhm: Scheduled Asset Hub Migration");
 			}*/
 
 			T::DbWeight::get().reads_writes(1, 1)

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -2190,7 +2190,7 @@ pub type Migrations = (migrations::Unreleased, migrations::Permanent);
 #[allow(deprecated, missing_docs)]
 pub mod migrations {
 	use super::*;
-	use frame_support::traits::{schedule::DispatchTime, OnRuntimeUpgrade};
+	use frame_support::traits::OnRuntimeUpgrade;
 	use pallet_rc_migrator::{MigrationStage, MigrationStartBlock, RcMigrationStage};
 
 	/// Unreleased migrations. Add new ones here:


### PR DESCRIPTION
Schedule the AHM on runtime upgrade so we can avoid doing another fellowship call.  
Exact values will be set in the subsequent runtime release MR.

Changes:
- Factor scheduling logic out into `do_schedule_migration`
- Add `KickoffAhm` to Kusama RC runtime
- Put a placeholder for the actual scheduling values that we can fill in later