### PR TITLE
ci: add check-runtime validation to release workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -386,7 +386,7 @@ jobs:
           for URI in "${URIS[@]}"; do
             echo "Trying $URI..."
             set +e
-            timeout 60 npx @polkadot-api/check-runtime@latest problems "$URI" --wasm "$WASM"
+            timeout 120 npx @polkadot-api/check-runtime@latest problems "$URI" --wasm "$WASM"
             EXIT_CODE=$?
             set -e
             if [ $EXIT_CODE -eq 0 ]; then


### PR DESCRIPTION
Runs [@polkadot-api/check-runtime](https://github.com/polkadot-api/check-runtime) against each chain's WASM produced by the build step to detect metadata, runtime API, and metadata-hash issues.

It runs between build-runtimes and ecosystem-tests, for each PR's `check-runtimes` step. 

Fix #1083. 

Example (run with a test workflow within this PR) [here](https://github.com/polkadot-fellows/runtimes/actions/runs/22327638424/job/64609453574?pr=1086).

The workflow could  be further simplified once/if [check-runtime tool](https://github.com/polkadot-api/check-runtime) returned a specific error if a node is unreachable (see related issue in the check-runtime repo [here](https://github.com/polkadot-api/check-runtime/issues/2))

- [x]  Does not require a CHANGELOG entry
