### PR TITLE
feat: add bulletin chain spec to generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Add Bulletin Polkadot live chain spec and genesis preset ([#1146](https://github.com/polkadot-fellows/runtimes/pull/1146)).
+
 ## [2.2.0] 10.04.2026
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "hex-literal",
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",

--- a/chain-spec-generator/src/main.rs
+++ b/chain-spec-generator/src/main.rs
@@ -119,6 +119,11 @@ fn main() -> Result<(), String> {
 			),
 			#[cfg(feature = "bulletin-polkadot")]
 			(
+				"bulletin-polkadot",
+				Box::new(system_parachains_specs::bulletin_polkadot_config) as Box<_>,
+			),
+			#[cfg(feature = "bulletin-polkadot")]
+			(
 				"bulletin-polkadot-local",
 				Box::new(system_parachains_specs::bulletin_polkadot_local_testnet_config) as Box<_>,
 			),

--- a/chain-spec-generator/src/system_parachains_specs.rs
+++ b/chain-spec-generator/src/system_parachains_specs.rs
@@ -376,7 +376,6 @@ pub fn bulletin_polkadot_config() -> Result<Box<dyn sc_chain_spec::ChainSpec>, S
 	properties.insert("tokenSymbol".into(), "DOT".into());
 	properties.insert("tokenDecimals".into(), 10.into());
 
-	// TODO: Add post-launch.
 	let boot_nodes: [&str; 0] = [];
 
 	Ok(Box::new(

--- a/chain-spec-generator/src/system_parachains_specs.rs
+++ b/chain-spec-generator/src/system_parachains_specs.rs
@@ -370,6 +370,40 @@ pub fn people_polkadot_local_testnet_config() -> Result<Box<dyn sc_chain_spec::C
 }
 
 #[cfg(feature = "bulletin-polkadot")]
+pub fn bulletin_polkadot_config() -> Result<Box<dyn sc_chain_spec::ChainSpec>, String> {
+	let mut properties = sc_chain_spec::Properties::new();
+	properties.insert("ss58Format".into(), 0.into());
+	properties.insert("tokenSymbol".into(), "DOT".into());
+	properties.insert("tokenDecimals".into(), 10.into());
+
+	// TODO: Add post-launch.
+	let boot_nodes: [&str; 0] = [];
+
+	Ok(Box::new(
+		BulletinPolkadotChainSpec::builder(
+			bulletin_polkadot_runtime::WASM_BINARY.expect("BulletinPolkadot wasm not available!"),
+			Extensions { relay_chain: "polkadot".into(), para_id: 1010 },
+		)
+		.with_name("Polkadot Bulletin")
+		.with_id("bulletin-polkadot")
+		.with_chain_type(sc_chain_spec::ChainType::Live)
+		.with_genesis_config_preset_name("live")
+		.with_properties(properties)
+		.with_boot_nodes(
+			boot_nodes
+				.iter()
+				.map(|addr| {
+					use std::str::FromStr;
+					sc_network::config::MultiaddrWithPeerId::from_str(addr)
+						.expect("Boot node address is incorrect.")
+				})
+				.collect(),
+		)
+		.build(),
+	))
+}
+
+#[cfg(feature = "bulletin-polkadot")]
 pub fn bulletin_polkadot_local_testnet_config() -> Result<Box<dyn sc_chain_spec::ChainSpec>, String>
 {
 	let mut properties = sc_chain_spec::Properties::new();

--- a/system-parachains/bulletin/bulletin-polkadot/Cargo.toml
+++ b/system-parachains/bulletin/bulletin-polkadot/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { features = ["derive"], workspace = true }
+hex-literal = { workspace = true }
 scale-info = { features = ["derive"], workspace = true }
 serde = { optional = true, features = [
 	"derive",

--- a/system-parachains/bulletin/bulletin-polkadot/src/genesis_config_presets.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/genesis_config_presets.rs
@@ -19,13 +19,45 @@ use crate::*;
 use alloc::{vec, vec::Vec};
 use cumulus_primitives_core::ParaId;
 use frame_support::build_struct_json_patch;
+use hex_literal::hex;
 use parachains_common::{AccountId, AuraId};
-use sp_core::sr25519;
+use sp_core::{crypto::UncheckedInto, sr25519};
 use sp_genesis_builder::PresetId;
 use system_parachains_constants::{genesis_presets::*, polkadot::currency::UNITS as DOT};
 
 const BULLETIN_POLKADOT_ED: Balance = ExistentialDeposit::get();
 pub const BULLETIN_PARA_ID: ParaId = ParaId::new(1010);
+
+fn bulletin_polkadot_live_genesis(id: ParaId) -> serde_json::Value {
+	bulletin_polkadot_genesis(
+		vec![
+			// Faraday Nodes
+			// 155wHcqJ3fcfgtHsjqKHwNEU24pzRkkmZK865xxHeFTXMU8T
+			(
+				hex!("b4b4a8fdf51911242d0a860640fa8952f4005d0c4542428b4bcfb9815fc6ec55").into(),
+				hex!("4e91cfd5145fea6ebd1d1a441b33797e9c19918fa017291c73e56d2590566778")
+					.unchecked_into(),
+			),
+			// yaron
+			// 1sXuddoUew7f9F9XTVyns8KjCRRLvpvvUsZUyxZhqtH4RZn
+			(
+				hex!("268a505e81484de28108b814d0ab5ea13b947d153c19ee26bd280bd886e57815").into(),
+				hex!("80d6667f725e501088c081ff924dbe1aa50c67618b0984cb996c3d5fa5500f0f")
+					.unchecked_into(),
+			),
+			// dapestake
+			// 1A1WrKowzJD4yQQcETugEV5UWoNo1o7ujuA3f1fBfpxPjZL
+			(
+				hex!("06def0ef07d9b5153276dd785525839706f4696c8cb86227a2af27fd7495ee63").into(),
+				hex!("5e9659d151a03a5902e3135c9e361855f6d1caaea6e53a7d8613d7ad410bf507")
+					.unchecked_into(),
+			),
+		],
+		Vec::new(),
+		0,
+		id,
+	)
+}
 
 fn bulletin_polkadot_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
@@ -61,6 +93,7 @@ fn bulletin_polkadot_genesis(
 /// Provides the JSON representation of predefined genesis config for given `id`.
 pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	let patch = match id.as_ref() {
+		"live" => bulletin_polkadot_live_genesis(BULLETIN_PARA_ID),
 		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET => bulletin_polkadot_genesis(
 			// initial collators.
 			invulnerables(),
@@ -96,6 +129,7 @@ pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 /// List of supported presets.
 pub fn preset_names() -> Vec<PresetId> {
 	vec![
+		PresetId::from("live"),
 		PresetId::from(sp_genesis_builder::DEV_RUNTIME_PRESET),
 		PresetId::from(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET),
 	]


### PR DESCRIPTION
Part of: https://github.com/polkadot-fellows/runtimes/issues/1119

I added the Bulletin Chain live genesis preset and used it in the chain spec generator
