### PR TITLE
Add hyperbridge to parachains header root 

### DIFF
--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -433,10 +433,10 @@ pub struct ParaHeadsRootProvider;
 impl BeefyDataProvider<H256> for ParaHeadsRootProvider {
 	fn extra_data() -> H256 {
 		let para_heads: BTreeMap<u32, Vec<u8>> = parachains_paras::Parachains::<Runtime>::get()
-			.into_iter()
-			.chain(BEEFY_WHITELISTED_PARATHREADS.into_iter().cloned())
+			.iter()
+			.chain(BEEFY_WHITELISTED_PARATHREADS.iter())
 			.filter_map(|id| {
-				parachains_paras::Heads::<Runtime>::get(id).map(|head| (id.into(), head.0))
+				parachains_paras::Heads::<Runtime>::get(id).map(|head| ((*id).into(), head.0))
 			})
 			.collect();
 


### PR DESCRIPTION
This PR manually adds hyperbridge to the parachains header root for the following reason.

Hyperbridge transitioned to a para thread recently since our lease period expired and our beefy consensus client on connected networks relies on Hyperbridge being part of the parachain heads root. The client can no longer be updated until this is fixed and it expires in 21 days after which it can no longer be updated permanently freezing the bridge.

You can find a Link to the thread on element chat here https://matrix.to/#/!bMWYTUFeSoYacMOlpS:matrix.parity.io/$heRddjL-qs_cRcJVjl-la19NibMYOQK5pvtGHnjVRmU?via=parity.io&via=matrix.org&via=matrix.parity.io

- [x] Does not require a CHANGELOG entry
