### PR TITLE
Bump maximum number of reserved cores to 50 on Polkadot and Kusama Coretime chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Bump maximum number of reserved cores to 50 on Polkadot and Kusama Coretime chains ([#1147](https://github.com/polkadot-fellows/runtimes/pull/1147))
+
 ## [2.2.0] 10.04.2026
 
 ### Added

--- a/system-parachains/coretime/coretime-kusama/src/coretime.rs
+++ b/system-parachains/coretime/coretime-kusama/src/coretime.rs
@@ -314,7 +314,7 @@ impl pallet_broker::Config for Runtime {
 	type OnRevenue = BurnCoretimeRevenue;
 	type TimeslicePeriod = ConstU32<{ coretime::TIMESLICE_PERIOD }>;
 	type MaxLeasedCores = ConstU32<50>;
-	type MaxReservedCores = ConstU32<10>;
+	type MaxReservedCores = ConstU32<50>;
 	type Coretime = CoretimeAllocator;
 	type ConvertBalance = sp_runtime::traits::Identity;
 	type WeightInfo = weights::pallet_broker::WeightInfo<Runtime>;

--- a/system-parachains/coretime/coretime-polkadot/src/coretime.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/coretime.rs
@@ -307,7 +307,7 @@ impl pallet_broker::Config for Runtime {
 	type OnRevenue = BurnCoretimeRevenue;
 	type TimeslicePeriod = ConstU32<{ coretime::TIMESLICE_PERIOD }>;
 	type MaxLeasedCores = ConstU32<55>;
-	type MaxReservedCores = ConstU32<10>;
+	type MaxReservedCores = ConstU32<50>;
 	type Coretime = CoretimeAllocator;
 	type ConvertBalance = sp_runtime::traits::Identity;
 	type WeightInfo = weights::pallet_broker::WeightInfo<Runtime>;


### PR DESCRIPTION
In the world of elastic scaling the original limits are too low.

- [ ] Does not require a CHANGELOG entry
