### PR TITLE
Fix static cache key to enable daily snapshot refresh

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -52,13 +52,19 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +%F)" >> $GITHUB_OUTPUT
+
       - name: Try to restore snapshot from cache
         id: cache-restore
         if: github.event_name != 'schedule'
         uses: actions/cache/restore@v4
         with:
           path: snapshot.raw
-          key: try-runtime-snapshot-${{ matrix.runtime.name }}
+          key: try-runtime-snapshot-${{ matrix.runtime.name }}-${{ steps.date.outputs.date }}
+          restore-keys: |
+            try-runtime-snapshot-${{ matrix.runtime.name }}-
           fail-on-cache-miss: false
 
       - name: Install updates and dependencies
@@ -110,7 +116,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: snapshot.raw
-          key: try-runtime-snapshot-${{ matrix.runtime.name }}
+          key: try-runtime-snapshot-${{ matrix.runtime.name }}-${{ steps.date.outputs.date }}
 
       - name: Upload snapshot as artifact
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
GitHub Actions caches are immutable - once a key exists it cannot be overwritten. The previous static key meant scheduled runs would silently fail to update the cache.

This fix:
- Adds a date component to the cache key (YYYY-MM-DD format)
- Uses restore-keys prefix matching to find the most recent snapshot
- Enables the daily 1 AM scheduled run to actually create fresh caches

<!-- Remember that you can run `/merge` to enable auto-merge in the PR -->

<!-- Remember to modify the changelog. If you don't need to modify it, you can check the following box.
Instead, if you have already modified it, simply delete the following line. -->

- [ ] Does not require a CHANGELOG entry
