### PR TITLE
Fix deps once more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
  "asset-hub-kusama-runtime",
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "kusama-emulated-chain",
  "parachains-common",
@@ -947,7 +947,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "sp-core 38.1.0",
  "sp-keyring",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
 ]
 
@@ -960,7 +960,7 @@ dependencies = [
  "asset-test-utils",
  "cumulus-pallet-parachain-system",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "hex-literal",
  "integration-tests-helpers",
  "kusama-runtime-constants",
@@ -975,9 +975,9 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "staging-kusama-runtime",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
  "xcm-runtime-apis",
@@ -1001,12 +1001,12 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -1052,7 +1052,7 @@ dependencies = [
  "pallet-society",
  "pallet-staking",
  "pallet-staking-async",
- "pallet-staking-async-rc-client 0.4.0",
+ "pallet-staking-async-rc-client",
  "pallet-staking-runtime-api",
  "pallet-state-trie-migration",
  "pallet-timestamp",
@@ -1076,26 +1076,26 @@ dependencies = [
  "scale-info",
  "serde_json",
  "snowbridge-inbound-queue-primitives",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
- "sp-npos-elections 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
  "sp-storage",
  "sp-tracing 19.0.0",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "sp-weights",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -1111,7 +1111,7 @@ dependencies = [
  "asset-hub-polkadot-runtime",
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "parachains-common",
  "penpal-emulated-chain",
@@ -1120,7 +1120,7 @@ dependencies = [
  "snowbridge-inbound-queue-primitives",
  "sp-core 38.1.0",
  "sp-keyring",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -1134,7 +1134,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "hex-literal",
  "integration-tests-helpers",
  "pallet-asset-conversion",
@@ -1148,8 +1148,8 @@ dependencies = [
  "polkadot-runtime",
  "polkadot-runtime-common",
  "polkadot-system-emulated-network",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
  "xcm-runtime-apis",
@@ -1174,12 +1174,12 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -1220,7 +1220,7 @@ dependencies = [
  "pallet-session",
  "pallet-staking",
  "pallet-staking-async",
- "pallet-staking-async-rc-client 0.4.0",
+ "pallet-staking-async-rc-client",
  "pallet-staking-runtime-api",
  "pallet-state-trie-migration",
  "pallet-timestamp",
@@ -1248,26 +1248,26 @@ dependencies = [
  "snowbridge-outbound-queue-primitives",
  "snowbridge-pallet-system-frontend",
  "snowbridge-runtime-common",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
- "sp-npos-elections 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
  "sp-storage",
  "sp-tracing 19.0.0",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "sp-weights",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -1284,8 +1284,8 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-asset-conversion",
  "pallet-assets",
  "pallet-balances",
@@ -1297,10 +1297,10 @@ dependencies = [
  "parachains-common",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "xcm-runtime-apis",
@@ -1314,8 +1314,8 @@ checksum = "1d5ca479930426bccab622fd7143a67519485528f66b492cffae286081439c1b"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "pallet-asset-conversion",
  "pallet-assets",
@@ -1325,10 +1325,10 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "tracing",
@@ -1892,11 +1892,11 @@ name = "bp-asset-hub-kusama"
 version = "1.0.0"
 dependencies = [
  "bp-xcm-bridge-hub-router",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "system-parachains-constants",
 ]
 
@@ -1905,11 +1905,11 @@ name = "bp-asset-hub-polkadot"
 version = "1.0.0"
 dependencies = [
  "bp-xcm-bridge-hub-router",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "system-parachains-constants",
 ]
 
@@ -1922,11 +1922,11 @@ dependencies = [
  "bp-messages",
  "bp-polkadot-core",
  "bp-runtime",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "parachains-common",
  "polkadot-primitives",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -1939,11 +1939,11 @@ dependencies = [
  "bp-messages",
  "bp-polkadot-core",
  "bp-runtime",
- "frame-support 43.0.0",
+ "frame-support",
  "kusama-runtime-constants",
  "polkadot-runtime-constants",
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
  "system-parachains-constants",
 ]
@@ -1957,14 +1957,14 @@ dependencies = [
  "bp-messages",
  "bp-polkadot-core",
  "bp-runtime",
- "frame-support 43.0.0",
+ "frame-support",
  "kusama-runtime-constants",
  "polkadot-runtime-constants",
  "snowbridge-core",
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "system-parachains-constants",
 ]
 
@@ -1976,13 +1976,13 @@ checksum = "9e415fb4d858ab9b27e0bf5c5883e01e1bc35468ac46558ceadeb8093d641806"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-consensus-grandpa",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1994,12 +1994,12 @@ checksum = "ff86db9ed6270997854bb077653a6560e928b50b117464fec284f3655cf95c92"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-std",
 ]
 
@@ -2012,12 +2012,12 @@ dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
  "bp-runtime",
- "frame-support 43.0.0",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2029,13 +2029,13 @@ checksum = "e72e648bba5f69cec033e46d7a7b4e3ee58cf363f5b989dbe52e8106599531bb"
 dependencies = [
  "bp-messages",
  "bp-runtime",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2049,12 +2049,12 @@ dependencies = [
  "bp-messages",
  "bp-parachains",
  "bp-runtime",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -2064,8 +2064,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611d5d02051e93598c9ea1fa629ff7f57315febbd2bb2a79c7729a48e0217dc6"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "hash-db",
  "impl-trait-for-tuples",
  "num-traits",
@@ -2073,9 +2073,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
  "sp-trie",
  "tracing",
@@ -2095,10 +2095,10 @@ dependencies = [
  "ed25519-dalek",
  "finality-grandpa",
  "parity-scale-codec",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-trie",
 ]
@@ -2111,14 +2111,14 @@ checksum = "073ba9fea997e650b57411824f7d1d6c77afba2021cb55ca88e057f463d75653"
 dependencies = [
  "bp-messages",
  "bp-runtime",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -2130,8 +2130,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -2141,15 +2141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e32327ba5087ba4e828b64569017b7b88c6cf6351ac79818d46f6c167170690e"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 43.0.0",
+ "frame-support",
  "pallet-message-queue",
  "parity-scale-codec",
  "scale-info",
  "snowbridge-core",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -2162,11 +2162,11 @@ dependencies = [
  "bridge-hub-common",
  "bridge-hub-kusama-runtime",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "parachains-common",
  "sp-core 38.1.0",
  "sp-keyring",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
  "bridge-hub-kusama-runtime",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "hex-literal",
  "integration-tests-helpers",
  "kusama-polkadot-system-emulated-network",
@@ -2199,8 +2199,8 @@ dependencies = [
  "snowbridge-pallet-outbound-queue",
  "snowbridge-pallet-system",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
  "xcm-runtime-apis",
@@ -2233,11 +2233,11 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -2272,22 +2272,22 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -2304,11 +2304,11 @@ dependencies = [
  "bridge-hub-common",
  "bridge-hub-polkadot-runtime",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "parachains-common",
  "sp-core 38.1.0",
  "sp-keyring",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -2324,7 +2324,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "hex-literal",
  "integration-tests-helpers",
  "kusama-polkadot-system-emulated-network",
@@ -2352,9 +2352,9 @@ dependencies = [
  "snowbridge-pallet-system-frontend",
  "snowbridge-pallet-system-v2",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "system-parachains-constants",
@@ -2388,11 +2388,11 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -2446,22 +2446,22 @@ dependencies = [
  "snowbridge-runtime-test-common",
  "snowbridge-system-runtime-api",
  "snowbridge-system-v2-runtime-api",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -2486,8 +2486,8 @@ dependencies = [
  "bp-test-utils",
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "pallet-balances",
  "pallet-bridge-grandpa",
@@ -2502,12 +2502,12 @@ dependencies = [
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-tracing 19.0.0",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "tracing",
@@ -2525,8 +2525,8 @@ dependencies = [
  "bp-polkadot-core",
  "bp-relayers",
  "bp-runtime",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-bridge-grandpa",
  "pallet-bridge-messages",
  "pallet-bridge-parachains",
@@ -2535,12 +2535,12 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "sp-trie",
  "sp-weights",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "static_assertions",
  "tracing",
  "tuplex",
@@ -2887,7 +2887,7 @@ dependencies = [
  "collectives-polkadot-runtime",
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "parachains-common",
  "sp-core 38.1.0",
 ]
@@ -2904,7 +2904,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "pallet-asset-rate",
  "pallet-assets",
@@ -2921,8 +2921,8 @@ dependencies = [
  "polkadot-runtime-constants",
  "polkadot-system-emulated-network",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-executor",
  "system-parachains-constants",
  "xcm-runtime-apis",
@@ -2941,11 +2941,11 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -2984,22 +2984,22 @@ dependencies = [
  "polkadot-runtime-constants",
  "scale-info",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -3183,7 +3183,7 @@ dependencies = [
  "coretime-kusama-runtime",
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "parachains-common",
  "sp-core 38.1.0",
 ]
@@ -3196,7 +3196,7 @@ dependencies = [
  "coretime-kusama-runtime",
  "cumulus-pallet-parachain-system",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "kusama-runtime-constants",
  "kusama-system-emulated-network",
@@ -3209,9 +3209,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "staging-kusama-runtime",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "xcm-runtime-apis",
 ]
@@ -3228,11 +3228,11 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -3263,20 +3263,20 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -3291,7 +3291,7 @@ dependencies = [
  "coretime-polkadot-runtime",
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "parachains-common",
  "sp-core 38.1.0",
 ]
@@ -3304,7 +3304,7 @@ dependencies = [
  "coretime-polkadot-runtime",
  "cumulus-pallet-parachain-system",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "pallet-balances",
  "pallet-broker",
@@ -3317,8 +3317,8 @@ dependencies = [
  "polkadot-runtime-constants",
  "polkadot-runtime-parachains",
  "polkadot-system-emulated-network",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-executor",
  "xcm-runtime-apis",
 ]
@@ -3335,11 +3335,11 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -3370,21 +3370,21 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -3700,15 +3700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae71c2557c310fe8fc6bb49f4a9be0813675845c3418ec598287b53842711a1"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-aura",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3723,9 +3723,9 @@ dependencies = [
  "cumulus-primitives-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
  "environmental",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hashbrown 0.15.4",
  "impl-trait-for-tuples",
  "log",
@@ -3737,14 +3737,14 @@ dependencies = [
  "sp-consensus-babe",
  "sp-core 38.1.0",
  "sp-externalities",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std",
  "sp-trie",
- "sp-version 42.0.0",
- "staging-xcm 19.0.0",
+ "sp-version",
+ "staging-xcm",
  "staging-xcm-builder",
  "trie-db",
 ]
@@ -3767,12 +3767,12 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8756b178fffef8c8ddaa84b0c97ac6ba2394a426b60b0ceac4e08fcd5b675d6"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3782,13 +3782,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a9728ca4bccdd222e3dbaf86730904649b007c35ffc75df496b01426ee91bd6"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -3801,18 +3801,18 @@ dependencies = [
  "bounded-collections 0.3.2",
  "bp-xcm-bridge-hub-router",
  "cumulus-primitives-core",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-message-queue",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "tracing",
@@ -3824,7 +3824,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af72499950fe7e8a02da9510418a90e2f9c7d4fb413a01d1889dd38641fcfedd"
 dependencies = [
- "sp-api 39.0.0",
+ "sp-api",
  "sp-consensus-aura",
 ]
 
@@ -3839,10 +3839,10 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "scale-info",
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-trie",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "tracing",
 ]
 
@@ -3857,7 +3857,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-inherents 39.0.0",
+ "sp-inherents",
  "sp-trie",
 ]
 
@@ -3879,13 +3879,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17dca78e1628a375ddf5d815b0d84c7748b40823c25df0f9d5a33d30c02ccb8"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 43.0.0",
+ "frame-support",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -3899,8 +3899,8 @@ dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-trie",
 ]
 
@@ -4468,8 +4468,8 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "pallet-asset-conversion",
  "pallet-assets",
@@ -4491,8 +4491,8 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 38.1.0",
  "sp-keyring",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "xcm-emulator",
@@ -4522,14 +4522,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aa0b67234535e526f39513912aee1addb688af609a6b1f8774cb8476ee4810"
 dependencies = [
  "encointer-primitives",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-asset-tx-payment",
  "pallet-encointer-balances",
  "pallet-encointer-ceremonies",
  "pallet-transaction-payment",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4539,10 +4539,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54d15bb99f9d4654ebac056c02bc41f13184c3b32bc8e07140ac1f58c9b898ed"
 dependencies = [
  "encointer-primitives",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -4553,7 +4553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9838146c5e514267fe14dbede864129504aee4bb4b46324f99af1fafa7db6a36"
 dependencies = [
  "encointer-primitives",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -4564,14 +4564,14 @@ dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
  "encointer-kusama-runtime",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "kusama-emulated-chain",
  "parachains-common",
  "polkadot-parachain-primitives",
  "sp-core 38.1.0",
  "sp-keyring",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
 ]
 
@@ -4584,7 +4584,7 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "emulated-integration-tests-common",
  "encointer-kusama-runtime",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "kusama-runtime-constants",
  "kusama-system-emulated-network",
@@ -4596,10 +4596,10 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-tracing 19.0.0",
  "staging-kusama-runtime",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "xcm-runtime-apis",
@@ -4620,11 +4620,11 @@ dependencies = [
  "encointer-balances-tx-payment",
  "encointer-balances-tx-payment-rpc-runtime-api",
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -4673,21 +4673,21 @@ dependencies = [
  "scale-info",
  "serde_json",
  "smallvec",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-tracing 19.0.0",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -4705,7 +4705,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -4718,14 +4718,14 @@ dependencies = [
  "bs58",
  "crc",
  "ep-core",
- "frame-support 43.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "substrate-geohash",
 ]
@@ -4812,7 +4812,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
  "substrate-fixed",
 ]
@@ -4830,7 +4830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5111,49 +5111,24 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b574ee6e347515ef5009a895e537922f6139f278842897c43c68d93e1d1d00d"
-dependencies = [
- "frame-support 42.0.0",
- "frame-support-procedural",
- "frame-system 42.0.0",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 38.0.0",
- "sp-application-crypto 42.0.0",
- "sp-core 38.1.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-runtime-interface 31.0.0",
- "sp-storage",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
 version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "766acd80fe6ac9504415051fc183f67511eabf764a3bef74813d4111c4558774"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "frame-support-procedural",
- "frame-system 43.0.0",
+ "frame-system",
  "linregress",
  "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-runtime-interface 32.0.0",
  "sp-storage",
  "static_assertions",
@@ -5201,37 +5176,19 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86eea8dcef5ce472448e2dbef18fda47af32bdd79c8f752be0b166dc56355da7"
-dependencies = [
- "frame-election-provider-solution-type",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core 38.1.0",
- "sp-npos-elections 38.0.0",
- "sp-runtime 43.0.0",
- "sp-std",
-]
-
-[[package]]
-name = "frame-election-provider-support"
 version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8ddd171c606313e738594a9dabe2d2a911239e6a78b5419faf2a2d6b106570c"
 dependencies = [
  "frame-election-provider-solution-type",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-npos-elections 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-npos-elections",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -5242,15 +5199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2897ed8d2696f4f7cadef11b6deabd74da7173bacf20919f8711f458fa2038cc"
 dependencies = [
  "aquamarine",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-try-runtime",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-tracing 19.0.0",
 ]
 
@@ -5297,12 +5254,12 @@ dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
  "docify",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5319,55 +5276,13 @@ dependencies = [
  "serde",
  "sp-core 38.1.0",
  "sp-crypto-hashing",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "spinners",
  "substrate-rpc-client",
  "tokio",
  "tokio-retry",
-]
-
-[[package]]
-name = "frame-support"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318417cb0d270d4a5bb8fff1619501ffbb5c484735e54113a9d9c381ad43c8fe"
-dependencies = [
- "aquamarine",
- "array-bytes 6.2.3",
- "binary-merkle-tree",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata 23.0.0",
- "frame-support-procedural",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "sp-api 38.0.0",
- "sp-arithmetic",
- "sp-core 38.1.0",
- "sp-crypto-hashing-proc-macro",
- "sp-debug-derive",
- "sp-genesis-builder 0.19.0",
- "sp-inherents 38.0.0",
- "sp-io 42.0.0",
- "sp-metadata-ir",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
- "sp-state-machine 0.47.0",
- "sp-std",
- "sp-tracing 18.0.0",
- "sp-trie",
- "sp-weights",
- "tt-call",
 ]
 
 [[package]]
@@ -5393,18 +5308,18 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core 38.1.0",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-metadata-ir",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
- "sp-state-machine 0.48.0",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std",
  "sp-tracing 19.0.0",
  "sp-trie",
@@ -5459,41 +5374,21 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8643078c6b60d4082dd566b25004ca74bce5241a167cde9e87a5ae939eeca471"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 42.0.0",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.1.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-version 41.0.0",
- "sp-weights",
-]
-
-[[package]]
-name = "frame-system"
 version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ec7d4d9abe4ec9ad4a48c88ddcf654e92a47393001d55760244a906a282c9e"
 dependencies = [
  "cfg-if",
  "docify",
- "frame-support 43.0.0",
+ "frame-support",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-version 42.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-version",
  "sp-weights",
 ]
 
@@ -5503,13 +5398,13 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b953ecbcccb719ec37ee0bb3711618d61ca390e9755b57a276ae536a577b66e6"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5520,7 +5415,7 @@ checksum = "aeb2ff9f335375bd834a6af597e4111e9101848e407aa61442934b8f631e874c"
 dependencies = [
  "docify",
  "parity-scale-codec",
- "sp-api 39.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -5529,10 +5424,10 @@ version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42efe41db00ed663234c202a65a97c28dfbbec37618752518127d9bb41834541"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -5791,10 +5686,10 @@ dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -5805,19 +5700,19 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -5840,8 +5735,8 @@ version = "1.0.0"
 dependencies = [
  "asset-hub-kusama-runtime",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "integration-tests-helpers",
  "kusama-system-emulated-network",
  "pallet-utility",
@@ -5849,9 +5744,9 @@ dependencies = [
  "pallet-xcm",
  "parity-scale-codec",
  "people-kusama-runtime",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "staging-kusama-runtime",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -5861,8 +5756,8 @@ dependencies = [
  "asset-hub-polkadot-runtime",
  "collectives-polkadot-runtime",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "integration-tests-helpers",
  "pallet-utility",
  "pallet-whitelist",
@@ -5870,8 +5765,8 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-runtime",
  "polkadot-system-emulated-network",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -6396,7 +6291,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6743,7 +6638,7 @@ dependencies = [
  "pallet-message-queue",
  "pallet-xcm",
  "paste",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "xcm-emulator",
 ]
 
@@ -7260,7 +7155,7 @@ dependencies = [
 name = "kusama-runtime-constants"
 version = "1.0.0"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "pallet-remote-proxy",
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7268,7 +7163,7 @@ dependencies = [
  "scale-info",
  "smallvec",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-trie",
  "sp-weights",
  "staging-xcm-builder",
@@ -8106,7 +8001,7 @@ checksum = "b3e3e3f549d27d2dc054372f320ddf68045a833fab490563ff70d4cf1b9d91ea"
 dependencies = [
  "array-bytes 9.3.0",
  "blake3",
- "frame-metadata 21.0.0",
+ "frame-metadata 23.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -8630,7 +8525,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -8783,10 +8678,10 @@ version = "0.1.0"
 dependencies = [
  "assets-common",
  "cumulus-primitives-core",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "hex",
  "hex-literal",
  "impl-trait-for-tuples",
@@ -8824,13 +8719,13 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "serde",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -8840,19 +8735,19 @@ name = "pallet-ah-ops"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-assets",
  "pallet-balances",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -8863,9 +8758,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaaa91418d315f73e94875f4f85d6953d0088e2f86021779fffcabc8b62fe3b2"
 dependencies = [
  "array-bytes 6.2.3",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-collective",
  "pallet-identity",
@@ -8873,8 +8768,8 @@ dependencies = [
  "scale-info",
  "sp-core 38.1.0",
  "sp-crypto-hashing",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8883,17 +8778,17 @@ version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb23b86d86619906c25c620a6f3c6fda7501d5bcbdf248c4fa379dfdce2982e"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8902,14 +8797,14 @@ version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce237c16b2807ad7c925b52cbb76bb99963f0450dbc835b088fbb5947b591d3f"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-asset-conversion",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8918,13 +8813,13 @@ version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e6cf89229b15eacd5a183070f4c1d5cd8fc9abc88e0593fb8482d6c3375534"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8933,15 +8828,15 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f4496707130bee919b33918c177e6e1f2fd3bb1fc36e255198f09f26d7c04"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8950,15 +8845,15 @@ version = "46.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7a2c9d0649080827c36a0326b752cecd8b78d81f73941860ca6b8a6597447a"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8967,15 +8862,15 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c73adf2f98b4ba1987c76db61513de8e328ca0ece93e706c6673d74c489f344"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -8984,14 +8879,14 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21778643fbeae9aac693eb7b821001f118622d6e9e8a81cefea8bc4c4155fe9c"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-authority-discovery",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9000,12 +8895,12 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b1edb2ecfdea55cfed3c70caa111d1fdb9d78e473855bb58ffc7197011d6fa5"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9014,22 +8909,22 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ffa13591db366cde0f31f54f8f39f97bc41110af1f46a5992fe7fc890e2c29"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-consensus-babe",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9040,17 +8935,17 @@ checksum = "1af799e28fb8c7623073634cd626a5a5da0ce8eab733bfb4aba8dfc90593f03f"
 dependencies = [
  "aquamarine",
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-tracing 19.0.0",
 ]
 
@@ -9061,14 +8956,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536039f21421a4b7b75d11cb4420b0d568c6fd194275be98a874655a8f096286"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9077,8 +8972,8 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556ef14617f8742e7385cae6917e48a1d1a3226daee38cf11099b836cac53ea6"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -9086,9 +8981,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-consensus-beefy",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9099,9 +8994,9 @@ checksum = "d2a7c7b05fcab1e4e9ba0cd5ea1c13f72eb5da5a5ec8335a6fa578c601831fe9"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-beefy",
  "pallet-mmr",
@@ -9109,12 +9004,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-consensus-beefy",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
@@ -9123,16 +9018,16 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd85812158bdf790ed4cd4423c091d4bf2972bccd0e0cd5504bc0e3d1ab15bfc"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9144,13 +9039,13 @@ dependencies = [
  "bp-header-chain",
  "bp-runtime",
  "bp-test-utils",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-consensus-grandpa",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
  "tracing",
 ]
@@ -9164,12 +9059,12 @@ dependencies = [
  "bp-header-chain",
  "bp-messages",
  "bp-runtime",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-trie",
  "tracing",
@@ -9185,13 +9080,13 @@ dependencies = [
  "bp-parachains",
  "bp-polkadot-core",
  "bp-runtime",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-bridge-grandpa",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
  "tracing",
 ]
@@ -9206,9 +9101,9 @@ dependencies = [
  "bp-messages",
  "bp-relayers",
  "bp-runtime",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-bridge-grandpa",
  "pallet-bridge-messages",
  "pallet-bridge-parachains",
@@ -9216,7 +9111,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "tracing",
 ]
 
@@ -9227,16 +9122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ba8a692b6503d1a228efa8c5d716dd03f91b9c25aefc89bae59e870bb754ae"
 dependencies = [
  "bitvec",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9245,17 +9140,17 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2ffb248d8ac2287f9e3daaa0222ea5b587ab2f8504a460cb1ed7c340e08e318"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-bounties",
  "pallet-treasury",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9264,9 +9159,9 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9248bd8e80c0f2e51061a360e02efbe38f231a0b12b9e9256a244ee762b119e"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-balances",
@@ -9274,8 +9169,8 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9285,15 +9180,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "620c2e8c2b88e4c9416a0b16accec13f361afab22194908ce58ac12645fe0b1a"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9303,14 +9198,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "208b505c86cf25c52c941fdde492c5688550d331670e611b9345b9190f08c9aa"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9319,17 +9214,17 @@ version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e71a07e17e2a89ee7c99ab9105a644d5336311db40292a43466fa856e7cfdf5"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-ranked-collective",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9338,14 +9233,14 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3df175469ae3069491f165c5d597c9a60fb2fc8c41b4929770740606258839d"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9354,19 +9249,19 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc2b132811bcf24495d2021180e15e237514a767b2826b22e0d9756450716c0"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-npos-elections 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9376,19 +9271,19 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a52fbda7fde4ff99e21cb48234d1dd7082f8da7eed5bcdca537e08cc9ad3159"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-npos-elections 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
  "strum 0.26.3",
 ]
 
@@ -9398,12 +9293,12 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10ba5199e9358197afe345fa4e6fb2da0e39dd7a3b9d8349725ff1e880af5072"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-system",
  "parity-scale-codec",
- "sp-npos-elections 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-npos-elections",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9414,15 +9309,15 @@ checksum = "a982bfe7b9f9da04200ab6b58197ddca30e95190d1daef068aa26fe1ddb87567"
 dependencies = [
  "approx",
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-asset-tx-payment",
  "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9433,9 +9328,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bbb27b0845cc057edfe8857380eda3f8b2de11d841bc1a8da3fec41ba8cbe86"
 dependencies = [
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-encointer-communities",
  "parity-scale-codec",
@@ -9451,9 +9346,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10eec59dd34ea3730d6d3dc6aac1c377418f11e7290b0edf739728d10cce30e1"
 dependencies = [
  "encointer-primitives",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -9466,9 +9361,9 @@ dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-encointer-balances",
  "pallet-encointer-communities",
@@ -9476,10 +9371,10 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9490,9 +9385,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a3ed1efab29844171d1b9e3159d0020b4d440a40fb122a91bf2dba4a491317"
 dependencies = [
  "encointer-primitives",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -9503,16 +9398,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ff0cb74f2f71719b3e153ba97ed164d22831ab508763038433425fb4d3dc7a"
 dependencies = [
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-encointer-balances",
  "pallet-encointer-scheduler",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9524,7 +9419,7 @@ checksum = "9fa9b06ef2820188a0bf2333089524254beb48430a62ab1b165bc735ed505909"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -9535,9 +9430,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71105fb71856466032f6ed4d7dd9791586ebdec3aede31360c1cf5f2312b196b"
 dependencies = [
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-encointer-ceremonies",
  "pallet-encointer-communities",
@@ -9547,10 +9442,10 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9562,16 +9457,16 @@ checksum = "c1b67a8943b0c3d249ff8f5034b27b62b24353d8a7d8d939f59787eebc36d0fc"
 dependencies = [
  "approx",
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-encointer-communities",
  "pallet-encointer-reputation-commitments",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9583,9 +9478,9 @@ checksum = "db4ac27f86c76e6f8f7c1b3c00c566d0feffc62b671fb708e023dec4fb295d15"
 dependencies = [
  "approx",
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-encointer-ceremonies",
  "pallet-encointer-communities",
@@ -9594,7 +9489,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9605,15 +9500,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217a66d05d13b3ea949129e00226519daa8ad7286ec538aa59858e726a089046"
 dependencies = [
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9625,9 +9520,9 @@ checksum = "303c5c1d2b84a894d2e2ca4ee3b083e4a335d2c0e225858af0e4b1ebc5d79d49"
 dependencies = [
  "approx",
  "encointer-primitives",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-encointer-balances",
  "pallet-encointer-communities",
@@ -9636,7 +9531,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -9647,10 +9542,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa5a45676c2d7daa046a185661009dbd42c5e59add6bba651204ddd15f59459"
 dependencies = [
  "encointer-primitives",
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -9661,16 +9556,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e4e280592339eb88823ecc4cca310bf5367b5c9d73cb63943bf083ed8cecf7"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9680,16 +9575,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5a4f8dc1d84da21f71e6ec960c3b888e92c3e4c1de155b1d9804af98c6b113"
 dependencies = [
  "blake2 0.10.6",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9698,21 +9593,21 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89c680a32b0ca4e0316348f4ab3d8472a5ed6922c1ef636c746c7fc681111a26"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-consensus-grandpa",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9722,14 +9617,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c53932cca6029c103d75dc5c5a1d015039d38de67a5713aa0769d478071da9"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9738,18 +9633,18 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3168cb2089405ffc38842b0f3146547101f825b843c931cae257e8e08a29afa9"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9758,14 +9653,14 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7db5d03b82ce6bacc04dc25c05960bbe1198c839e212ce1c6701da490e628e6"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9786,15 +9681,15 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6180843b3fea1b679d1f39d9c45fd3bb3461f23569fd9815e6d02ecdb2bc89b2"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9804,16 +9699,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bf589acfe78eb44a9acc45f4d3b64e73fe178cf68587135e11461625d490462"
 dependencies = [
  "environmental",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -9824,17 +9719,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f7ecc141fa35634970ba9568a9930d985ec27a53714bacbdbb0883d1142e628"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9883,15 +9778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09138b5034ac335980fa22726d56137d2cef324055e6ee4ceebadfd5f4d7d8ab"
 dependencies = [
  "enumflags2",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -9901,7 +9796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37cb496a8f0cfb4fadb2b7563839aca6d87ace59be3afc1b2df473a84fa5a159"
 dependencies = [
  "parity-scale-codec",
- "sp-api 39.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -9921,16 +9816,16 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e43220f061551773e884b33996d35164ef5c3b7edc2a1868735b18f30e4c08"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-tracing 19.0.0",
 ]
 
@@ -9940,19 +9835,19 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0aad0a17823791a10e5ce2b5bb2c74dd8116e71713f2f499978b2e3f78c80b"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "pallet-bags-list",
  "pallet-delegated-staking",
  "pallet-nomination-pools",
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-runtime-interface 32.0.0",
- "sp-staking 41.0.0",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9963,7 +9858,7 @@ checksum = "dd26a2a3b347533e64e4372632e1678d26d453ff2d1a53bfacc2e6b81759478a"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
- "sp-api 39.0.0",
+ "sp-api",
 ]
 
 [[package]]
@@ -9972,14 +9867,14 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f14ee247baad8738bea1282f0d8f99619b1a50f839207756f99d011c5079849"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -9988,10 +9883,10 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d50173c7000f381213cc7553b580cb6b2829865b0b30cf0b7bf425cd737f08"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-babe",
  "pallet-balances",
@@ -10002,8 +9897,8 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10013,15 +9908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4806298448f61b32a96239dc298761f69452701f48042d245054ff378fb61a"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10030,15 +9925,15 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4426b05c265cca148c9b5df1e809f9b453e62f1c86fd68467286c04a5797b11a"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10058,27 +9953,27 @@ version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "594609026d1744e2a662b6ba5a6570f1deeb5612ad93de1c0a0e80f40f2ea9b5"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-rc-migrator"
 version = "0.1.0"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "impl-trait-for-tuples",
  "log",
@@ -10115,11 +10010,11 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -10142,16 +10037,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8932d89996118a472a7a061ef412f4407c3641272ab453103b933c004ef3cc"
 dependencies = [
  "assert_matches",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10160,18 +10055,18 @@ version = "1.0.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-balances",
  "pallet-proxy",
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-trie",
 ]
 
@@ -10186,9 +10081,9 @@ dependencies = [
  "environmental",
  "ethereum-standards",
  "ethereum-types",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "humantime-serde",
  "impl-trait-for-tuples",
@@ -10211,14 +10106,14 @@ dependencies = [
  "rlp 0.6.1",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-consensus-aura",
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "substrate-bn",
  "subxt-signer 0.41.0",
 ]
@@ -10237,7 +10132,7 @@ dependencies = [
  "polkavm-linker 0.27.0",
  "serde_json",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
  "toml 0.8.23",
 ]
 
@@ -10285,14 +10180,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff81b8f8f4282d3e436609d48f598e35f029e56fac4bdcbd2376c21a68cf3ea6"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -10302,8 +10197,8 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88e61bebb5bfdd5be045eb902776bc376cb6b5b568eb1e616e7814f8aa74ecc"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-balances",
@@ -10311,11 +10206,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
- "sp-state-machine 0.48.0",
+ "sp-staking",
+ "sp-state-machine",
  "sp-trie",
 ]
 
@@ -10325,14 +10220,14 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59126f9f4988f4b835f82cf62e66141443e6ace41cf2cddc76368753f8d17937"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
  "rand 0.8.5",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
 ]
 
@@ -10342,16 +10237,16 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9858f3975276bfac0ea27e7a4488514735a3cb301aaa6d3c67730042dc288f"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10360,10 +10255,10 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce23099893b90f921c53ce92db08d3b9ada8ec532f3ea125e9b117236ee4808"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
@@ -10371,34 +10266,35 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-application-crypto 43.0.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
 name = "pallet-staking-async"
-version = "0.6.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5d872880114aa775ae374d217a1f22e25a72df323451ce9905c05d2ae4401d"
+checksum = "3da3269c028fac46ff7b3a2ebf88eefe6e9777fed336778b09f420ffb5d70e39"
 dependencies = [
- "frame-benchmarking 42.0.0",
- "frame-election-provider-support 42.0.0",
- "frame-support 42.0.0",
- "frame-system 42.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "log",
- "pallet-staking-async-rc-client 0.5.0",
+ "pallet-staking-async-rc-client",
  "parity-scale-codec",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-application-crypto 42.0.0",
+ "sp-application-crypto",
  "sp-core 38.1.0",
- "sp-io 42.0.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10407,19 +10303,19 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ac03aaabe946ebc26b93e8047eb5adcd0c7fb73af4fe6efbaac7ae7df181edf"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-authorship",
  "pallet-session",
- "pallet-staking-async-rc-client 0.4.0",
+ "pallet-staking-async-rc-client",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10428,34 +10324,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab4b6e0d5e116d7a82a540572b4c0f2630da3706c21e5129c1febb7c212e924"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
- "staging-xcm 19.0.0",
-]
-
-[[package]]
-name = "pallet-staking-async-rc-client"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf81d91ffeeb7da45327ac8b852030e95a316555702ff3cc066f3e7db659ecd"
-dependencies = [
- "frame-support 42.0.0",
- "frame-system 42.0.0",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core 38.1.0",
- "sp-runtime 43.0.0",
- "sp-staking 40.0.0",
- "staging-xcm 18.0.0",
+ "sp-runtime",
+ "sp-staking",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -10487,8 +10365,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96637e1c53c699c03456a33bd7c070939be84f701c0f524ab12d70bf59256b9e"
 dependencies = [
  "parity-scale-codec",
- "sp-api 39.0.0",
- "sp-staking 41.0.0",
+ "sp-api",
+ "sp-staking",
 ]
 
 [[package]]
@@ -10497,15 +10375,15 @@ version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3fffb516a1425627e207517e7cf3518ef8f09ae6886d22d67d27132e606d21"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10515,13 +10393,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a5bd043ab6161ce4a06daab4fb646d6ea09058bb5021607386b5486dd0c6d79"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10531,14 +10409,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e7ef0a40eb925e3b5d10b8f673f4cd0e5fa9b0faa3d2cc38af7acf574c62b31"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-storage",
  "sp-timestamp",
 ]
@@ -10549,14 +10427,14 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d32ad5952a49c3f06c71f2536aeb42808761272ade7ea76b54527f11cfeb0d6"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10567,8 +10445,8 @@ checksum = "45b7aaf47d75c74ff26649290a694c4e4252467bbc9433c9c472bbabb324fc95"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -10579,9 +10457,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7bd354ff36d74e80050e71c87c7497dc57db9b9a02ab66c8e97b04e2613d87"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-balances",
@@ -10589,7 +10467,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10598,13 +10476,13 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae28e37d5a0616f270fb69483c1ee82948c5c7772beb481f6125ec115a6924a"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10613,14 +10491,14 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff9841c0c0f081b7534c9900f5d5c72183887bd04f1cdfd7145627582cb68602"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10629,13 +10507,13 @@ version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90efd95270046942079947991a2d8331186683b97e086c4146755ad702796f30"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -10656,9 +10534,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1494fdace5286d530b46ed4a802e3ae2c01e4be1f397ec6e989e9387f726f661"
 dependencies = [
  "bounded-collections 0.3.2",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "pallet-balances",
  "pallet-revive",
@@ -10666,9 +10544,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "tracing",
@@ -10681,14 +10559,14 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5268816c31ee0a68d3c20bd560c9f67cf6111dc8cacddfc85cbc9b52976bd6"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -10702,15 +10580,15 @@ dependencies = [
  "bp-messages",
  "bp-runtime",
  "bp-xcm-bridge-hub",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-bridge-messages",
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "tracing",
@@ -10723,16 +10601,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd4b7ced8d14d8efb7a6d07fcc04b25869010ebc05f090d3aa2d7b6d5ab0c16"
 dependencies = [
  "bp-xcm-bridge-hub-router",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "tracing",
 ]
@@ -10745,8 +10623,8 @@ checksum = "ea0c0137a802599040cb6f666588fb25db08a6447b5b61b18f11646a6eb483cc"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
@@ -10761,10 +10639,10 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "tracing",
 ]
@@ -10780,8 +10658,8 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-sproof-builder",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-balances",
  "pallet-collator-selection",
  "pallet-session",
@@ -10792,11 +10670,11 @@ dependencies = [
  "polkadot-parachain-primitives",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-tracing 19.0.0",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "xcm-runtime-apis",
 ]
@@ -10959,14 +10837,14 @@ version = "1.0.0"
 dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "kusama-emulated-chain",
  "parachains-common",
  "penpal-runtime",
  "polkadot-emulated-chain",
  "sp-core 38.1.0",
  "sp-keyring",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -10983,11 +10861,11 @@ dependencies = [
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -11017,21 +10895,21 @@ dependencies = [
  "scale-info",
  "serde_json",
  "smallvec",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -11046,7 +10924,7 @@ version = "1.0.0"
 dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "kusama-emulated-chain",
  "kusama-runtime-constants",
  "parachains-common",
@@ -11062,7 +10940,7 @@ dependencies = [
  "asset-test-utils",
  "cumulus-pallet-parachain-system",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "kusama-runtime-constants",
  "kusama-system-emulated-network",
@@ -11074,9 +10952,9 @@ dependencies = [
  "parity-scale-codec",
  "people-kusama-runtime",
  "polkadot-runtime-common",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "staging-kusama-runtime",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "xcm-runtime-apis",
 ]
@@ -11094,11 +10972,11 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
  "enumflags2",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -11130,20 +11008,20 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -11157,7 +11035,7 @@ version = "1.0.0"
 dependencies = [
  "cumulus-primitives-core",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "parachains-common",
  "people-polkadot-runtime",
  "polkadot-emulated-chain",
@@ -11173,7 +11051,7 @@ dependencies = [
  "asset-test-utils",
  "cumulus-pallet-parachain-system",
  "emulated-integration-tests-common",
- "frame-support 43.0.0",
+ "frame-support",
  "integration-tests-helpers",
  "pallet-balances",
  "pallet-identity",
@@ -11186,8 +11064,8 @@ dependencies = [
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
  "polkadot-system-emulated-network",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-executor",
  "xcm-runtime-apis",
 ]
@@ -11205,11 +11083,11 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
  "enumflags2",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
  "frame-metadata-hash-extension",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -11240,20 +11118,20 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -11441,7 +11319,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11459,7 +11337,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-beefy",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -11476,7 +11354,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-weights",
 ]
 
@@ -11495,17 +11373,17 @@ dependencies = [
  "polkadot-parachain-primitives",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots",
  "sp-core 38.1.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
+ "sp-runtime",
+ "sp-staking",
  "sp-std",
  "thiserror 1.0.69",
 ]
@@ -11516,13 +11394,13 @@ version = "1.0.0"
 dependencies = [
  "approx",
  "binary-merkle-tree",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
  "frame-remote-externalities",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -11563,7 +11441,7 @@ dependencies = [
  "pallet-session-benchmarking",
  "pallet-staking",
  "pallet-staking-async-ah-client",
- "pallet-staking-async-rc-client 0.4.0",
+ "pallet-staking-async-rc-client",
  "pallet-staking-reward-curve",
  "pallet-staking-reward-fn",
  "pallet-staking-runtime-api",
@@ -11587,8 +11465,8 @@ dependencies = [
  "scale-info",
  "separator",
  "serde_json",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -11596,22 +11474,22 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 38.1.0",
  "sp-debug-derive",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
- "sp-npos-elections 39.0.0",
+ "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
  "sp-storage",
  "sp-tracing 19.0.0",
  "sp-transaction-pool",
  "sp-trie",
- "sp-version 42.0.0",
+ "sp-version",
  "ss58-registry",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -11626,10 +11504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4fff9195f82fcbcf43d32921111abfa0a8bf208c66797bc26353f8d2a1f4b5"
 dependencies = [
  "bitvec",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "libsecp256k1",
  "log",
@@ -11655,16 +11533,16 @@ dependencies = [
  "scale-info",
  "serde",
  "slot-range-helper",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-core 38.1.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
- "sp-npos-elections 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-npos-elections",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
- "staging-xcm 19.0.0",
+ "sp-staking",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "static_assertions",
@@ -11674,7 +11552,7 @@ dependencies = [
 name = "polkadot-runtime-constants"
 version = "1.0.0"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "pallet-remote-proxy",
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11682,7 +11560,7 @@ dependencies = [
  "scale-info",
  "smallvec",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-trie",
  "sp-weights",
  "staging-xcm-builder",
@@ -11695,7 +11573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97f2125c2672c7b6b3d284fc8adfeb0f39fc2dcc3b779017b07e26743f0c617e"
 dependencies = [
  "bs58",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-tracing 19.0.0",
@@ -11709,10 +11587,10 @@ checksum = "a328d3fbbf9b702bb087be43fd9ae325061ad759f9d87793e44589c865ea052e"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "log",
  "pallet-authority-discovery",
@@ -11734,19 +11612,19 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-inherents",
+ "sp-io",
  "sp-keystore",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
  "sp-std",
  "sp-tracing 19.0.0",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "static_assertions",
 ]
@@ -11758,10 +11636,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36b4da1d09fe585a15f540d32767ad91d247c8908ca11eb1b95b44d09b2ffcf"
 dependencies = [
  "docify",
- "frame-benchmarking 43.0.0",
+ "frame-benchmarking",
  "frame-executive",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -11769,22 +11647,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-arithmetic",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-grandpa",
  "sp-core 38.1.0",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
  "sp-storage",
  "sp-transaction-pool",
- "sp-version 42.0.0",
+ "sp-version",
 ]
 
 [[package]]
@@ -12328,7 +12206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -12361,7 +12239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -12480,7 +12358,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12759,8 +12637,8 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "scale-info",
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13072,14 +12950,14 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8afb9cf740bd98bae3520b6b5b465f5a329bf3f8e9253aff0700537cf4cff6c"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
 ]
 
@@ -13217,7 +13095,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13230,7 +13108,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13321,7 +13199,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13447,12 +13325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d81a79f28855011b168fb61a3c500eb859a4a3a4cff5e5a644c2b88c7d328ae"
 dependencies = [
  "parity-scale-codec",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-block-builder",
  "sp-blockchain",
  "sp-core 38.1.0",
- "sp-inherents 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-trie",
 ]
 
@@ -13476,10 +13354,10 @@ dependencies = [
  "sp-blockchain",
  "sp-core 38.1.0",
  "sp-crypto-hashing",
- "sp-genesis-builder 0.20.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-genesis-builder",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-tracing 19.0.0",
 ]
 
@@ -13509,14 +13387,14 @@ dependencies = [
  "sc-executor",
  "sc-transaction-pool-api",
  "sc-utils",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-blockchain",
  "sp-consensus",
  "sp-core 38.1.0",
  "sp-database",
  "sp-externalities",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-storage",
  "sp-trie",
  "substrate-prometheus-endpoint",
@@ -13540,8 +13418,8 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-runtime",
+ "sp-state-machine",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -13577,8 +13455,8 @@ dependencies = [
  "sc-transaction-pool-api",
  "sc-utils",
  "serde_json",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
@@ -13586,7 +13464,7 @@ dependencies = [
  "sp-core 38.1.0",
  "sp-crypto-hashing",
  "sp-keystore",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
 ]
@@ -13603,14 +13481,14 @@ dependencies = [
  "sc-executor-polkavm",
  "sc-executor-wasmtime",
  "schnellru",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-core 38.1.0",
  "sp-externalities",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-panic-handler",
  "sp-runtime-interface 32.0.0",
  "sp-trie",
- "sp-version 42.0.0",
+ "sp-version",
  "sp-wasm-interface 24.0.0",
  "tracing",
 ]
@@ -13678,12 +13556,12 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sc-transaction-pool-api",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core 38.1.0",
  "sp-keystore",
  "sp-mixnet",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -13727,7 +13605,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-blockchain",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -13746,7 +13624,7 @@ checksum = "7419cbc4a107ec4f430b263408db1527f2ce5fd6ed136c279f22057d3d202965"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -13764,7 +13642,7 @@ dependencies = [
  "sc-network-sync",
  "sc-network-types",
  "schnellru",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "tracing",
 ]
@@ -13798,7 +13676,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
@@ -13843,8 +13721,8 @@ dependencies = [
  "serde_json",
  "sp-core 38.1.0",
  "sp-rpc",
- "sp-runtime 44.0.0",
- "sp-version 42.0.0",
+ "sp-runtime",
+ "sp-version",
  "thiserror 1.0.69",
 ]
 
@@ -13882,7 +13760,7 @@ dependencies = [
  "serde",
  "sp-blockchain",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -14633,7 +14511,7 @@ dependencies = [
  "enumn",
  "parity-scale-codec",
  "paste",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14786,7 +14664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d72a0f9b37ce252bbce1152f6b6171d707dd636110dc0ff3525cce2dcf9c6af"
 dependencies = [
  "byte-slice-cast",
- "frame-support 43.0.0",
+ "frame-support",
  "hex",
  "parity-scale-codec",
  "rlp 0.6.1",
@@ -14795,8 +14673,8 @@ dependencies = [
  "snowbridge-ethereum",
  "snowbridge-milagro-bls",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "ssz_rs",
  "ssz_rs_derive",
@@ -14809,8 +14687,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19af84aab0631fb789d9504d5d4b75f06fd56ba46d7dec69baee8e0aafc7b6ea"
 dependencies = [
  "bp-relayers",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "log",
  "parity-scale-codec",
@@ -14819,10 +14697,10 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -14843,8 +14721,8 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-big-array",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -14855,8 +14733,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2fa7734e14e4313e6f6e5bef58d43fa886a4d4ffdd1f043c97e7a07b02e11b5"
 dependencies = [
  "alloy-core",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "log",
  "parity-scale-codec",
@@ -14865,10 +14743,10 @@ dependencies = [
  "snowbridge-core",
  "snowbridge-verification-primitives",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -14882,7 +14760,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -14908,8 +14786,8 @@ checksum = "e0bb7893eadcae10a7d98fcd3560fcf311167b365ac7c65d83e6a7b231d9c5fc"
 dependencies = [
  "alloy-core",
  "ethabi-decode",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "log",
  "parity-scale-codec",
@@ -14919,10 +14797,10 @@ dependencies = [
  "snowbridge-verification-primitives",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -14933,12 +14811,12 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b17802ac0da9403bc24147515139d18f3d22f8211dd7c2e5a703ad753f1204a"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "snowbridge-core",
  "snowbridge-merkle-tree",
  "snowbridge-outbound-queue-primitives",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -14948,11 +14826,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24052b3167c76930ff9688d4d496cc833ea38841c90d32356de757852f022625"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "snowbridge-merkle-tree",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
 ]
 
@@ -14962,9 +14840,9 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8b5041f5131db6dba0e2aaaeeb0404f20ee5f3245e9d4a501d18015b29be3ae"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "log",
  "pallet-timestamp",
@@ -14977,8 +14855,8 @@ dependencies = [
  "snowbridge-pallet-ethereum-client-fixtures",
  "snowbridge-verification-primitives",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
  "static_assertions",
 ]
@@ -15003,9 +14881,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94c77c66c01c002323531687853b4ac56002576a43efc2acfe667cdc0992fc72"
 dependencies = [
  "alloy-core",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
@@ -15016,10 +14894,10 @@ dependencies = [
  "snowbridge-inbound-queue-primitives",
  "snowbridge-pallet-inbound-queue-fixtures",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
 ]
 
@@ -15045,9 +14923,9 @@ checksum = "7d655ef63659cc0f4c74fe5429ecd0ab768783148f0439f47bc9d9bf520116a6"
 dependencies = [
  "alloy-core",
  "bp-relayers",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-balances",
  "parity-scale-codec",
@@ -15058,10 +14936,10 @@ dependencies = [
  "snowbridge-inbound-queue-primitives",
  "snowbridge-pallet-inbound-queue-v2-fixtures",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "tracing",
@@ -15089,9 +14967,9 @@ checksum = "8d4c9912580bc44fb13a7a21db23aea535607c8d888c0b7c3868e5a19d6d6601"
 dependencies = [
  "bridge-hub-common",
  "ethabi-decode",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -15100,8 +14978,8 @@ dependencies = [
  "snowbridge-outbound-queue-primitives",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -15115,9 +14993,9 @@ dependencies = [
  "bp-relayers",
  "bridge-hub-common",
  "ethabi-decode",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "hex-literal",
  "parity-scale-codec",
  "scale-info",
@@ -15129,10 +15007,10 @@ dependencies = [
  "snowbridge-verification-primitives",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -15143,19 +15021,19 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1118523226a4afafe22fbd5464f68a13093ae7cc5942cc561427396a01817dd"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
  "snowbridge-core",
  "snowbridge-outbound-queue-primitives",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
 ]
 
@@ -15165,19 +15043,19 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b1c53b5250c70a213507a156c359c9060518d32354cb68fa6bc4f04ddc1ce0"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-asset-conversion",
  "parity-scale-codec",
  "scale-info",
  "snowbridge-core",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "tracing",
 ]
@@ -15188,9 +15066,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04afeaac83e8da50535b77536a917237d36970c2e16a5e3fd9dd8bec91631ff3"
 dependencies = [
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -15198,10 +15076,10 @@ dependencies = [
  "snowbridge-outbound-queue-primitives",
  "snowbridge-pallet-system",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "tracing",
 ]
@@ -15212,14 +15090,14 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb167b1c4d04cb07e0f191a24636ae456ab81532fccd6c4866263ec162155fc3"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "log",
  "pallet-xcm",
  "parity-scale-codec",
  "sp-arithmetic",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]
@@ -15231,8 +15109,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32c5a2673d23b69e8652b09f57ab74db7f572a14b4d2c1f7d5db6595eb3a0af7"
 dependencies = [
  "cumulus-pallet-parachain-system",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "pallet-balances",
  "pallet-collator-selection",
  "pallet-message-queue",
@@ -15248,11 +15126,11 @@ dependencies = [
  "snowbridge-pallet-outbound-queue",
  "snowbridge-pallet-system",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-keyring",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "staging-parachain-info",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
 ]
 
@@ -15264,9 +15142,9 @@ checksum = "12448b9bc9067f2e3f75506b91e79e3a294d25cb972a8cd7fdca790a137448bf"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -15277,9 +15155,9 @@ checksum = "01febfce6c6aff5c342996901018543818f435e6a12da08b5cd4cf62db6d68e8"
 dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-std",
- "staging-xcm 19.0.0",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -15288,7 +15166,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86a3634e76e83426ed85f70350fb67f2cc0c872083531d2e2e44248ae55f2b41"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "snowbridge-beacon-primitives",
@@ -15333,29 +15211,6 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d91062b6183f20a6c5fb02d055eeacb4791c8ad32fa1d280c75c0b29aa74acf"
-dependencies = [
- "docify",
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 24.0.0",
- "sp-core 38.1.0",
- "sp-externalities",
- "sp-metadata-ir",
- "sp-runtime 43.0.0",
- "sp-runtime-interface 31.0.0",
- "sp-state-machine 0.47.0",
- "sp-trie",
- "sp-version 41.0.0",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-api"
 version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cc9635cc2a860eff0b2d8b05ba217085c8292f41793f9cadfd931dc54976c00"
@@ -15365,31 +15220,16 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 25.0.0",
+ "sp-api-proc-macro",
  "sp-core 38.1.0",
  "sp-externalities",
  "sp-metadata-ir",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-runtime-interface 32.0.0",
- "sp-state-machine 0.48.0",
+ "sp-state-machine",
  "sp-trie",
- "sp-version 42.0.0",
+ "sp-version",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8124c25cffbde85d2ef5978fa710bb900d89c368821e04d59040788a0ece3e25"
-dependencies = [
- "Inflector",
- "blake2 0.10.6",
- "expander",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -15409,19 +15249,6 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb8f2382e7b06f3754d66d781bb57021e415715b48a3a65ea452f9ca7e13ec8"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.1.0",
- "sp-io 42.0.0",
-]
-
-[[package]]
-name = "sp-application-crypto"
 version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6067f30cf3fb9270471cf24a65d73b33330f32573abab2d97196f83fc076de0"
@@ -15430,7 +15257,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
 ]
 
 [[package]]
@@ -15456,9 +15283,9 @@ checksum = "371762212dd2ecf361913297bbc93f291bb2a020b9c483dcd1a220eb5410c324"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15467,9 +15294,9 @@ version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aed5a2780e211f8b1faac53679238e527847d345120dd9acf8e506a39505957a"
 dependencies = [
- "sp-api 39.0.0",
- "sp-inherents 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-inherents",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15482,12 +15309,12 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
  "schnellru",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-consensus",
  "sp-core 38.1.0",
  "sp-database",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -15501,9 +15328,9 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "sp-inherents 39.0.0",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "thiserror 1.0.69",
 ]
 
@@ -15516,11 +15343,11 @@ dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-inherents 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -15534,12 +15361,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-consensus-slots",
  "sp-core 38.1.0",
- "sp-inherents 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "sp-timestamp",
 ]
 
@@ -15552,14 +15379,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core 38.1.0",
  "sp-crypto-hashing",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-weights",
  "strum 0.26.3",
 ]
@@ -15575,11 +15402,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-core 38.1.0",
  "sp-keystore",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15749,19 +15576,6 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e16e1046045e47124c09a9c9c03bfd1933926d67512aa1e66b778b81e51f4bb"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api 38.0.0",
- "sp-runtime 43.0.0",
-]
-
-[[package]]
-name = "sp-genesis-builder"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f929edd118b6332b016e0e5a3eb962b8568b14eee024f818685f8ea5f80d53"
@@ -15769,22 +15583,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d91ae44bf5232bff4e1a804b8eda9cecbf56921c0d67699f7b638db4ea1b776"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 43.0.0",
- "thiserror 1.0.69",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15797,35 +15597,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-io"
-version = "42.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0f8eb3f6c8824549b9482d71516324cf6e2fd650fcc0845d7a4080233898da"
-dependencies = [
- "bytes",
- "docify",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.26.0",
- "rustversion",
- "secp256k1 0.28.2",
- "sp-core 38.1.0",
- "sp-crypto-hashing",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface 31.0.0",
- "sp-state-machine 0.47.0",
- "sp-tracing 18.0.0",
- "sp-trie",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -15848,7 +15621,7 @@ dependencies = [
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface 32.0.0",
- "sp-state-machine 0.48.0",
+ "sp-state-machine",
  "sp-tracing 19.0.0",
  "sp-trie",
  "tracing",
@@ -15862,7 +15635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7cc9d55214634477506144bdc32039d490d9f5ca15997403e7a7613539ddebd"
 dependencies = [
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "strum 0.26.3",
 ]
 
@@ -15907,8 +15680,8 @@ checksum = "a9747afd7025801232758df5a693393ede420523de73295e0f23501052e804c2"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
 ]
 
 [[package]]
@@ -15922,25 +15695,11 @@ dependencies = [
  "polkadot-ckb-merkle-mountain-range",
  "scale-info",
  "serde",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-core 38.1.0",
  "sp-debug-derive",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-npos-elections"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db55883feff59ac34d221f97030d1a0b0699ab259838cb28a5ed19d56de40519"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-arithmetic",
- "sp-core 38.1.0",
- "sp-runtime 43.0.0",
 ]
 
 [[package]]
@@ -15954,7 +15713,7 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15963,9 +15722,9 @@ version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69dd826d2ae5e64b6bef5f670e620ddd52eb3f762a4f1a16a984c23d6113e470"
 dependencies = [
- "sp-api 39.0.0",
+ "sp-api",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -15991,36 +15750,6 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "43.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3992bd6026675946f12fc3c891c863f017a01449a5a15d07656ea1b6503f3ba2"
-dependencies = [
- "binary-merkle-tree",
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 42.0.0",
- "sp-arithmetic",
- "sp-core 38.1.0",
- "sp-io 42.0.0",
- "sp-std",
- "sp-trie",
- "sp-weights",
- "tracing",
- "tuplex",
-]
-
-[[package]]
-name = "sp-runtime"
 version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee57bb77e94c26306501426ac82aca401bb80ee2279ecdba148f68e76cf58247"
@@ -16038,10 +15767,10 @@ dependencies = [
  "scale-info",
  "serde",
  "simple-mermaid",
- "sp-application-crypto 43.0.0",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-std",
  "sp-trie",
  "sp-weights",
@@ -16066,26 +15795,6 @@ dependencies = [
  "sp-storage",
  "sp-tracing 17.1.0",
  "sp-wasm-interface 21.0.1",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4820882d8e6e764b98efaeed3a431aa9a0d1738c4adf935fbb4c50113288073"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.26.0",
- "primitive-types 0.13.1",
- "sp-externalities",
- "sp-runtime-interface-proc-macro 20.0.0",
- "sp-std",
- "sp-storage",
- "sp-tracing 18.0.0",
- "sp-wasm-interface 23.0.0",
  "static_assertions",
 ]
 
@@ -16144,25 +15853,11 @@ checksum = "327e2a7cf952f6ed6ca86d3fe9ab71561d30a358a83129afe60efc9bd2720ab0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-core 38.1.0",
  "sp-keystore",
- "sp-runtime 44.0.0",
- "sp-staking 41.0.0",
-]
-
-[[package]]
-name = "sp-staking"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9945ce70bbfb9b1c876f94a81017915bc932a576b8a9735b88aabfa01ea4e5"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 38.1.0",
- "sp-runtime 43.0.0",
+ "sp-runtime",
+ "sp-staking",
 ]
 
 [[package]]
@@ -16176,28 +15871,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa59c3fdf73700dd3e9dcce503fb15c3ef59dfed3ed34f0eec78d8f5b5d1c45"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot 0.12.4",
- "rand 0.8.5",
- "smallvec",
- "sp-core 38.1.0",
- "sp-externalities",
- "sp-panic-handler",
- "sp-trie",
- "thiserror 1.0.69",
- "tracing",
- "trie-db",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16248,8 +15922,8 @@ checksum = "074a33fe8fc3b6dc53c8b3b879c68efb070aa6aea3a2cb04b714da347643494c"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-inherents",
+ "sp-runtime",
  "thiserror 1.0.69",
 ]
 
@@ -16260,19 +15934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6147a5b8c98b9ed4bf99dc033fab97a468b4645515460974c8784daeb7c35433"
 dependencies = [
  "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.19",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fa3a9161173fa99b4455afc52811eb8251e90ca37a2cbebb8be9c47dc55c00"
-dependencies = [
- "parity-scale-codec",
- "regex",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.19",
@@ -16297,8 +15958,8 @@ version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2a9a006d5a5ffcc779148acabfa27dbedb3c93909e8592f2ec8c98e3a6745fe"
 dependencies = [
- "sp-api 39.0.0",
- "sp-runtime 44.0.0",
+ "sp-api",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16329,24 +15990,6 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d7b57b6577ddab5b363c2d6e9d49609749e041ee50e7232ecb413bc1cfa3f"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro",
- "sp-runtime 43.0.0",
- "sp-std",
- "sp-version-proc-macro",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-version"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633ea19da3ec057d449af667099072daa4e99900984f304b96f4c2ee15aeecc7"
@@ -16357,7 +16000,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-crypto-hashing-proc-macro",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
  "thiserror 1.0.69",
@@ -16381,18 +16024,6 @@ name = "sp-wasm-interface"
 version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b066baa6d57951600b14ffe1243f54c47f9c23dd89c262e17ca00ae8dca58be9"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568979072b49384ef6bbaa5aa1306a91f0b983a4b22c8ef515b601748683b97c"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -16510,13 +16141,13 @@ name = "staging-kusama-runtime"
 version = "1.0.0"
 dependencies = [
  "binary-merkle-tree",
- "frame-benchmarking 43.0.0",
- "frame-election-provider-support 43.0.0",
+ "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-executive",
  "frame-metadata-hash-extension",
  "frame-remote-externalities",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -16563,7 +16194,7 @@ dependencies = [
  "pallet-society",
  "pallet-staking",
  "pallet-staking-async-ah-client",
- "pallet-staking-async-rc-client 0.4.0",
+ "pallet-staking-async-rc-client",
  "pallet-staking-runtime-api",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -16582,8 +16213,8 @@ dependencies = [
  "scale-info",
  "separator",
  "serde_json",
- "sp-api 39.0.0",
- "sp-application-crypto 43.0.0",
+ "sp-api",
+ "sp-application-crypto",
  "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
@@ -16591,22 +16222,22 @@ dependencies = [
  "sp-consensus-beefy",
  "sp-core 38.1.0",
  "sp-debug-derive",
- "sp-genesis-builder 0.20.0",
- "sp-inherents 39.0.0",
- "sp-io 43.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
  "sp-keyring",
- "sp-npos-elections 39.0.0",
+ "sp-npos-elections",
  "sp-offchain",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-session",
- "sp-staking 41.0.0",
+ "sp-staking",
  "sp-storage",
  "sp-tracing 19.0.0",
  "sp-transaction-pool",
  "sp-trie",
- "sp-version 42.0.0",
+ "sp-version",
  "ss58-registry",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
@@ -16621,33 +16252,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c09acbd6891e8b6e6ac6d2d868b4fb66bfb63e98ad0aad0e3b8935404f5b262"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 44.0.0",
-]
-
-[[package]]
-name = "staging-xcm"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16708a8ff2bf701090ca8146ad4a0eb8ab00f2a03108f8c889d4eb2eccd7233d"
-dependencies = [
- "array-bytes 6.2.3",
- "bounded-collections 0.3.2",
- "derive-where",
- "environmental",
- "frame-support 42.0.0",
- "hex-literal",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-runtime 43.0.0",
- "sp-weights",
- "xcm-procedural",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16660,13 +16269,13 @@ dependencies = [
  "bounded-collections 0.3.2",
  "derive-where",
  "environmental",
- "frame-support 43.0.0",
+ "frame-support",
  "hex-literal",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-weights",
  "tracing",
  "xcm-procedural",
@@ -16679,8 +16288,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a747666d141266f9f94af6435337d9fc39202e50751867b1308dce71b9fa344c"
 dependencies = [
  "environmental",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "pallet-asset-conversion",
  "pallet-transaction-payment",
@@ -16689,10 +16298,10 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "tracing",
 ]
@@ -16704,17 +16313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960590e3381796ad06ca92fdfcf0a02360de823100bd2223a3233d36833e87c9"
 dependencies = [
  "environmental",
- "frame-benchmarking 43.0.0",
- "frame-support 43.0.0",
+ "frame-benchmarking",
+ "frame-support",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "tracing",
 ]
 
@@ -16849,7 +16458,7 @@ dependencies = [
  "log",
  "sc-rpc-api",
  "serde",
- "sp-runtime 44.0.0",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -16882,10 +16491,10 @@ dependencies = [
  "sc-executor",
  "shlex",
  "sp-core 38.1.0",
- "sp-io 43.0.0",
+ "sp-io",
  "sp-maybe-compressed-blob",
  "sp-tracing 19.0.0",
- "sp-version 42.0.0",
+ "sp-version",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.23",
@@ -17269,17 +16878,17 @@ version = "1.0.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
- "frame-support 43.0.0",
+ "frame-support",
  "log",
- "sp-runtime 44.0.0",
- "sp-state-machine 0.48.0",
+ "sp-runtime",
+ "sp-state-machine",
 ]
 
 [[package]]
 name = "system-parachains-constants"
 version = "1.0.0"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "kusama-runtime-constants",
  "parachains-common",
  "polkadot-core-primitives",
@@ -17287,8 +16896,8 @@ dependencies = [
  "polkadot-runtime-constants",
  "smallvec",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
 ]
 
 [[package]]
@@ -17330,7 +16939,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -17355,12 +16964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad51a5144bc04b07ef70ee17d130316b073fb88acde22849249739ad6850a9a8"
 dependencies = [
  "cumulus-primitives-core",
- "frame-support 43.0.0",
+ "frame-support",
  "polkadot-core-primitives",
  "rococo-runtime-constants",
  "smallvec",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-runtime",
+ "staging-xcm",
  "westend-runtime-constants",
 ]
 
@@ -18703,14 +18312,14 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bc2f3b81ef6af907b3c13377bc4c30de1c3c3d6036005661f91f35224e2fd8"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core 38.1.0",
- "sp-runtime 44.0.0",
+ "sp-runtime",
  "sp-weights",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-builder",
 ]
 
@@ -18752,7 +18361,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19330,8 +18939,8 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-sproof-builder",
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "pallet-balances",
  "pallet-message-queue",
@@ -19345,10 +18954,10 @@ dependencies = [
  "sp-arithmetic",
  "sp-core 38.1.0",
  "sp-crypto-hashing",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
+ "sp-io",
+ "sp-runtime",
  "sp-tracing 19.0.0",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
  "tracing",
  "xcm-simulator",
@@ -19372,12 +18981,12 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a093033360dadcda3e836d0e9734ad4d0cc42aaaa7358e59b207a36d5780a8"
 dependencies = [
- "frame-support 43.0.0",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
- "sp-api 39.0.0",
+ "sp-api",
  "sp-weights",
- "staging-xcm 19.0.0",
+ "staging-xcm",
  "staging-xcm-executor",
 ]
 
@@ -19387,8 +18996,8 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df54f12e8a7b91f0ca1099e547e5770c1a16a1d512381524a6bde7cee4716309"
 dependencies = [
- "frame-support 43.0.0",
- "frame-system 43.0.0",
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "paste",
  "polkadot-core-primitives",
@@ -19396,9 +19005,9 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-io 43.0.0",
- "sp-runtime 44.0.0",
- "staging-xcm 19.0.0",
+ "sp-io",
+ "sp-runtime",
+ "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ pallet-ah-migrator = { path = "pallets/ah-migrator", default-features = false }
 pallet-rc-migrator = { path = "pallets/rc-migrator", default-features = false }
 pallet-ah-ops = { path = "pallets/ah-ops", default-features = false }
 pallet-election-provider-multi-block = { version = "0.4.0", default-features = false }
-pallet-staking-async = { version = "0.6.2", default-features = false }
+pallet-staking-async = { version = "0.5.1", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 rand = { version = "0.9.2" }
 impl-trait-for-tuples = { version = "0.2.3", default-features = false }


### PR DESCRIPTION
Merging main into the upgrade branch has messed up the dependencies again.

This PR fixes them by:
* cargo update -p encointer-pallets-at-wrong-version
* Fixing the staking dependency that was accidentally downgraded in the Cargo.toml