### PR TITLE
Fix depencencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7959,7 +7959,7 @@ checksum = "b3e3e3f549d27d2dc054372f320ddf68045a833fab490563ff70d4cf1b9d91ea"
 dependencies = [
  "array-bytes 9.3.0",
  "blake3",
- "frame-metadata 21.0.0",
+ "frame-metadata 23.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -8483,7 +8483,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -12224,7 +12224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -12257,7 +12257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "GPL-3.0-only"                                        # TODO <https://
 pallet-ah-migrator = { path = "pallets/ah-migrator", default-features = false }
 pallet-rc-migrator = { path = "pallets/rc-migrator", default-features = false }
 pallet-ah-ops = { path = "pallets/ah-ops", default-features = false }
-pallet-election-provider-multi-block = { version = "0.3.2", default-features = false }
-pallet-staking-async = { version = "0.6.2", default-features = false }
+pallet-election-provider-multi-block = { version = "0.4.0", default-features = false }
+pallet-staking-async = { version = "0.5.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 rand = { version = "0.9.2" }
 impl-trait-for-tuples = { version = "0.2.3", default-features = false }
@@ -215,7 +215,7 @@ snowbridge-beacon-primitives = { version = "0.16.1", default-features = false }
 snowbridge-core = { version = "0.16.0", default-features = false }
 snowbridge-merkle-tree = { version = "0.5.0", default-features = false }
 snowbridge-outbound-queue-runtime-api = { version = "0.16.0", default-features = false }
-snowbridge-outbound-queue-v2-runtime-api = { version = "0.4.0", default-features = false }
+snowbridge-outbound-queue-v2-runtime-api = { version = "0.5.0", default-features = false }
 snowbridge-outbound-queue-primitives = { version = "0.5.0", default-features = false }
 snowbridge-pallet-ethereum-client = { version = "0.16.1", default-features = false }
 snowbridge-pallet-inbound-queue = { version = "0.16.1", default-features = false }
@@ -231,7 +231,7 @@ snowbridge-inbound-queue-primitives = { version = "0.5.0", default-features = fa
 snowbridge-runtime-common = { version = "0.17.0", default-features = false }
 snowbridge-runtime-test-common = { version = "0.19.0" }
 snowbridge-system-runtime-api = { version = "0.16.0", default-features = false }
-snowbridge-system-v2-runtime-api = { version = "0.4.0", default-features = false }
+snowbridge-system-v2-runtime-api = { version = "0.5.0", default-features = false }
 sp-api = { version = "39.0.0", default-features = false }
 sp-application-crypto = { version = "43.0.0", default-features = false }
 sp-arithmetic = { version = "28.0.0", default-features = false }


### PR DESCRIPTION
This PR fixes the dependency mess that we still have in the update branch.

The issues with encointer's dependencies was that we only introduced patch bumps for the stable202509 upgrade to keep being aligned with the polkadot-sdk releases (we messed up the rhythm, as the unstable branch was a major release for us). The patch bump did not propagate to our innermost dependencies in the lock file, as it was deemed compatible with the ones explicitly defined in the root toml.

So this PR fixes (I believe all) of the duplicate substrate dependencies by running

1.  `cargo update -p encointer-crates-at-wrong-version`
2. `psvm --version polkadot-stable2509-1`