### PR TITLE
bulletin-chain: switch to 24s aura slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - [[#1143](https://github.com/polkadot-fellows/runtimes/pull/1143)] All runtimes now support the transaction extension `AuthorizeCall`.
 
 ### Changed
+
 - Polkadot and Kusama AH: reduce `DepositPerChildTrieItem` config of pallet-revive by factor of 10 ([1113](https://github.com/polkadot-fellows/runtimes/pull/1113))
 - Bump maximum number of reserved cores to 50 on Polkadot and Kusama Coretime chains ([#1147](https://github.com/polkadot-fellows/runtimes/pull/1147))
 - Update dependencies to stable2603-1 ([#1148](https://github.com/polkadot-fellows/runtimes/pull/1148)).
+- Bulletin Polkadot: switch to 24s Aura slot duration ([#1149](https://github.com/polkadot-fellows/runtimes/pull/1149))
 
 ## [2.2.0] 10.04.2026
 

--- a/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
@@ -69,7 +69,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use system_parachains_constants::{
 	async_backing::{
-		AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, MILLISECS_PER_BLOCK,
+		AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT,
 	},
 	polkadot::{
 		consensus::{
@@ -92,7 +92,7 @@ use xcm_runtime_apis::{
 };
 
 /// Bulletin uses 24s slot duration.
-pub const SLOT_DURATION: u64 = 4 * MILLISECS_PER_BLOCK;
+pub const SLOT_DURATION: u64 = 24_000;
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;

--- a/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
@@ -91,7 +91,7 @@ use xcm_runtime_apis::{
 	fees::Error as XcmPaymentApiError,
 };
 
-/// Bulletin uses 24s slot duration (4 blocks per slot).
+/// Bulletin uses 24s slot duration.
 pub const SLOT_DURATION: u64 = 4 * MILLISECS_PER_BLOCK;
 
 /// The address format for describing accounts.

--- a/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
@@ -91,8 +91,8 @@ use xcm_runtime_apis::{
 	fees::Error as XcmPaymentApiError,
 };
 
-/// Bulletin uses 6s slot duration (same as block time).
-pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
+/// Bulletin uses 24s slot duration (4 blocks per slot).
+pub const SLOT_DURATION: u64 = 4 * MILLISECS_PER_BLOCK;
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;

--- a/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
@@ -68,9 +68,7 @@ use sp_runtime::{
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use system_parachains_constants::{
-	async_backing::{
-		AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT,
-	},
+	async_backing::{AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT},
 	polkadot::{
 		consensus::{
 			async_backing::UNINCLUDED_SEGMENT_CAPACITY, BLOCK_PROCESSING_VELOCITY,


### PR DESCRIPTION
We missed this during initial review. Longer AURA slots improve elastic scaling tput and censorship resistance.
