### PR TITLE
[encointer] update hardcoded remote execution weight for AHK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- [encointer] updated hardcoded remote execution weight for AHK [1124](https://github.com/polkadot-fellows/runtimes/pull/1124)
 - Fix fee calculation on Polkadot and Kusama system parachains: use chain-specific `ExtrinsicBaseWeight` instead of the generic `frame_support` default [1117](https://github.com/polkadot-fellows/runtimes/pull/1117).
 - Remove hardcoded `deposit_asset` weight cap from people runtimes to align with other system parachains ([#1121](https://github.com/polkadot-fellows/runtimes/pull/1121)).
 

--- a/system-parachains/encointer/src/treasuries_xcm_payout.rs
+++ b/system-parachains/encointer/src/treasuries_xcm_payout.rs
@@ -30,7 +30,7 @@ pub use pallet_encointer_treasuries::Transfer;
 // This is the value that has been queried from the Asset Hub Kusama runtime.
 // There is an integration test in `integration-tests/emulated/tests/encointer/encointer-kusama/
 // That verifies that this fee is correct and will catch fee changes in Asset-Hub Kusama
-pub const REMOTE_XCM_TRANSFER_REMOTE_EXECUTION_FEE: u128 = 2239503844;
+pub const REMOTE_XCM_TRANSFER_REMOTE_EXECUTION_FEE: u128 = 1942312457;
 
 pub trait GetRemoteFee {
 	fn get_remote_fee(xcm: Xcm<()>, asset_id: Option<AssetId>) -> Asset;


### PR DESCRIPTION
This PR updates the hardcoded weight for our remote treasury payout, which has become oudated due to https://github.com/polkadot-fellows/runtimes/pull/1117.

Closes #1122.
