### PR TITLE
Don't migrate staking era forcing info to AH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Do not migrate staking era forcing info to AH ([polkadot-fellows/runtimes/pull/939](https://github.com/polkadot-fellows/runtimes/pull/939))
+
 ## [1.9.1] 30.09.2025
 
 ### Fixed

--- a/pallets/ah-migrator/src/staking/checks.rs
+++ b/pallets/ah-migrator/src/staking/checks.rs
@@ -55,7 +55,6 @@ impl<T: crate::Config> crate::types::AhMigrationCheck
 			rc.active_era.map(translate_active_era),
 			pallet_staking_async::ActiveEra::<T>::get()
 		);
-		// assert_eq!(translate_forcing(rc.force_era), pallet_staking_async::ForceEra::<T>::get());
 		assert_eq!(rc.max_staked_rewards, pallet_staking_async::MaxStakedRewards::<T>::get());
 		assert_eq!(rc.slash_reward_fraction, pallet_staking_async::SlashRewardFraction::<T>::get());
 		assert_eq!(rc.canceled_slash_payout, pallet_staking_async::CanceledSlashPayout::<T>::get());
@@ -146,16 +145,6 @@ fn translate_reward_destination(
 
 fn translate_active_era(era: pallet_staking::ActiveEraInfo) -> pallet_staking_async::ActiveEraInfo {
 	pallet_staking_async::ActiveEraInfo { index: era.index, start: era.start }
-}
-
-fn translate_forcing(forcing: pallet_staking::Forcing) -> pallet_staking_async::Forcing {
-	use pallet_staking_async::Forcing;
-	match forcing {
-		pallet_staking::Forcing::NotForcing => Forcing::NotForcing,
-		pallet_staking::Forcing::ForceNew => Forcing::ForceNew,
-		pallet_staking::Forcing::ForceNone => Forcing::ForceNone,
-		pallet_staking::Forcing::ForceAlways => Forcing::ForceAlways,
-	}
 }
 
 fn translate_validator_prefs(

--- a/pallets/ah-migrator/src/staking/checks.rs
+++ b/pallets/ah-migrator/src/staking/checks.rs
@@ -55,7 +55,7 @@ impl<T: crate::Config> crate::types::AhMigrationCheck
 			rc.active_era.map(translate_active_era),
 			pallet_staking_async::ActiveEra::<T>::get()
 		);
-		assert_eq!(translate_forcing(rc.force_era), pallet_staking_async::ForceEra::<T>::get());
+		// assert_eq!(translate_forcing(rc.force_era), pallet_staking_async::ForceEra::<T>::get());
 		assert_eq!(rc.max_staked_rewards, pallet_staking_async::MaxStakedRewards::<T>::get());
 		assert_eq!(rc.slash_reward_fraction, pallet_staking_async::SlashRewardFraction::<T>::get());
 		assert_eq!(rc.canceled_slash_payout, pallet_staking_async::CanceledSlashPayout::<T>::get());

--- a/pallets/rc-migrator/src/staking/checks.rs
+++ b/pallets/rc-migrator/src/staking/checks.rs
@@ -138,7 +138,7 @@ impl<T: crate::Config> crate::types::RcMigrationCheck for StakingMigratedCorrect
 		assert!(!MaxNominatorsCount::<T>::exists());
 		assert!(!CurrentEra::<T>::exists());
 		assert!(!ActiveEra::<T>::exists());
-		assert!(!ForceEra::<T>::exists());
+		// assert!(!ForceEra::<T>::exists());
 		assert!(!MaxStakedRewards::<T>::exists());
 		assert!(!SlashRewardFraction::<T>::exists());
 		assert!(!CanceledSlashPayout::<T>::exists());

--- a/pallets/rc-migrator/src/staking/message.rs
+++ b/pallets/rc-migrator/src/staking/message.rs
@@ -175,7 +175,7 @@ pub struct StakingValues<Balance> {
 	pub max_nominators_count: Option<u32>,
 	pub current_era: Option<EraIndex>,
 	pub active_era: Option<PortableActiveEraInfo>,
-	pub force_era: Option<PortableForcing>,
+	// pub force_era: Option<PortableForcing>,
 	pub max_staked_rewards: Option<Percent>,
 	pub slash_reward_fraction: Option<Perbill>,
 	pub canceled_slash_payout: Option<Balance>,
@@ -234,10 +234,11 @@ impl<T: pallet_staking_async::Config> StakingMigrator<T> {
 			ActiveEra::<T>::put(&active_era);
 			CurrentEra::<T>::put(active_era.index);
 		});
-		values.force_era.map(|force_era| {
-			let force_era: pallet_staking_async::Forcing = force_era.into();
-			ForceEra::<T>::put(force_era);
-		});
+		// don't interpret the forcing, as it is is artificially set to ForceNone on RC.
+		// values.force_era.map(|force_era| {
+		// 	let force_era: pallet_staking_async::Forcing = force_era.into();
+		// 	ForceEra::<T>::put(force_era);
+		// });
 		values.max_staked_rewards.map(MaxStakedRewards::<T>::put);
 		values.slash_reward_fraction.map(SlashRewardFraction::<T>::put);
 		values.canceled_slash_payout.map(CanceledSlashPayout::<T>::put);

--- a/pallets/rc-migrator/src/staking/message.rs
+++ b/pallets/rc-migrator/src/staking/message.rs
@@ -175,7 +175,7 @@ pub struct StakingValues<Balance> {
 	pub max_nominators_count: Option<u32>,
 	pub current_era: Option<EraIndex>,
 	pub active_era: Option<PortableActiveEraInfo>,
-	// pub force_era: Option<PortableForcing>,
+	pub force_era: Option<PortableForcing>,
 	pub max_staked_rewards: Option<Percent>,
 	pub slash_reward_fraction: Option<Perbill>,
 	pub canceled_slash_payout: Option<Balance>,

--- a/pallets/rc-migrator/src/staking/message.rs
+++ b/pallets/rc-migrator/src/staking/message.rs
@@ -200,9 +200,8 @@ impl<T: pallet_staking::Config> StakingMigrator<T> {
 			max_nominators_count: MaxNominatorsCount::<T>::take(),
 			current_era: CurrentEra::<T>::take(),
 			active_era: ActiveEra::<T>::take().map(IntoPortable::into_portable),
-			force_era: ForceEra::<T>::exists()
-				.then(ForceEra::<T>::take)
-				.map(IntoPortable::into_portable),
+			// always send `Forcing::NotForcing`, as we want the value to stay put in RC.
+			force_era: Forcing::NotForcing.into_portable().into(),
 			max_staked_rewards: MaxStakedRewards::<T>::take(),
 			slash_reward_fraction: SlashRewardFraction::<T>::exists()
 				.then(SlashRewardFraction::<T>::take),
@@ -234,11 +233,11 @@ impl<T: pallet_staking_async::Config> StakingMigrator<T> {
 			ActiveEra::<T>::put(&active_era);
 			CurrentEra::<T>::put(active_era.index);
 		});
-		// don't interpret the forcing, as it is is artificially set to ForceNone on RC.
-		// values.force_era.map(|force_era| {
-		// 	let force_era: pallet_staking_async::Forcing = force_era.into();
-		// 	ForceEra::<T>::put(force_era);
-		// });
+		// this will always be Forcing::NotForcing, so it will be a no-op
+		values.force_era.map(|force_era| {
+			let force_era: pallet_staking_async::Forcing = force_era.into();
+			ForceEra::<T>::put(force_era);
+		});
 		values.max_staked_rewards.map(MaxStakedRewards::<T>::put);
 		values.slash_reward_fraction.map(SlashRewardFraction::<T>::put);
 		values.canceled_slash_payout.map(CanceledSlashPayout::<T>::put);


### PR DESCRIPTION
Doing it quick and dirty way here, just ignoring it on the recipient, to minimize code change. 