### PR TITLE
ci: Test for metadata-hash feature more robustly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,7 +267,7 @@ jobs:
           FEATURES=""
           # Find out if the `metadata-hash` feature exists for the given package.
           # Exclude glutton runtimes as they don't support metadata-hash
-          if [[ "${{ matrix.runtime.package }}" != "glutton-kusama-runtime" ]] && cargo metadata --format-version=1 | jq '.packages[] | select(.name=="${{ matrix.runtime.package }}") | .features' | grep -q metadata-hash; then
+          if [[ "${{ matrix.runtime.package }}" != *"glutton"* ]] && cargo metadata --format-version=1 | jq '.packages[] | select(.name=="${{ matrix.runtime.package }}") | .features' | grep -q metadata-hash; then
             FEATURES="metadata-hash"
           fi
 


### PR DESCRIPTION

Sometimes the CI is wrongly detecting the metadata-hash feature as being enabled for glutton based runtimes:
- https://github.com/polkadot-fellows/runtimes/actions/runs/20337480608/job/58441235613#step:8:336

To improve this check:
- grep is used in quiet mode to avoid stdout/stderr pollution for our checks
- glutton runtimes are entirely skipped for the metadata-hash feature