### PR TITLE
Use chain-specific ExtrinsicBaseWeight in fee constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix fee calculation on Polkadot and Kusama system parachains: use chain-specific `ExtrinsicBaseWeight` instead of the generic `frame_support` default [1117](https://github.com/polkadot-fellows/runtimes/pull/1117).
+
 ## [2.1.1] 13.03.2026
 
 ### Added

--- a/system-parachains/constants/src/kusama.rs
+++ b/system-parachains/constants/src/kusama.rs
@@ -77,7 +77,7 @@ pub mod currency {
 
 /// Constants related to Kusama fee payment.
 pub mod fee {
-	use frame_support::weights::constants::ExtrinsicBaseWeight;
+	use kusama_runtime_constants::weights::ExtrinsicBaseWeight;
 	use polkadot_core_primitives::Balance;
 	pub use sp_runtime::Perbill;
 

--- a/system-parachains/constants/src/polkadot.rs
+++ b/system-parachains/constants/src/polkadot.rs
@@ -101,8 +101,8 @@ pub mod currency {
 
 /// Constants related to Polkadot fee payment.
 pub mod fee {
-	use frame_support::weights::constants::ExtrinsicBaseWeight;
 	use polkadot_core_primitives::Balance;
+	use polkadot_runtime_constants::weights::ExtrinsicBaseWeight;
 	pub use sp_runtime::Perbill;
 
 	/// The block saturation level. Fees will be updates based on this value.


### PR DESCRIPTION
The `ExtrinsicBaseWeight` used to calculate fees on the Polkadot and Kusama system parachains is currently being imported from the generic `frame_support::weights::constants`, which is incorrect.

What makes this especially confusing is that `System.BlockWeights.per_class_normal.base_extrinsic` shows the correct value. However, that value is not the one actually used internally for fee calculation. As a result, a utility for local fee calculations that we created was not matching the runtime’s calculations.

@voliva and I spent quite a while debugging this discrepancy before tracing it back to the runtime importing the wrong constant.

This PR fixes the issue by importing `ExtrinsicBaseWeight` from the appropriate chain-specific configuration for each runtime.