### PR TITLE
[AHM] Remove debug logs to reduce the wasm size

### DIFF
--- a/pallets/ah-migrator/src/bounties.rs
+++ b/pallets/ah-migrator/src/bounties.rs
@@ -102,15 +102,11 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn do_process_bounty_message(message: RcBountiesMessageOf<T>) -> Result<(), Error<T>> {
-		log::debug!(target: LOG_TARGET, "Processing bounties message: {message:?}");
-
 		match message {
 			RcBountiesMessage::BountyCount(count) => {
-				log::debug!(target: LOG_TARGET, "Integrating bounties count: {count:?}");
 				pallet_bounties::BountyCount::<T>::put(count);
 			},
 			RcBountiesMessage::BountyApprovals(approvals) => {
-				log::debug!(target: LOG_TARGET, "Integrating bounties approvals: {approvals:?}");
 				let approvals = BoundedVec::<
                     _,
                     <T as pallet_treasury::Config>::MaxApprovals
@@ -118,7 +114,6 @@ impl<T: Config> Pallet<T> {
 				pallet_bounties::BountyApprovals::<T>::put(approvals);
 			},
 			RcBountiesMessage::BountyDescriptions((index, description)) => {
-				log::debug!(target: LOG_TARGET, "Integrating bounties descriptions: {description:?}");
 				let description = BoundedVec::<
 					_,
 					<T as pallet_bounties::Config>::MaximumReasonLength,
@@ -126,7 +121,6 @@ impl<T: Config> Pallet<T> {
 				pallet_bounties::BountyDescriptions::<T>::insert(index, description);
 			},
 			RcBountiesMessage::Bounties((index, bounty)) => {
-				log::debug!(target: LOG_TARGET, "Integrating bounty: {index:?}");
 				let translated_bounty = Self::translate_bounty(bounty);
 				pallet_rc_migrator::bounties::alias::Bounties::<T>::insert(
 					index,
@@ -135,7 +129,6 @@ impl<T: Config> Pallet<T> {
 			},
 		}
 
-		log::debug!(target: LOG_TARGET, "Processed bounties message");
 		Ok(())
 	}
 }

--- a/pallets/ah-migrator/src/call.rs
+++ b/pallets/ah-migrator/src/call.rs
@@ -38,18 +38,10 @@ impl<T: Config> Pallet<T> {
 			return Err(Error::<T>::FailedToConvertCall);
 		};
 
-		log::debug!(target: LOG_TARGET, "mapped call: {call:?}");
-
 		let ah_bounded_call = T::Preimage::bound(call).map_err(|err| {
 			defensive!("Failed to bound call: {:?}", err);
 			Error::<T>::FailedToBoundCall
 		})?;
-
-		if ah_bounded_call.lookup_needed() {
-			// Noted preimages for referendums that did not pass will need to be manually removed
-			// later.
-			log::debug!(target: LOG_TARGET, "New preimage was noted for call");
-		}
 
 		Ok(ah_bounded_call)
 	}

--- a/pallets/ah-migrator/src/claims.rs
+++ b/pallets/ah-migrator/src/claims.rs
@@ -51,28 +51,24 @@ impl<T: Config> Pallet<T> {
 				if pallet_claims::Total::<T>::exists() {
 					return Err(Error::<T>::InsertConflict);
 				}
-				log::debug!(target: LOG_TARGET, "Processing claims message: total {total:?}");
 				pallet_claims::Total::<T>::put(total);
 			},
 			RcClaimsMessage::Claims((who, amount)) => {
 				if pallet_claims::Claims::<T>::contains_key(who) {
 					return Err(Error::<T>::InsertConflict);
 				}
-				log::debug!(target: LOG_TARGET, "Processing claims message: claims {who:?}");
 				pallet_claims::Claims::<T>::insert(who, amount);
 			},
 			RcClaimsMessage::Vesting { who, schedule } => {
 				if pallet_claims::Vesting::<T>::contains_key(who) {
 					return Err(Error::<T>::InsertConflict);
 				}
-				log::debug!(target: LOG_TARGET, "Processing claims message: vesting {who:?}");
 				pallet_claims::Vesting::<T>::insert(who, schedule);
 			},
 			RcClaimsMessage::Signing((who, statement_kind)) => {
 				if pallet_claims::Signing::<T>::contains_key(who) {
 					return Err(Error::<T>::InsertConflict);
 				}
-				log::debug!(target: LOG_TARGET, "Processing claims message: signing {who:?}");
 				pallet_claims::Signing::<T>::insert(who, statement_kind);
 			},
 			RcClaimsMessage::Preclaims((who, address)) => {
@@ -80,7 +76,6 @@ impl<T: Config> Pallet<T> {
 				if pallet_claims::Preclaims::<T>::contains_key(&translated_who) {
 					return Err(Error::<T>::InsertConflict);
 				}
-				log::debug!(target: LOG_TARGET, "Processing claims message: preclaims {translated_who:?}");
 				pallet_claims::Preclaims::<T>::insert(translated_who, address);
 			},
 		}

--- a/pallets/ah-migrator/src/conviction_voting.rs
+++ b/pallets/ah-migrator/src/conviction_voting.rs
@@ -21,7 +21,7 @@ use pallet_rc_migrator::{
 	conviction_voting::{
 		alias, ConvictionVotingMigrator, RcConvictionVotingMessage, RcConvictionVotingMessageOf,
 	},
-	types::{SortByEncoded, ToPolkadotSs58},
+	types::SortByEncoded,
 };
 
 impl<T: Config> Pallet<T> {
@@ -67,10 +67,6 @@ impl<T: Config> Pallet<T> {
 		// Translate the voter account from RC to AH format
 		let translated_account = Self::translate_account_rc_to_ah(account_id.clone());
 
-		log::debug!(target: LOG_TARGET, "Processing VotingFor record for {}",
-			translated_account.to_polkadot_ss58()
-		);
-
 		// Translate any delegate accounts within the voting structure if it's delegating
 		let mut translated_voting = voting;
 		if let pallet_conviction_voting::Voting::Delegating(ref mut delegating) = translated_voting
@@ -88,10 +84,6 @@ impl<T: Config> Pallet<T> {
 	) {
 		// Translate the account from RC to AH format
 		let translated_account = Self::translate_account_rc_to_ah(account_id.clone());
-
-		log::debug!(target: LOG_TARGET, "Processing ClassLocksFor record for {}",
-			translated_account.to_polkadot_ss58()
-		);
 
 		let balance_per_class =
 			BoundedVec::<_, ClassCountOf<T::Polls, TallyOf<T, ()>>>::defensive_truncate_from(

--- a/pallets/ah-migrator/src/indices.rs
+++ b/pallets/ah-migrator/src/indices.rs
@@ -37,7 +37,6 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn do_receive_index(index: RcIndicesIndexOf<T>) {
-		log::debug!(target: LOG_TARGET, "Integrating index {:?}", &index.index);
 		defensive_assert!(!pallet_indices::Accounts::<T>::contains_key(index.index));
 
 		let translated_who = Self::translate_account_rc_to_ah(index.who);

--- a/pallets/ah-migrator/src/preimage.rs
+++ b/pallets/ah-migrator/src/preimage.rs
@@ -51,11 +51,10 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn do_receive_preimage_chunk(chunk: RcPreimageChunk) -> Result<(), Error<T>> {
-		log::debug!(target: LOG_TARGET, "Integrating preimage chunk {} offset {}/{}", chunk.preimage_hash, chunk.chunk_byte_offset + chunk.chunk_bytes.len() as u32, chunk.preimage_len);
 		let key = (chunk.preimage_hash, chunk.preimage_len);
 
 		// First check that we did not miss a chunk
-		let preimage = match pallet_preimage::PreimageFor::<T>::get(key) {
+		let _preimage = match pallet_preimage::PreimageFor::<T>::get(key) {
 			Some(preimage) => {
 				if preimage.len() != chunk.chunk_byte_offset as usize {
 					defensive!("Preimage chunk missing");
@@ -92,10 +91,6 @@ impl<T: Config> Pallet<T> {
 				bounded_preimage
 			},
 		};
-
-		if preimage.len() == chunk.preimage_len as usize + chunk.chunk_byte_offset as usize {
-			log::debug!(target: LOG_TARGET, "Preimage complete: {}", chunk.preimage_hash);
-		}
 
 		Ok(())
 	}
@@ -214,7 +209,6 @@ impl<T: Config> Pallet<T> {
 		};
 
 		pallet_preimage::RequestStatusFor::<T>::insert(request_status.hash, &new_request_status);
-		log::debug!(target: LOG_TARGET, "Integrating preimage request status: {new_request_status:?}");
 
 		Ok(())
 	}

--- a/pallets/ah-migrator/src/proxy.rs
+++ b/pallets/ah-migrator/src/proxy.rs
@@ -51,10 +51,6 @@ impl<T: Config> Pallet<T> {
 		// Translate the delegator account from RC to AH format
 		let translated_delegator = Self::translate_account_rc_to_ah(proxy.delegator.clone());
 
-		log::debug!(target: LOG_TARGET, "Integrating proxy {}, deposit {:?}",
-			translated_delegator.to_polkadot_ss58(),
-			proxy.deposit
-		);
 		let max_proxies = <T as pallet_proxy::Config>::MaxProxies::get() as usize;
 
 		// Translate the incoming ones from RC
@@ -68,10 +64,6 @@ impl<T: Config> Pallet<T> {
 			// Translate the delegate account from RC to AH format
 			let translated_delegate = Self::translate_account_rc_to_ah(p.delegate.clone());
 
-			log::debug!(target: LOG_TARGET, "Proxy type: {:?} delegate: {}",
-				proxy_type,
-				translated_delegate.to_polkadot_ss58()
-			);
 			Some(pallet_proxy::ProxyDefinition {
 				delegate: translated_delegate,
 				delay: p.delay,
@@ -146,11 +138,6 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(), Error<T>> {
 		// Translate the depositor account from RC to AH format
 		let translated_depositor = Self::translate_account_rc_to_ah(announcement.depositor.clone());
-
-		log::debug!(target: LOG_TARGET, "Unreserving proxy announcement deposit for {}, amount {:?}",
-			translated_depositor.to_polkadot_ss58(),
-			announcement.deposit
-		);
 
 		let before = frame_system::Account::<T>::get(&translated_depositor);
 		let missing = <T as pallet_proxy::Config>::Currency::unreserve(

--- a/pallets/ah-migrator/src/referenda.rs
+++ b/pallets/ah-migrator/src/referenda.rs
@@ -174,8 +174,6 @@ impl<T: Config> Pallet<T> {
 		id: u32,
 		referendum: RcReferendumInfoOf<T, ()>,
 	) -> Result<(), Error<T>> {
-		log::debug!(target: LOG_TARGET, "Integrating referendum id: {id}, info: {referendum:?}");
-
 		let referendum: AhReferendumInfoOf<T, ()> = match referendum {
 			ReferendumInfo::Ongoing(status) => {
 				let cancel_referendum = |id, status: RcReferendumStatusOf<T, ()>| {
@@ -237,8 +235,6 @@ impl<T: Config> Pallet<T> {
 
 		alias::ReferendumInfoFor::<T>::insert(id, referendum);
 
-		log::debug!(target: LOG_TARGET, "Referendum {id} integrated");
-
 		Ok(())
 	}
 
@@ -253,9 +249,7 @@ impl<T: Config> Pallet<T> {
 		});
 
 		for (id, hash) in metadata {
-			log::debug!(target: LOG_TARGET, "Integrating referendum {id} metadata");
 			MetadataOf::<T, ()>::insert(id, hash);
-			log::debug!(target: LOG_TARGET, "Referendum {id} integrated");
 		}
 
 		Self::deposit_event(Event::BatchProcessed {

--- a/pallets/ah-migrator/src/scheduler.rs
+++ b/pallets/ah-migrator/src/scheduler.rs
@@ -63,8 +63,6 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn do_process_scheduler_message(message: RcSchedulerMessageOf<T>) -> Result<(), Error<T>> {
-		log::debug!(target: LOG_TARGET, "Processing scheduler message: {message:?}");
-
 		match message {
 			RcSchedulerMessage::IncompleteSince(block_number) => {
 				pallet_scheduler::IncompleteSince::<T>::put(block_number);

--- a/pallets/ah-migrator/src/society.rs
+++ b/pallets/ah-migrator/src/society.rs
@@ -46,59 +46,46 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn do_receive_society_message(message: PortableSocietyMessage) {
-		log::debug!(target: LOG_TARGET, "Processing society message: {message:?}");
-
 		let message = message.translate_accounts(&Self::translate_account_rc_to_ah);
 
 		match message {
 			PortableSocietyMessage::Values(values) => {
-				log::debug!(target: LOG_TARGET, "Integrating society values: {values:?}");
 				pallet_rc_migrator::society::SocietyValues::put_values::<T::KusamaConfig>(*values);
 			},
 			PortableSocietyMessage::Member(account, member) => {
-				log::debug!(target: LOG_TARGET, "Integrating society member: {account:?}, {member:?}");
 				let member: pallet_society::MemberRecord = member.into();
 				pallet_society::Members::<T::KusamaConfig>::insert(account, member);
 			},
 			PortableSocietyMessage::Payout(account, payout) => {
-				log::debug!(target: LOG_TARGET, "Integrating society payout: {account:?}, {payout:?}");
 				let payout: pallet_society::PayoutRecord<_, _> = payout.into();
 				pallet_society::Payouts::<T::KusamaConfig>::insert(account, payout);
 			},
 			PortableSocietyMessage::MemberByIndex(index, account) => {
-				log::debug!(target: LOG_TARGET, "Integrating society member by index: {index:?}, {account:?}");
 				pallet_society::MemberByIndex::<T::KusamaConfig>::insert(index, account);
 			},
 			PortableSocietyMessage::SuspendedMembers(account, member) => {
-				log::debug!(target: LOG_TARGET, "Integrating suspended society member: {account:?}, {member:?}");
 				let member: pallet_society::MemberRecord = member.into();
 				pallet_society::SuspendedMembers::<T::KusamaConfig>::insert(account, member);
 			},
 			PortableSocietyMessage::Candidates(account, candidacy) => {
-				log::debug!(target: LOG_TARGET, "Integrating society candidate: {account:?}, {candidacy:?}");
 				let candidacy: pallet_society::Candidacy<_, _> = candidacy.into();
 				pallet_society::Candidates::<T::KusamaConfig>::insert(account, candidacy);
 			},
 			PortableSocietyMessage::Votes(account1, account2, vote) => {
-				log::debug!(target: LOG_TARGET, "Integrating society vote: {account1:?}, {account2:?}, {vote:?}");
 				let vote: pallet_society::Vote = vote.into();
 				pallet_society::Votes::<T::KusamaConfig>::insert(account1, account2, vote);
 			},
 			PortableSocietyMessage::VoteClearCursor(account, cursor) => {
-				log::debug!(target: LOG_TARGET, "Integrating society vote clear cursor: {account:?}, {cursor:?}");
 				pallet_society::VoteClearCursor::<T::KusamaConfig>::insert(
 					account,
 					BoundedVec::<u8, KeyLenOf<pallet_society::Votes<T::KusamaConfig>>>::defensive_truncate_from(cursor),
 				);
 			},
 			PortableSocietyMessage::DefenderVotes(index, account, vote) => {
-				log::debug!(target: LOG_TARGET, "Integrating society defender vote: {index:?}, {account:?}, {vote:?}");
 				let vote: pallet_society::Vote = vote.into();
 				pallet_society::DefenderVotes::<T::KusamaConfig>::insert(index, account, vote);
 			},
 		}
-
-		log::debug!(target: LOG_TARGET, "Processed society message");
 	}
 }
 

--- a/pallets/ah-migrator/src/staking/bags_list.rs
+++ b/pallets/ah-migrator/src/staking/bags_list.rs
@@ -73,7 +73,6 @@ impl<T: Config> Pallet<T> {
 				};
 
 				pallet_bags_list::ListNodes::<T, I>::insert(&translated_id, &translated_node);
-				log::debug!(target: LOG_TARGET, "Integrating BagsListNode: {:?}", &translated_id);
 			},
 			PortableBagsListMessage::Bag { score, bag } => {
 				debug_assert!(!pallet_bags_list::ListBags::<T, I>::contains_key(score));
@@ -87,7 +86,6 @@ impl<T: Config> Pallet<T> {
 				};
 
 				pallet_bags_list::ListBags::<T, I>::insert(score, &translated_bag);
-				log::debug!(target: LOG_TARGET, "Integrating BagsListBag: {:?}", &score);
 			},
 		}
 

--- a/pallets/ah-migrator/src/staking/delegated_staking.rs
+++ b/pallets/ah-migrator/src/staking/delegated_staking.rs
@@ -78,8 +78,6 @@ impl<T: Config> Pallet<T> {
 	fn do_process_delegated_staking_message(
 		message: PortableDelegatedStakingMessage,
 	) -> Result<(), Error<T>> {
-		log::debug!(target: LOG_TARGET, "Processing delegated staking message: {message:?}");
-
 		match message {
 			PortableDelegatedStakingMessage::Delegators { delegator, agent, amount } => {
 				let delegation = pallet_delegated_staking::types::Delegation { agent, amount };

--- a/pallets/ah-migrator/src/staking/nom_pools.rs
+++ b/pallets/ah-migrator/src/staking/nom_pools.rs
@@ -21,7 +21,7 @@ use pallet_nomination_pools::BondedPoolInner;
 #[cfg(feature = "std")]
 use pallet_rc_migrator::staking::nom_pools::{tests, NomPoolsMigrator, NomPoolsStorageValues};
 
-use pallet_rc_migrator::{staking::nom_pools::BalanceOf, types::ToPolkadotSs58};
+use pallet_rc_migrator::staking::nom_pools::BalanceOf;
 
 /// Trait to provide account translation logic for bonded pool structures.
 ///
@@ -202,47 +202,36 @@ impl<T: Config> Pallet<T> {
 		match translated_message {
 			StorageValues { values } => {
 				pallet_rc_migrator::staking::nom_pools::NomPoolsMigrator::<T>::put_values(values);
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsStorageValues");
 			},
 			PoolMembers { member: (account_id, member_data) } => {
 				debug_assert!(!pallet_nomination_pools::PoolMembers::<T>::contains_key(
 					&account_id
 				));
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsPoolMember: {}",
-					account_id.to_polkadot_ss58());
 				pallet_nomination_pools::PoolMembers::<T>::insert(account_id, member_data);
 			},
 			BondedPools { pool: (pool_id, pool_data) } => {
 				debug_assert!(!pallet_nomination_pools::BondedPools::<T>::contains_key(pool_id));
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsBondedPool: {}", &pool_id);
 				pallet_nomination_pools::BondedPools::<T>::insert(pool_id, pool_data);
 			},
 			RewardPools { rewards } => {
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsRewardPool: {:?}", &rewards.0);
 				// Not sure if it is the best to use the alias here, but it is the easiest...
 				pallet_rc_migrator::staking::nom_pools_alias::RewardPools::<T>::insert(
 					rewards.0, rewards.1,
 				);
 			},
 			SubPoolsStorage { sub_pools } => {
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsSubPoolsStorage: {:?}", &sub_pools.0);
 				pallet_rc_migrator::staking::nom_pools_alias::SubPoolsStorage::<T>::insert(
 					sub_pools.0,
 					sub_pools.1,
 				);
 			},
 			Metadata { meta } => {
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsMetadata: {:?}", &meta.0);
 				pallet_nomination_pools::Metadata::<T>::insert(meta.0, meta.1);
 			},
 			ReversePoolIdLookup { lookups: (account_id, pool_id) } => {
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsReversePoolIdLookup: {}",
-					account_id.to_polkadot_ss58());
 				pallet_nomination_pools::ReversePoolIdLookup::<T>::insert(account_id, pool_id);
 			},
 			ClaimPermissions { perms: (account_id, permissions) } => {
-				log::debug!(target: LOG_TARGET, "Integrating NomPoolsClaimPermissions: {}",
-					account_id.to_polkadot_ss58());
 				pallet_nomination_pools::ClaimPermissions::<T>::insert(account_id, permissions);
 			},
 		}

--- a/pallets/ah-migrator/src/staking/staking_impl.rs
+++ b/pallets/ah-migrator/src/staking/staking_impl.rs
@@ -57,49 +57,39 @@ impl<T: Config> Pallet<T> {
 
 		match message {
 			Values(values) => {
-				log::debug!(target: LOG_TARGET, "Integrating StakingValues");
 				pallet_rc_migrator::staking::StakingMigrator::<T>::put_values(values);
 			},
 			Invulnerables(invulnerables) => {
-				log::debug!(target: LOG_TARGET, "Integrating StakingInvulnerables");
 				let bounded: BoundedVec<_, _> = invulnerables.defensive_truncate_into();
 				pallet_staking_async::Invulnerables::<T>::put(bounded);
 			},
 			Bonded { stash, controller } => {
-				log::debug!(target: LOG_TARGET, "Integrating Bonded of stash {stash:?}");
 				pallet_staking_async::Bonded::<T>::insert(stash, controller);
 			},
 			Ledger { controller, ledger } => {
-				log::debug!(target: LOG_TARGET, "Integrating Ledger of controller {controller:?}");
 				let ledger: pallet_staking_async::StakingLedger<_> = ledger.into();
 				pallet_staking_async::Ledger::<T>::insert(controller, ledger);
 			},
 			Payee { stash, payment } => {
-				log::debug!(target: LOG_TARGET, "Integrating Payee of stash {stash:?}");
 				let payment: pallet_staking_async::RewardDestination<_> = payment.into();
 				pallet_staking_async::Payee::<T>::insert(stash, payment);
 			},
 			Validators { stash, validators } => {
-				log::debug!(target: LOG_TARGET, "Integrating Validators of stash {stash:?}");
 				let validators: pallet_staking_async::ValidatorPrefs = validators.into();
 				pallet_staking_async::Validators::<T>::insert(stash, validators);
 			},
 			Nominators { stash, nominations } => {
-				log::debug!(target: LOG_TARGET, "Integrating Nominators of stash {stash:?}");
 				let nominations: pallet_staking_async::Nominations<_> = nominations.into();
 				pallet_staking_async::Nominators::<T>::insert(stash, nominations);
 			},
 			VirtualStakers(staker) => {
-				log::debug!(target: LOG_TARGET, "Integrating VirtualStakers of staker {staker:?}");
 				pallet_staking_async::VirtualStakers::<T>::insert(staker, ());
 			},
 			ErasStakersOverview { era, validator, exposure } => {
-				log::debug!(target: LOG_TARGET, "Integrating ErasStakersOverview {validator:?}/{era:?}");
 				let exposure: sp_staking::PagedExposureMetadata<_> = exposure.into();
 				pallet_staking_async::ErasStakersOverview::<T>::insert(era, validator, exposure);
 			},
 			ErasStakersPaged { era, validator, page, exposure } => {
-				log::debug!(target: LOG_TARGET, "Integrating ErasStakersPaged {validator:?}/{era:?}/{page:?}");
 				let exposure: pallet_staking_async::BoundedExposurePage<_> = exposure.into();
 				pallet_staking_async::ErasStakersPaged::<T>::insert(
 					(era, validator, page),
@@ -107,7 +97,6 @@ impl<T: Config> Pallet<T> {
 				);
 			},
 			ClaimedRewards { era, validator, rewards } => {
-				log::debug!(target: LOG_TARGET, "Integrating ErasClaimedRewards {validator:?}/{era:?}");
 				let bounded =
 					BoundedVec::<_, pallet_staking_async::ClaimedRewardsBound<T>>::defensive_truncate_from(
 						rewards,
@@ -116,25 +105,20 @@ impl<T: Config> Pallet<T> {
 				pallet_staking_async::ClaimedRewards::<T>::insert(era, validator, weak_bounded);
 			},
 			ErasValidatorPrefs { era, validator, prefs } => {
-				log::debug!(target: LOG_TARGET, "Integrating ErasValidatorPrefs {validator:?}/{era:?}");
 				let prefs: pallet_staking_async::ValidatorPrefs = prefs.into();
 				pallet_staking_async::ErasValidatorPrefs::<T>::insert(era, validator, prefs);
 			},
 			ErasValidatorReward { era, reward } => {
-				log::debug!(target: LOG_TARGET, "Integrating ErasValidatorReward of era {era:?}");
 				pallet_staking_async::ErasValidatorReward::<T>::insert(era, reward);
 			},
 			ErasRewardPoints { era, points } => {
-				log::debug!(target: LOG_TARGET, "Integrating ErasRewardPoints of era {era:?}");
 				let points: pallet_staking_async::EraRewardPoints<_> = points.into();
 				pallet_staking_async::ErasRewardPoints::<T>::insert(era, points);
 			},
 			ErasTotalStake { era, total_stake } => {
-				log::debug!(target: LOG_TARGET, "Integrating ErasTotalStake of era {era:?}");
 				pallet_staking_async::ErasTotalStake::<T>::insert(era, total_stake);
 			},
 			UnappliedSlashes { era, slash } => {
-				log::debug!(target: LOG_TARGET, "Integrating UnappliedSlashes of era {era:?}");
 				let slash_key = (slash.validator.clone(), Perbill::from_percent(99), 9999);
 				let slash: pallet_staking_async::UnappliedSlash<_> = slash.into();
 				pallet_staking_async::UnappliedSlashes::<T>::insert(era, slash_key, slash);
@@ -144,12 +128,10 @@ impl<T: Config> Pallet<T> {
 					log::error!("BondedEras already exists, skipping insert");
 					defensive_assert!(bonded_eras.is_empty());
 				} else {
-					log::debug!(target: LOG_TARGET, "Integrating BondedEras");
 					let bounded: BoundedVec<_, _> = bonded_eras.clone().defensive_truncate_into();
 					pallet_staking_async::BondedEras::<T>::put(bounded);
 				},
 			ValidatorSlashInEra { era, validator, slash } => {
-				log::debug!(target: LOG_TARGET, "Integrating ValidatorSlashInEra {validator:?}/{era:?}");
 				pallet_staking_async::ValidatorSlashInEra::<T>::insert(era, validator, slash);
 			},
 		}

--- a/pallets/ah-migrator/src/treasury.rs
+++ b/pallets/ah-migrator/src/treasury.rs
@@ -50,8 +50,6 @@ impl<T: Config> Pallet<T> {
 	}
 
 	fn do_process_treasury_message(message: PortableTreasuryMessage) -> Result<(), Error<T>> {
-		log::debug!(target: LOG_TARGET, "Processing treasury message: {message:?}");
-
 		match message {
 			PortableTreasuryMessage::ProposalCount(proposal_count) => {
 				pallet_treasury::ProposalCount::<T>::put(proposal_count);
@@ -108,7 +106,6 @@ impl<T: Config> Pallet<T> {
 					expire_at,
 					status,
 				};
-				log::debug!(target: LOG_TARGET, "Mapped treasury spend: {spend:?}");
 				pallet_treasury::Spends::<T>::insert(spend_index, spend);
 			},
 			PortableTreasuryMessage::LastSpendPeriod(last_spend_period) => {

--- a/pallets/ah-migrator/src/vesting.rs
+++ b/pallets/ah-migrator/src/vesting.rs
@@ -70,7 +70,6 @@ impl<T: Config> Pallet<T> {
 		}
 
 		pallet_vesting::Vesting::<T>::insert(&translated_account, &ah_schedules);
-		log::debug!(target: LOG_TARGET, "Integrated vesting schedule for {:?}, len {}", translated_account, ah_schedules.len());
 
 		Ok(())
 	}

--- a/pallets/rc-migrator/src/accounts.rs
+++ b/pallets/rc-migrator/src/accounts.rs
@@ -444,10 +444,6 @@ impl<T: Config> AccountsMigrator<T> {
 			// This scenario causes a panic in the test environment - see:
 			// https://github.com/paritytech/polkadot-sdk/blob/35e6befc5dd61deb154ff0eb7c180a038e626d66/substrate/frame/balances/src/impl_fungible.rs#L285
 			let amount = if free < rc_ed && amount.saturating_sub(rc_ed - free) > 0 {
-				log::debug!(
-					target: LOG_TARGET,
-					"Partially releasing hold to prevent the free balance from being burned"
-				);
 				let partial_amount = rc_ed - free;
 				if let Err(e) =
 					<T as Config>::Currency::release(&id, &who, partial_amount, Precision::Exact)
@@ -708,7 +704,6 @@ impl<T: Config> AccountsMigrator<T> {
 	/// The state is retrieved from storage if previously set, otherwise defaults to `Migrate`.
 	pub fn get_account_state(who: &T::AccountId) -> AccountStateFor<T> {
 		if let Some(state) = RcAccounts::<T>::get(who) {
-			log::debug!(target: LOG_TARGET, "Account state for '{}': {:?}", who.to_ss58check(), state);
 			return state;
 		}
 		AccountStateFor::<T>::Migrate
@@ -834,11 +829,6 @@ impl<T: Config> AccountsMigrator<T> {
 			.saturating_sub(missing_free);
 
 			if actual_rc_reserved == 0 {
-				log::debug!(
-					target: LOG_TARGET,
-					"Account doesn't have enough reserved balance to keep on RC. account: {:?}.",
-					id.to_ss58check(),
-				);
 				continue;
 			}
 
@@ -882,11 +872,6 @@ impl<T: Config> AccountsMigrator<T> {
 		weight += T::DbWeight::get().writes(1);
 		let on_demand_pallet_account: T::AccountId =
 			T::OnDemandPalletId::get().into_account_truncating();
-		log::debug!(
-			target: LOG_TARGET,
-			"Preserve on-demand pallet account on Relay Chain: '{:?}'",
-			on_demand_pallet_account.to_ss58check()
-		);
 		RcAccounts::<T>::insert(&on_demand_pallet_account, AccountState::Preserve);
 
 		weight

--- a/pallets/rc-migrator/src/asset_rate.rs
+++ b/pallets/rc-migrator/src/asset_rate.rs
@@ -92,13 +92,11 @@ impl<T: Config> PalletMigration for AssetRateMigrator<T> {
 
 			match iter.next() {
 				Some((key, value)) => {
-					log::debug!(target: LOG_TARGET, "Extracting asset rate for {:?}", &key);
 					ConversionRateToNative::<T>::remove(&key);
 					messages.push((key.clone(), value));
 					last_key = Some(key);
 				},
 				None => {
-					log::debug!(target: LOG_TARGET, "No more asset rates to migrate");
 					last_key = None;
 					break;
 				},

--- a/pallets/rc-migrator/src/bounties.rs
+++ b/pallets/rc-migrator/src/bounties.rs
@@ -130,20 +130,14 @@ impl<T: Config> PalletMigration for BountiesMigrator<T> {
 				BountiesStage::BountyCount => {
 					if pallet_bounties::BountyCount::<T>::exists() {
 						let count = pallet_bounties::BountyCount::<T>::take();
-						log::debug!(target: LOG_TARGET, "Migration BountyCount {:?}", &count);
 						messages.push(RcBountiesMessage::BountyCount(count));
-					} else {
-						log::debug!(target: LOG_TARGET, "Not migrating empty BountyCount");
 					}
 					BountiesStage::BountyApprovals
 				},
 				BountiesStage::BountyApprovals => {
 					if pallet_bounties::BountyApprovals::<T>::exists() {
 						let approvals = pallet_bounties::BountyApprovals::<T>::take();
-						log::debug!(target: LOG_TARGET, "Migration BountyApprovals {:?}", &approvals);
 						messages.push(RcBountiesMessage::BountyApprovals(approvals.into_inner()));
-					} else {
-						log::debug!(target: LOG_TARGET, "Not migrating empty BountyApprovals");
 					}
 					BountiesStage::BountyDescriptions { last_key: None }
 				},
@@ -155,11 +149,6 @@ impl<T: Config> PalletMigration for BountiesMigrator<T> {
 					};
 					match iter.next() {
 						Some((key, value)) => {
-							log::debug!(
-								target: LOG_TARGET,
-								"Migration BountyDescription for bounty {:?}",
-								&key
-							);
 							pallet_bounties::BountyDescriptions::<T>::remove(key);
 							messages.push(RcBountiesMessage::BountyDescriptions((
 								key,
@@ -178,7 +167,6 @@ impl<T: Config> PalletMigration for BountiesMigrator<T> {
 					};
 					match iter.next() {
 						Some((key, value)) => {
-							log::debug!(target: LOG_TARGET, "Migration Bounty {:?}", &key);
 							alias::Bounties::<T>::remove(key);
 							messages.push(RcBountiesMessage::Bounties((key, value)));
 							BountiesStage::Bounties { last_key: Some(key) }

--- a/pallets/rc-migrator/src/claims.rs
+++ b/pallets/rc-migrator/src/claims.rs
@@ -134,8 +134,6 @@ impl<T: Config> PalletMigration for ClaimsMigrator<T> {
 					if pallet_claims::Total::<T>::exists() {
 						let total = pallet_claims::Total::<T>::take();
 						messages.push(RcClaimsMessage::StorageValues { total });
-					} else {
-						log::debug!(target: LOG_TARGET, "Not migrating empty claims::Total");
 					}
 					ClaimsStage::Claims(None)
 				},

--- a/pallets/rc-migrator/src/crowdloan.rs
+++ b/pallets/rc-migrator/src/crowdloan.rs
@@ -233,7 +233,6 @@ impl<T: Config> PalletMigration for CrowdloanMigrator<T>
 
 							let unreserve_block = num_leases_to_ending_block::<T>(leases.len() as u32).defensive().map_err(|_| Error::<T>::Unreachable)?;
 
-							log::debug!(target: LOG_TARGET, "Migrating out lease reserve for para_id: {:?}, account: {:?}, amount: {:?}, unreserve_block: {:?}", &para_id, &lease_acc, &amount, &unreserve_block);
 							messages.push(RcCrowdloanMessage::LeaseReserve { unreserve_block, account: lease_acc.clone(), para_id, amount });
 							inner_key
 						},
@@ -282,8 +281,6 @@ impl<T: Config> PalletMigration for CrowdloanMigrator<T>
 						// We directly remove so that we dont have to store a cursor:
 						pallet_crowdloan::Pallet::<T>::contribution_kill(fund.fund_index, &contributor);
 
-						log::debug!(target: LOG_TARGET, "Migrating out crowdloan contribution for para_id: {:?}, contributor: {:?}, amount: {:?}, withdraw_block: {:?}", &para_id, &contributor, &amount, &withdraw_block);							
-
 						messages.push(RcCrowdloanMessage::CrowdloanContribution { withdraw_block, contributor, para_id, amount: amount.into(), crowdloan_account });
 					}
 					CrowdloanStage::CrowdloanContribution { last_key: Some(para_id) }
@@ -300,8 +297,6 @@ impl<T: Config> PalletMigration for CrowdloanMigrator<T>
 								continue;
 							}
 							let unreserve_block = num_leases_to_ending_block::<T>(leases.len() as u32).defensive().map_err(|_| Error::<T>::Unreachable)?;
-
-							log::debug!(target: LOG_TARGET, "Migrating out crowdloan deposit for para_id: {:?}, fund_index: {:?}, amount: {:?}, depositor: {:?}", &para_id, &fund.fund_index, &fund.deposit, &fund.depositor);
 
 							messages.push(RcCrowdloanMessage::CrowdloanReserve { unreserve_block, para_id, amount: fund.deposit.into(), depositor: fund.depositor });
 							inner_key

--- a/pallets/rc-migrator/src/indices.rs
+++ b/pallets/rc-migrator/src/indices.rs
@@ -110,7 +110,6 @@ impl<T: Config> PalletMigration for IndicesMigrator<T> {
 			match pallet_indices::Accounts::<T>::iter().next() {
 				Some((index, (who, deposit, frozen))) => {
 					pallet_indices::Accounts::<T>::remove(index);
-					log::debug!(target: LOG_TARGET, "Migrating index: {index:?}");
 					messages.push(RcIndicesIndex { index, who, deposit, frozen });
 					inner_key = Some(());
 				},

--- a/pallets/rc-migrator/src/lib.rs
+++ b/pallets/rc-migrator/src/lib.rs
@@ -1496,7 +1496,6 @@ pub mod pallet {
 				},
 				MigrationStage::WaitingForAh => {
 					// waiting AH to send a message and to start sending the data.
-					log::debug!(target: LOG_TARGET, "Waiting for AH to start the migration");
 					// We transition out here in `start_data_migration`
 					return weight_counter.consumed();
 				},
@@ -2456,10 +2455,6 @@ pub mod pallet {
 				);
 				return true;
 			}
-			log::debug!(
-				target: LOG_TARGET,
-				"No excess unconfirmed XCM messages: unconfirmed = {unconfirmed}, unprocessed_buffer = {unprocessed_buffer}"
-			);
 			false
 		}
 

--- a/pallets/rc-migrator/src/multisig.rs
+++ b/pallets/rc-migrator/src/multisig.rs
@@ -166,8 +166,6 @@ impl<T: Config> PalletMigration for MultisigMigrator<T> {
 				break;
 			};
 
-			log::debug!(target: LOG_TARGET, "Migrating multisigs of acc {k1:?}");
-
 			batch.push(RcMultisig { creator: multisig.depositor, deposit: multisig.deposit });
 
 			aliases::Multisigs::<T>::remove(&k1, k2);

--- a/pallets/rc-migrator/src/preimage/chunks.rs
+++ b/pallets/rc-migrator/src/preimage/chunks.rs
@@ -154,10 +154,6 @@ impl<T: Config> PalletMigration for PreimageChunkMigrator<T> {
 			});
 
 			last_offset += chunk_bytes.len() as u32;
-			log::debug!(
-				target: LOG_TARGET,
-				"Exported preimage chunk {next_key_inner:?} until offset {last_offset}"
-			);
 
 			// set the offset of the next_key
 			next_key = Some((next_key_inner, last_offset));

--- a/pallets/rc-migrator/src/preimage/legacy_request_status.rs
+++ b/pallets/rc-migrator/src/preimage/legacy_request_status.rs
@@ -142,7 +142,6 @@ impl<T: Config> PalletMigration for PreimageLegacyRequestStatusMigrator<T> {
 				_ => {},
 			}
 
-			log::debug!(target: LOG_TARGET, "Exported legacy preimage status for: {next_key_inner:?}");
 			next_key = Self::next_key(Some(next_key_inner));
 			// Remove the migrated key from the relay chain
 			pallet_preimage::StatusFor::<T>::remove(next_key_inner);

--- a/pallets/rc-migrator/src/preimage/request_status.rs
+++ b/pallets/rc-migrator/src/preimage/request_status.rs
@@ -203,7 +203,6 @@ impl<T: Config> PalletMigration for PreimageRequestStatusMigrator<T> {
 				hash: next_key_inner,
 				request_status: request_status.into_portable(),
 			});
-			log::debug!(target: LOG_TARGET, "Exported preimage request status for: {next_key_inner:?}");
 
 			next_key = Self::next_key(Some(next_key_inner));
 			// Remove the migrated key from the relay chain

--- a/pallets/rc-migrator/src/proxy.rs
+++ b/pallets/rc-migrator/src/proxy.rs
@@ -110,7 +110,6 @@ impl<T: Config> PalletMigration for ProxyProxiesMigrator<T> {
 								.collect::<Vec<_>>()
 								.defensive_truncate_into();
 							let deposit: BalanceOf<T> = Zero::zero();
-							log::debug!(target: LOG_TARGET, "Pure account {} gets {} proxies for free: {:?}", acc.to_ss58check(), free_proxies.len(), free_proxies);
 
 							if !free_proxies.is_empty() {
 								pallet_proxy::Proxies::<T>::insert(&acc, (free_proxies, deposit));

--- a/pallets/rc-migrator/src/referenda.rs
+++ b/pallets/rc-migrator/src/referenda.rs
@@ -81,8 +81,6 @@ impl<T: Config> PalletMigration for ReferendaMigrator<T> {
 
 impl<T: Config> ReferendaMigrator<T> {
 	fn migrate_values(weight_counter: &mut WeightMeter) -> Result<(), Error<T>> {
-		log::debug!(target: LOG_TARGET, "Migrating referenda values");
-
 		let referendum_count =
 			ReferendumCount::<T, ()>::exists().then(ReferendumCount::<T, ()>::take);
 
@@ -126,8 +124,6 @@ impl<T: Config> ReferendaMigrator<T> {
 		mut last_key: Option<u32>,
 		weight_counter: &mut WeightMeter,
 	) -> Result<Option<u32>, Error<T>> {
-		log::debug!(target: LOG_TARGET, "Migrating referenda metadata");
-
 		let mut batch = XcmBatchAndMeter::new_from_config::<T>();
 
 		let last_key = loop {
@@ -222,8 +218,6 @@ impl<T: Config> ReferendaMigrator<T> {
 		mut last_key: Option<u32>,
 		weight_counter: &mut WeightMeter,
 	) -> Result<Option<u32>, Error<T>> {
-		log::debug!(target: LOG_TARGET, "Migrating referenda info");
-
 		// we should not send more than AH can handle within the block.
 		let mut ah_weight_counter = WeightMeter::with_limit(T::MaxAhWeight::get());
 

--- a/pallets/rc-migrator/src/vesting.rs
+++ b/pallets/rc-migrator/src/vesting.rs
@@ -119,7 +119,6 @@ impl<T: Config> PalletMigration for VestingMigrator<T> {
 				Some((who, schedules)) => {
 					pallet_vesting::Vesting::<T>::remove(&who);
 					messages.push(RcVestingSchedule { who: who.clone(), schedules });
-					log::debug!(target: LOG_TARGET, "Migrating vesting schedules for {who:?}");
 					inner_key = Some(who);
 				},
 				None => {


### PR DESCRIPTION
Remove debug logs to reduce the wasm size

```
> ls -lha target/production/wbuild/asset-hub-kusama-runtime
...
...   3.0M Sep 29 18:49 asset_hub_kusama_runtime.compact.compressed.wasm
...   13M Sep 29 18:55 asset_hub_kusama_runtime.compact.wasm
...   14M Sep 29 18:49 asset_hub_kusama_runtime.wasm

>  stat target/production/wbuild/asset-hub-kusama-runtime/asset_hub_kusama_runtime.compact.compressed.wasm
16777231 107046852 -rw-r--r-- 1 ___ staff 0 3166241 "Sep 29 18:55:55 2025" "Sep 29 18:49:45 2025" "Sep 29 18:55:54 2025" "Aug 25 11:29:01 2025" 4096 6192 0 target/production/wbuild/asset-hub-kusama-runtime/asset_hub_kusama_runtime.compact.compressed.wasm
```

- [x] Does not require a CHANGELOG entry