### PR TITLE
[AHM]: manually fix proxy tests for whales

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,8 +209,8 @@ jobs:
       - name: Download Kusama snaps
         run: |
           python3 -m pip install gdown
-          gdown 1ypya2WHc1f47H5ahLzXzUmLjGD9z8VpQ # 2025-09-24 AH
-          gdown 1I7odLC3fPcfPsRTTbeNz9rbjtYTdDsjR # 2025-09-24 RC
+          gdown 1btR8mE32WpqhH7BpB9Ci5xQhs3UTzRx4 # 2025-10-07 AH
+          gdown 1C4C1GBDMQSA-m6Ezpf-ozrlM2nFP6H7R # 2025-10-07 RC
 
           lz4 -d kusama.snap.lz4 kusama.snap
           lz4 -d ah-kusama.snap.lz4 ah-kusama.snap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [AHM] Small fixes to successfully dry-run migration tests ([polkadot-fellows/runtimes/pull/942](https://github.com/polkadot-fellows/runtimes/pull/942))
 - [AHM] Fix crowdloan withdrawing and weight limit ([polkadot-fellows/runtimes/pull/943](https://github.com/polkadot-fellows/runtimes/pull/943))
 - [Encointer] Fix remote treasury payout on asset hub ([polkadot-fellows/runtimes/pull/944](https://github.com/polkadot-fellows/runtimes/pull/944))
+- [AHM] Fix integration tests for whales (https://github.com/polkadot-fellows/runtimes/pull/945)
 
 ## [1.9.1] 30.09.2025
 

--- a/integration-tests/ahm/src/proxy/whale_watching.rs
+++ b/integration-tests/ahm/src/proxy/whale_watching.rs
@@ -40,7 +40,7 @@ const WHALES: &[(AccountId32, usize)] = &[
 #[cfg(feature = "kusama-ahm")]
 const WHALES: &[(AccountId32, usize)] = &[
 	(AccountId32::new(hex!("b07540f07739fd2e72661b5e6a3ad6e1349c175b90f7f03501dda388f150cbb4")), 6),
-	(AccountId32::new(hex!("224b4123952e63a0ef3ecb41a4d283d0df1b36d7024eb19072a217f89572b089")), 4),
+	(AccountId32::new(hex!("224b4123952e63a0ef3ecb41a4d283d0df1b36d7024eb19072a217f89572b089")), 5),
 	(AccountId32::new(hex!("5280a6d07acb3d96e732c49f1b2aa75cbfcfdbcd5f7530ad9a026ddeff3e0bbe")), 2),
 ];
 


### PR DESCRIPTION
The whale watching integration test is fragile and requires adjustment e.g. each time a whale creates or removes a new proxy. This is one of the cases.
