### PR TITLE
Add fast-runtime wasm builds to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         id: features
         run: |
           CARGO_TOML="${{ matrix.runtime.path }}/Cargo.toml"
-          has_feature() { awk '/^\[features\]/,/^\[/' "$CARGO_TOML" | grep -q "^$1 *="; }
+          has_feature() { sed -n '/^\[features\]/,/^\[/{ /^\[/d; p; }' "$CARGO_TOML" | grep -q "^$1 *="; }
 
           METADATA_HASH=""
           if has_feature "metadata-hash"; then


### PR DESCRIPTION
# Summary                                                                                                                                                                                                          
  - Build and release runtimes with fast-runtime and metadata-hash features enabled                                                                                                                        
  - Only runtimes that declare fast-runtime in their Cargo.toml are built (currently: polkadot, kusama, asset-hub-polkadot, coretime-kusama, coretime-polkadot, encointer-kusama)
  - Packaged as runtimes-with-fast-runtime.zip and uploaded to the GitHub release
  - Fix: metadata-hash feature is now conditionally included — runtimes like glutton-kusama that lack this feature no longer fail the try-runtime build
                                                                                                                                                                                                           
# Motivation                                                                                                                                                                                               
                                                                                                                                                                                                           
Pre-built fast-runtime wasms let teams test with Zombienet without building from source. Yes, zombie-bite / Chopsticks could work against live chains, but having these artifacts in releases makes local and CI testing much easier.                                              

We could also release the chain-spec-generator binary instead, but it's planned for removal (https://github.com/polkadot-fellows/runtimes/issues/395), so shipping the wasms directly makes more sense.

- [X] Does not require a CHANGELOG entry