### PR TITLE
Release 1.9.2 for Kusama Relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [1.9.2] 08.10.2025
 
 ### Fixed
 

--- a/relay/kusama/src/ah_migration/phase1.rs
+++ b/relay/kusama/src/ah_migration/phase1.rs
@@ -138,7 +138,7 @@ pub fn call_allowed_status(call: &<Runtime as frame_system::Config>::RuntimeCall
 		MessageQueue(..) => (ON, ON), // contains non-permissioned service calls
 		AssetRate(..) => (OFF, OFF),
 		Beefy(..) => (ON, ON), // For reporting equivocation proofs; security relevant
-		RcMigrator(..) => (ON, ON), // Required for the migration, only permissioned calls
+		RcMigrator(..) => (ON, OFF), // Permissioned calls during the migration and not needed after
 
 		// Kusama specific calls
 		Society(..) => (OFF, OFF),  // migrating pallet

--- a/relay/kusama/src/ah_migration/phase1.rs
+++ b/relay/kusama/src/ah_migration/phase1.rs
@@ -138,7 +138,7 @@ pub fn call_allowed_status(call: &<Runtime as frame_system::Config>::RuntimeCall
 		MessageQueue(..) => (ON, ON), // contains non-permissioned service calls
 		AssetRate(..) => (OFF, OFF),
 		Beefy(..) => (ON, ON), // For reporting equivocation proofs; security relevant
-		RcMigrator(..) => (ON, OFF), // Permissioned calls during the migration and not needed after
+		RcMigrator(..) => (ON, ON), // Required for the migration, only permissioned calls
 
 		// Kusama specific calls
 		Society(..) => (OFF, OFF),  // migrating pallet

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("kusama"),
 	impl_name: alloc::borrow::Cow::Borrowed("parity-kusama"),
 	authoring_version: 2,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 26,

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -175,7 +175,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: alloc::borrow::Cow::Borrowed("polkadot"),
 	impl_name: alloc::borrow::Cow::Borrowed("parity-polkadot"),
 	authoring_version: 0,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 26,

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -143,7 +143,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("statemine"),
 	impl_name: Cow::Borrowed("statemine"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 15,

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -191,7 +191,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: Cow::Borrowed("statemint"),
 	spec_name: Cow::Borrowed("statemint"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 15,

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -180,7 +180,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("bridge-hub-kusama"),
 	impl_name: Cow::Borrowed("bridge-hub-kusama"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 5,

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -210,7 +210,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("bridge-hub-polkadot"),
 	impl_name: Cow::Borrowed("bridge-hub-polkadot"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,

--- a/system-parachains/collectives/collectives-polkadot/src/lib.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("collectives"),
 	impl_name: Cow::Borrowed("collectives"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 7,

--- a/system-parachains/coretime/coretime-kusama/src/lib.rs
+++ b/system-parachains/coretime/coretime-kusama/src/lib.rs
@@ -154,7 +154,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("coretime-kusama"),
 	impl_name: Cow::Borrowed("coretime-kusama"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/system-parachains/coretime/coretime-polkadot/src/lib.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("coretime-polkadot"),
 	impl_name: Cow::Borrowed("coretime-polkadot"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/system-parachains/encointer/src/lib.rs
+++ b/system-parachains/encointer/src/lib.rs
@@ -146,7 +146,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("encointer-parachain"),
 	impl_name: Cow::Borrowed("encointer-parachain"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,

--- a/system-parachains/gluttons/glutton-kusama/src/lib.rs
+++ b/system-parachains/gluttons/glutton-kusama/src/lib.rs
@@ -94,7 +94,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("glutton"),
 	impl_name: Cow::Borrowed("glutton"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/system-parachains/people/people-kusama/src/lib.rs
+++ b/system-parachains/people/people-kusama/src/lib.rs
@@ -175,7 +175,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-kusama"),
 	impl_name: Cow::Borrowed("people-kusama"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -163,7 +163,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("people-polkadot"),
 	impl_name: Cow::Borrowed("people-polkadot"),
 	authoring_version: 1,
-	spec_version: 1_009_001,
+	spec_version: 1_009_002,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,


### PR DESCRIPTION
To release the Post Kusama AHM Cleanup. Waiting for https://github.com/polkadot-fellows/runtimes/pull/946
