### PR TITLE
AH-Polkadot/Kusama: enable pallet-revive AutoMap (#11416)

### DIFF
--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -213,8 +213,8 @@ impl frame_system::Config for Runtime {
 	type DbWeight = InMemoryDbWeight;
 	type Version = Version;
 	type PalletInfo = PalletInfo;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
+	type OnNewAccount = pallet_revive::AutoMapper<Runtime>;
+	type OnKilledAccount = pallet_revive::AutoMapper<Runtime>;
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
 	type ExtensionsWeightInfo = weights::frame_system_extensions::WeightInfo<Runtime>;
@@ -1267,7 +1267,7 @@ impl pallet_revive::Config for Runtime {
 	type MaxEthExtrinsicWeight = MaxEthExtrinsicWeight;
 	// Must be set to `false` in a live chain
 	type DebugEnabled = ConstBool<false>;
-	type AutoMap = ConstBool<false>;
+	type AutoMap = ConstBool<true>;
 	type GasScale = ConstU32<100_000>;
 	type OnBurn = ();
 }

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/migrations.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/migrations.rs
@@ -66,6 +66,7 @@ mod multiblock_migrations {
 			ForeignAssetsInstance,
 			pallet_assets_precompiles::weights::SubstrateWeight<Runtime>,
 		>,
+		pallet_revive::migrations::v3::Migration<Runtime>,
 	);
 
 	/// This type provides reserves information for `asset_id`. Meant to be used in a migration

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -263,8 +263,8 @@ impl frame_system::Config for Runtime {
 	type DbWeight = InMemoryDbWeight;
 	type Version = Version;
 	type PalletInfo = PalletInfo;
-	type OnNewAccount = ();
-	type OnKilledAccount = ();
+	type OnNewAccount = pallet_revive::AutoMapper<Runtime>;
+	type OnKilledAccount = pallet_revive::AutoMapper<Runtime>;
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
 	type ExtensionsWeightInfo = weights::frame_system_extensions::WeightInfo<Runtime>;
@@ -1465,7 +1465,7 @@ impl pallet_revive::Config for Runtime {
 	type MaxEthExtrinsicWeight = MaxEthExtrinsicWeight;
 	// Must be set to `false` in a live chain
 	type DebugEnabled = ConstBool<false>;
-	type AutoMap = ConstBool<false>;
+	type AutoMap = ConstBool<true>;
 	type GasScale = ConstU32<80_000>;
 	type OnBurn = Dap;
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/migrations.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/migrations.rs
@@ -133,6 +133,7 @@ mod multiblock_migrations {
 			ForeignAssetsInstance,
 			pallet_assets_precompiles::weights::SubstrateWeight<Runtime>,
 		>,
+		pallet_revive::migrations::v3::Migration<Runtime>,
 	);
 
 	/// This type provides reserves information for `asset_id`. Meant to be used in a migration


### PR DESCRIPTION
Completes [polkadot-sdk#11416](https://github.com/paritytech/polkadot-sdk/pull/11416) on AH-Polkadot and AH-Kusama.
  - `frame_system::Config::OnNewAccount`/`OnKilledAccount` → `pallet_revive::AutoMapper<Runtime>`
  - `pallet_revive::Config::AutoMap` → `ConstBool<true>`
  - Append `pallet_revive::migrations::v3::Migration<Runtime>` to `MbmMigrations`