### PR TITLE
integrate Penpal Asset changes

### DIFF
--- a/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -19,9 +19,9 @@ pub use penpal_runtime::{
 	self,
 	xcm_config::{
 		CustomizableAssetFromSystemAssetHub, LocalPen2Asset, LocalReservableFromAssetHub,
-		LocalTeleportableToAssetHub, PenpalNativeCurrency,
-		RelayNetworkId as PenpalRelayNetworkId, XcmConfig, ASSET_HUB_ASSETS_PALLET_ID,
-		PEN2_TELEPORTABLE_GENERAL_INDEX, PENPAL_ASSETS_PALLET_ID, RESERVABLE_ASSET_ID,
+		LocalTeleportableToAssetHub, PenpalNativeCurrency, RelayNetworkId as PenpalRelayNetworkId,
+		XcmConfig, ASSET_HUB_ASSETS_PALLET_ID, PEN2_TELEPORTABLE_GENERAL_INDEX,
+		PENPAL_ASSETS_PALLET_ID, RESERVABLE_ASSET_ID,
 	},
 };
 

--- a/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
+++ b/integration-tests/emulated/chains/parachains/testing/penpal/src/lib.rs
@@ -18,10 +18,10 @@ pub use genesis::{genesis, PenpalAssetOwner, ED, PARA_ID_A, PARA_ID_B};
 pub use penpal_runtime::{
 	self,
 	xcm_config::{
-		CustomizableAssetFromSystemAssetHub, LocalReservableFromAssetHub,
-		LocalTeleportableToAssetHub, RelayNetworkId as PenpalRelayNetworkId, XcmConfig,
-		ASSET_HUB_ASSETS_PALLET_ID as ASSETS_PALLET_ID,
-		PEN2_TELEPORTABLE_GENERAL_INDEX as TELEPORTABLE_ASSET_ID, RESERVABLE_ASSET_ID,
+		CustomizableAssetFromSystemAssetHub, LocalPen2Asset, LocalReservableFromAssetHub,
+		LocalTeleportableToAssetHub, PenpalNativeCurrency,
+		RelayNetworkId as PenpalRelayNetworkId, XcmConfig, ASSET_HUB_ASSETS_PALLET_ID,
+		PEN2_TELEPORTABLE_GENERAL_INDEX, PENPAL_ASSETS_PALLET_ID, RESERVABLE_ASSET_ID,
 	},
 };
 
@@ -58,7 +58,6 @@ decl_test_parachains! {
 		pallets = {
 			PolkadotXcm: penpal_runtime::PolkadotXcm,
 			Assets: penpal_runtime::Assets,
-			ForeignAssets: penpal_runtime::Assets,
 			AssetConversion: penpal_runtime::AssetConversion,
 			Balances: penpal_runtime::Balances,
 		}
@@ -82,7 +81,6 @@ decl_test_parachains! {
 		pallets = {
 			PolkadotXcm: penpal_runtime::PolkadotXcm,
 			Assets: penpal_runtime::Assets,
-			ForeignAssets: penpal_runtime::Assets,
 			AssetConversion: penpal_runtime::AssetConversion,
 			Balances: penpal_runtime::Balances,
 		}

--- a/integration-tests/emulated/helpers/src/lib.rs
+++ b/integration-tests/emulated/helpers/src/lib.rs
@@ -30,3 +30,21 @@ pub use emulated_integration_tests_common::*;
 pub use xcm_emulator::Chain;
 
 pub mod common;
+
+/// Read the balance of an `Assets`-pallet asset on a chain.
+///
+/// Centralised here so the asset-hub-{kusama,polkadot} and bridge-hub-{kusama,polkadot}
+/// test crates share one definition. The polkadot-sdk emulated tests define the same
+/// macro per-test-crate (it is not exported from `emulated-integration-tests-common`),
+/// so we cannot pull it from upstream and instead host it here.
+#[macro_export]
+macro_rules! assets_balance_on {
+	( $chain:ident, $id:expr, $who:expr ) => {
+		$crate::paste::paste! {
+			<$chain>::execute_with(|| {
+				type Assets = <$chain as [<$chain Pallet>]>::Assets;
+				<Assets as frame_support::traits::fungibles::Inspect<_>>::balance($id, $who)
+			})
+		}
+	};
+}

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/lib.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/lib.rs
@@ -37,7 +37,8 @@ pub use xcm_executor::traits::TransferType;
 pub use asset_hub_kusama_runtime::xcm_config::{KsmLocation, XcmConfig as AssetHubKusamaXcmConfig};
 pub use asset_test_utils::xcm_helpers;
 pub use emulated_integration_tests_common::{
-	test_parachain_is_trusted_teleporter,
+	create_foreign_pool_with_native_on, create_foreign_pool_with_parent_native_on,
+	local_penpal_asset, test_parachain_is_trusted_teleporter,
 	xcm_emulator::{
 		assert_expected_events, bx, helpers::weight_within_threshold, Chain, Parachain as Para,
 		RelayChain as Relay, Test, TestArgs, TestContext, TestExt,
@@ -59,6 +60,7 @@ pub use kusama_system_emulated_network::{
 	kusama_emulated_chain::{genesis::ED as KUSAMA_ED, KusamaRelayPallet as KusamaPallet},
 	penpal_emulated_chain::{
 		penpal_runtime::xcm_config::{
+			LocalPen2Asset as PenpalLocalPen2Asset,
 			LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,
 			LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
 			UniversalLocation as PenpalUniversalLocation,
@@ -88,10 +90,10 @@ pub type RelayToSystemParaTest = Test<Kusama, AssetHubKusama>;
 pub type RelayToParaTest = Test<Kusama, PenpalA>;
 pub type ParaToRelayTest = Test<PenpalA, Kusama>;
 pub type SystemParaToRelayTest = Test<AssetHubKusama, Kusama>;
-pub type SystemParaToParaTest = Test<AssetHubKusama, PenpalA>;
-pub type ParaToSystemParaTest = Test<PenpalA, AssetHubKusama>;
-pub type ParaToParaThroughRelayTest = Test<PenpalA, PenpalB, Kusama>;
-pub type ParaToParaThroughAHTest = Test<PenpalA, PenpalB, AssetHubKusama>;
+pub type SystemParaToParaTest = Test<AssetHubKusama, PenpalA, (), TestArgs<Location>>;
+pub type ParaToSystemParaTest = Test<PenpalA, AssetHubKusama, (), TestArgs<Location>>;
+pub type ParaToParaThroughRelayTest = Test<PenpalA, PenpalB, Kusama, TestArgs<Location>>;
+pub type ParaToParaThroughAHTest = Test<PenpalA, PenpalB, AssetHubKusama, TestArgs<Location>>;
 pub type RelayToParaThroughAHTest = Test<Kusama, PenpalA, AssetHubKusama>;
 pub type PenpalToRelayThroughAHTest = Test<PenpalA, Kusama, AssetHubKusama>;
 

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/lib.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/lib.rs
@@ -47,7 +47,8 @@ pub use emulated_integration_tests_common::{
 	PROOF_SIZE_THRESHOLD, REF_TIME_THRESHOLD, RESERVABLE_ASSET_ID, XCM_V5,
 };
 pub use integration_tests_helpers::{
-	test_parachain_is_trusted_teleporter_for_relay, test_relay_is_trusted_teleporter,
+	assets_balance_on, test_parachain_is_trusted_teleporter_for_relay,
+	test_relay_is_trusted_teleporter,
 };
 pub use kusama_runtime::{xcm_config::UniversalLocation as KusamaUniversalLocation, Dmp};
 pub use kusama_system_emulated_network::{

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/exchange_asset.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/exchange_asset.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{assets_balance_on, create_pool_with_ksm_on, foreign_balance_on, *};
+use crate::{assets_balance_on, create_pool_with_ksm_on, *};
 use asset_hub_kusama_runtime::{
 	xcm_config::KsmLocation, Balances, ExistentialDeposit, ForeignAssets, PolkadotXcm,
 	RuntimeOrigin,

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/exchange_asset.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/exchange_asset.rs
@@ -268,8 +268,7 @@ fn exchange_asset_from_penpal_via_asset_hub_back_to_penpal() {
 	});
 
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubKusama, USDT_ID, &sender);
-	let sender_usdt_on_penpal_after =
-		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+	let sender_usdt_on_penpal_after = assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	assert_eq!(
 		sender_usdt_on_penpal_after,

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/exchange_asset.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/exchange_asset.rs
@@ -172,7 +172,7 @@ fn exchange_asset_from_penpal_via_asset_hub_back_to_penpal() {
 	);
 
 	let sender_usdt_on_penpal_before =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 	let sender_usdt_on_ah_before = assets_balance_on!(AssetHubKusama, USDT_ID, &sender);
 
 	let asset_hub_location_penpal_pov = PenpalA::sibling_location_of(AssetHubKusama::para_id());
@@ -269,7 +269,7 @@ fn exchange_asset_from_penpal_via_asset_hub_back_to_penpal() {
 
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubKusama, USDT_ID, &sender);
 	let sender_usdt_on_penpal_after =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	assert_eq!(
 		sender_usdt_on_penpal_after,

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/foreign_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/foreign_assets.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{
-	asset_exists_on, assets_balance_on, foreign_balance_on,
+	asset_exists_on, assets_balance_on,
 	tests::send::penpal_register_foreign_asset_on_asset_hub, *,
 };
 use xcm::latest::AssetTransferFilter;

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/foreign_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/foreign_assets.rs
@@ -14,8 +14,7 @@
 // limitations under the License.
 
 use crate::{
-	asset_exists_on, assets_balance_on,
-	tests::send::penpal_register_foreign_asset_on_asset_hub, *,
+	asset_exists_on, assets_balance_on, tests::send::penpal_register_foreign_asset_on_asset_hub, *,
 };
 use xcm::latest::AssetTransferFilter;
 

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/foreign_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/foreign_assets.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{tests::send::penpal_register_foreign_asset_on_asset_hub, *};
+use crate::{
+	asset_exists_on, assets_balance_on, foreign_balance_on,
+	tests::send::penpal_register_foreign_asset_on_asset_hub, *,
+};
 use xcm::latest::AssetTransferFilter;
 
 // Registers a new asset on Penpal, then registers it over XCM as foreign asset on Asset Hub.
@@ -22,44 +25,34 @@ use xcm::latest::AssetTransferFilter;
 // between Penpal and AH.
 pub fn set_up_foreign_asset(
 	sender: sp_runtime::AccountId32,
-	asset_id_on_penpal: u32,
+	asset_location_on_penpal: Location,
 	asset_amount_to_send: u128,
 	teleportable: bool,
 ) -> (Location, Location) {
 	let asset_owner = PenpalAssetOwner::get();
-	let to_fund = asset_amount_to_send * 2;
 
 	// Give the sender enough native
-	PenpalA::mint_foreign_asset(
-		<PenpalA as Chain>::RuntimeOrigin::signed(asset_owner.clone()),
-		KsmLocation::get(),
-		sender.clone(),
-		to_fund,
-	);
+	PenpalA::fund_accounts(vec![(sender.clone(), asset_amount_to_send)]);
 
 	// Create the asset on Penpal
-	PenpalA::force_create_asset(
-		asset_id_on_penpal,
+	let to_fund = asset_amount_to_send * 2;
+	PenpalA::force_create_foreign_asset(
+		asset_location_on_penpal.clone(),
 		asset_owner.clone(),
 		true,
 		ASSET_MIN_BALANCE,
 		vec![(sender.clone(), to_fund)],
 	);
-	PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		assert!(Assets::asset_exists(asset_id_on_penpal));
-	});
-	let asset_location_on_penpal = Location::new(
-		0,
-		[
-			Junction::PalletInstance(ASSETS_PALLET_ID),
-			Junction::GeneralIndex(asset_id_on_penpal.into()),
-		],
-	);
+
+	asset_exists_on!(PenpalA, asset_location_on_penpal.clone());
 
 	// Setup a pool on Penpal between native asset and newly created asset, so we can pay fees using
 	// new asset directly.
-	create_pool_with_ksm_on!(PenpalA, asset_location_on_penpal.clone(), false, asset_owner.clone());
+	create_foreign_pool_with_native_on!(
+		PenpalA,
+		asset_location_on_penpal.clone(),
+		asset_owner.clone()
+	);
 
 	// Register asset on Asset Hub using XCM
 	let penpal_sovereign_account = AssetHubKusama::sovereign_account_id_of(
@@ -73,10 +66,9 @@ pub fn set_up_foreign_asset(
 
 	// Setup a pool on Asset Hub between native asset and newly created asset, so we can pay fees
 	// using new asset directly.
-	create_pool_with_ksm_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubKusama,
 		foreign_asset_at_asset_hub.clone(),
-		true,
 		penpal_sovereign_account.clone()
 	);
 
@@ -146,16 +138,16 @@ pub fn penpal_set_foreign_asset_reserves_on_asset_hub(
 fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 	let sender = PenpalASender::get();
 	let receiver = AssetHubKusamaReceiver::get();
-	let new_asset_id = 42;
+	let new_asset_id = local_penpal_asset(42);
 	let asset_amount_to_send = ASSET_HUB_KUSAMA_ED * 10_000;
 	let (asset_location_on_penpal, foreign_asset_location_on_ah) =
-		set_up_foreign_asset(sender.clone(), new_asset_id, asset_amount_to_send, true);
+		set_up_foreign_asset(sender.clone(), new_asset_id.clone(), asset_amount_to_send, true);
 
 	////////////////////////////////
 	// Teleport it from Penpal to AH
 	////////////////////////////////
 
-	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_before =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -192,7 +184,7 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 		.unwrap();
 	});
 
-	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_after =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -243,7 +235,7 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 	let asset_amount_to_send = ah_receiver_balance_after;
 	let ah_sender_balance_before =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah.clone(), &receiver);
-	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	let dest = AssetHubKusama::sibling_location_of(PenpalA::para_id());
 	// execute xcm from asset hub to penpal
@@ -300,7 +292,7 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 
 	let ah_sender_balance_after =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah, &receiver);
-	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	assert!(ah_sender_balance_after < ah_sender_balance_before);
 	assert!(penpal_receiver_balance_after > penpal_receiver_balance_before);
@@ -316,16 +308,16 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 	let sender = PenpalASender::get();
 	let receiver = AssetHubKusamaReceiver::get();
-	let new_asset_id = 42;
+	let new_asset_id = local_penpal_asset(42);
 	let asset_amount_to_send = ASSET_HUB_KUSAMA_ED * 10_000;
 	let (asset_location_on_penpal, foreign_asset_location_on_ah) =
-		set_up_foreign_asset(sender.clone(), new_asset_id, asset_amount_to_send, false);
+		set_up_foreign_asset(sender.clone(), new_asset_id.clone(), asset_amount_to_send, false);
 
 	////////////////////////////////////////
 	// Reserve-transfer it from Penpal to AH
 	////////////////////////////////////////
 
-	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_before =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -381,7 +373,7 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 		));
 	});
 
-	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_after =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -395,7 +387,7 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 	let asset_amount_to_send = ah_receiver_balance_after;
 	let ah_sender_balance_before =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah.clone(), &receiver);
-	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	let dest = AssetHubKusama::sibling_location_of(PenpalA::para_id());
 	// execute xcm from asset hub to penpal
@@ -451,7 +443,7 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 
 	let ah_sender_balance_after =
 		foreign_balance_on!(AssetHubKusama, foreign_asset_location_on_ah, &receiver);
-	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	assert!(ah_sender_balance_after < ah_sender_balance_before);
 	assert!(penpal_receiver_balance_after > penpal_receiver_balance_before);
@@ -462,10 +454,10 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 #[test]
 fn verify_foreign_asset_origin_checks() {
 	let sender = PenpalASender::get();
-	let new_asset_id = 42;
+	let new_asset_id = local_penpal_asset(42);
 	let asset_amount_to_send = ASSET_HUB_KUSAMA_ED * 10_000;
 	let (_, foreign_asset_location_on_ah) =
-		set_up_foreign_asset(sender.clone(), new_asset_id, asset_amount_to_send, false);
+		set_up_foreign_asset(sender.clone(), new_asset_id.clone(), asset_amount_to_send, false);
 
 	let penpal_sovereign = AssetHubKusama::sovereign_account_id_of(
 		AssetHubKusama::sibling_location_of(PenpalA::para_id()),

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
@@ -15,7 +15,7 @@
 
 use super::reserve_transfer::*;
 use crate::{
-	foreign_balance_on,
+	assets_balance_on, foreign_balance_on,
 	tests::teleport::do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using_xt,
 	*,
 };
@@ -229,11 +229,11 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sender)
 	});
 	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &receiver)
 	});
 	let receiver_dots_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &receiver)
 	});
 
@@ -250,11 +250,11 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sender)
 	});
 	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &receiver)
 	});
 	let receiver_dots_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
 	});
 
@@ -370,11 +370,11 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_native_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &sender)
 	});
 	let sender_dots_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
 	});
 	let receiver_native_before = test.receiver.balance;
@@ -391,11 +391,11 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_native_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &sender)
 	});
 	let sender_dots_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
 	});
 	let receiver_native_after = test.receiver.balance;
@@ -532,11 +532,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query initial balances
 	let sender_ksms_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_location.clone(), &sender)
 	});
 	let sender_dots_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
 	});
 	let ksms_in_sender_reserve_on_ahk_before =
@@ -552,11 +552,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sov_of_receiver_on_ah)
 	});
 	let receiver_ksms_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_location.clone(), &receiver)
 	});
 	let receiver_dots_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &receiver)
 	});
 
@@ -569,11 +569,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query final balances
 	let sender_ksms_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_location.clone(), &sender)
 	});
 	let sender_dots_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
 	});
 	let dots_in_sender_reserve_on_ahk_after = AssetHubKusama::execute_with(|| {
@@ -589,11 +589,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	let ksms_in_receiver_reserve_on_ahk_after =
 		<AssetHubKusama as Chain>::account_data_of(sov_of_receiver_on_ah).free;
 	let receiver_ksms_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_location, &receiver)
 	});
 	let receiver_dots_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest, &receiver)
 	});
 
@@ -690,14 +690,14 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 
 	// PenpalB has a pool between USDT and ksm so fees can be paid with USDT by automatically
 	// swapping them for ksm.
-	create_pool_with_ksm_on!(PenpalB, usdt_location.clone(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalB, usdt_location.clone(), PenpalAssetOwner::get());
 
 	// Sender starts with a lot of USDT.
-	let sender_balance_before = foreign_balance_on!(PenpalA, usdt_location.clone(), &sender);
+	let sender_balance_before = assets_balance_on!(PenpalA, usdt_location.clone(), &sender);
 	assert_eq!(sender_balance_before, 10_000_000_000_000);
 
 	// Receiver has no USDT.
-	let receiver_balance_before = foreign_balance_on!(PenpalB, usdt_location.clone(), &receiver);
+	let receiver_balance_before = assets_balance_on!(PenpalB, usdt_location.clone(), &receiver);
 	assert_eq!(receiver_balance_before, 0);
 
 	let test_args = TestContext {
@@ -725,7 +725,7 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 		assert_expected_events!(
 			PenpalA,
 			vec![
-				Event::ForeignAssets(
+				Event::Assets(
 					pallet_assets::Event::Withdrawn { asset_id, amount, .. }
 				) => {
 					asset_id: *asset_id == usdt_location.clone(),
@@ -776,7 +776,7 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 			PenpalB,
 			vec![
 				// Final amount gets deposited to receiver.
-				Event::ForeignAssets(
+				Event::Assets(
 					pallet_assets::Event::Deposited { asset_id, who, .. }
 				) => {
 					asset_id: *asset_id == usdt_location,
@@ -798,11 +798,11 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 	test.assert();
 
 	// Sender has less USDT after the transfer.
-	let sender_balance_after = foreign_balance_on!(PenpalA, usdt_location.clone(), &sender);
+	let sender_balance_after = assets_balance_on!(PenpalA, usdt_location.clone(), &sender);
 	assert_eq!(sender_balance_after, 9_000_000_000_000);
 
 	// Receiver gets `transfer_amount` minus fees.
-	let receiver_balance_after = foreign_balance_on!(PenpalB, usdt_location.clone(), &receiver);
+	let receiver_balance_after = assets_balance_on!(PenpalB, usdt_location.clone(), &receiver);
 	assert!(receiver_balance_after > receiver_balance_before);
 }
 
@@ -862,7 +862,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 
 	// Query initial balances
 	let sender_balance_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let sov_penpal_on_ah_before = AssetHubKusama::execute_with(|| {
@@ -918,7 +918,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 
 	// Query final balances
 	let sender_balance_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let sov_penpal_on_ah_after = AssetHubKusama::execute_with(|| {

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
@@ -248,7 +248,7 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 	let receiver_assets_after = assets_balance_on!(PenpalA, native_asset_location, &receiver);
 	let receiver_dots_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains, &receiver);
 
-	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	// Sender's balance is reduced by amount sent plus delivery fees
 	assert!(sender_balance_after < sender_balance_before - native_amount_to_send);
 	// Sender's balance is reduced by foreign amount sent
 	assert_eq!(sender_dots_after, sender_dots_before - foreign_amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
@@ -228,8 +228,10 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sender)
 	});
-	let receiver_assets_before = assets_balance_on!(PenpalA, native_asset_location.clone(), &receiver);
-	let receiver_dots_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalA, native_asset_location.clone(), &receiver);
+	let receiver_dots_before =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubKusama>(system_para_to_para_sender_assertions);
@@ -358,7 +360,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_native_before = assets_balance_on!(PenpalA, native_asset_location.clone(), &sender);
-	let sender_dots_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
+	let sender_dots_before =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_native_before = test.receiver.balance;
 	let receiver_dots_before = AssetHubKusama::execute_with(|| {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
@@ -373,7 +376,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_native_after = assets_balance_on!(PenpalA, native_asset_location, &sender);
-	let sender_dots_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
+	let sender_dots_after =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_native_after = test.receiver.balance;
 	let receiver_dots_after = AssetHubKusama::execute_with(|| {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
@@ -508,7 +512,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query initial balances
 	let sender_ksms_before = assets_balance_on!(PenpalA, ksm_location.clone(), &sender);
-	let sender_dots_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
+	let sender_dots_before =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let ksms_in_sender_reserve_on_ahk_before =
 		<AssetHubKusama as Chain>::account_data_of(sov_of_sender_on_ah.clone()).free;
 	let dots_in_sender_reserve_on_ahk_before = AssetHubKusama::execute_with(|| {
@@ -522,7 +527,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sov_of_receiver_on_ah)
 	});
 	let receiver_ksms_before = assets_balance_on!(PenpalB, ksm_location.clone(), &receiver);
-	let receiver_dots_before = assets_balance_on!(PenpalB, dot_at_kusama_parachains_latest.clone(), &receiver);
+	let receiver_dots_before =
+		assets_balance_on!(PenpalB, dot_at_kusama_parachains_latest.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalA>(para_to_para_through_hop_sender_assertions);
@@ -533,7 +539,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query final balances
 	let sender_ksms_after = assets_balance_on!(PenpalA, ksm_location.clone(), &sender);
-	let sender_dots_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
+	let sender_dots_after =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let dots_in_sender_reserve_on_ahk_after = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sov_of_sender_on_ah)
@@ -547,7 +554,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	let ksms_in_receiver_reserve_on_ahk_after =
 		<AssetHubKusama as Chain>::account_data_of(sov_of_receiver_on_ah).free;
 	let receiver_ksms_after = assets_balance_on!(PenpalB, ksm_location, &receiver);
-	let receiver_dots_after = assets_balance_on!(PenpalB, dot_at_kusama_parachains_latest, &receiver);
+	let receiver_dots_after =
+		assets_balance_on!(PenpalB, dot_at_kusama_parachains_latest, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert_eq!(sender_ksms_after, sender_ksms_before - ksm_to_send);
@@ -813,7 +821,8 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	AssetHubKusama::fund_accounts(vec![(sov_penpal_on_ah.clone(), amount_to_send * 2)]);
 
 	// Query initial balances
-	let sender_balance_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let sender_balance_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_before = AssetHubKusama::execute_with(|| {
 		<AssetHubKusama as AssetHubKusamaPallet>::Balances::free_balance(sov_penpal_on_ah.clone())
 	});
@@ -866,7 +875,8 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_balance_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let sender_balance_after =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_after = AssetHubKusama::execute_with(|| {
 		<AssetHubKusama as AssetHubKusamaPallet>::Balances::free_balance(sov_penpal_on_ah.clone())
 	});

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
@@ -228,14 +228,8 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sender)
 	});
-	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &receiver)
-	});
-	let receiver_dots_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &receiver)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalA, native_asset_location.clone(), &receiver);
+	let receiver_dots_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubKusama>(system_para_to_para_sender_assertions);
@@ -249,14 +243,8 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sender)
 	});
-	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &receiver)
-	});
-	let receiver_dots_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalA, native_asset_location, &receiver);
+	let receiver_dots_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - native_amount_to_send);
@@ -369,14 +357,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(test_args);
 
 	// Query initial balances
-	let sender_native_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &sender)
-	});
-	let sender_dots_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
-	});
+	let sender_native_before = assets_balance_on!(PenpalA, native_asset_location.clone(), &sender);
+	let sender_dots_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_native_before = test.receiver.balance;
 	let receiver_dots_before = AssetHubKusama::execute_with(|| {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
@@ -390,14 +372,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_native_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &sender)
-	});
-	let sender_dots_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
-	});
+	let sender_native_after = assets_balance_on!(PenpalA, native_asset_location, &sender);
+	let sender_dots_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_native_after = test.receiver.balance;
 	let receiver_dots_after = AssetHubKusama::execute_with(|| {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
@@ -531,14 +507,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	let mut test = ParaToParaThroughAHTest::new(test_args);
 
 	// Query initial balances
-	let sender_ksms_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_location.clone(), &sender)
-	});
-	let sender_dots_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
-	});
+	let sender_ksms_before = assets_balance_on!(PenpalA, ksm_location.clone(), &sender);
+	let sender_dots_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let ksms_in_sender_reserve_on_ahk_before =
 		<AssetHubKusama as Chain>::account_data_of(sov_of_sender_on_ah.clone()).free;
 	let dots_in_sender_reserve_on_ahk_before = AssetHubKusama::execute_with(|| {
@@ -551,14 +521,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sov_of_receiver_on_ah)
 	});
-	let receiver_ksms_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_location.clone(), &receiver)
-	});
-	let receiver_dots_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &receiver)
-	});
+	let receiver_ksms_before = assets_balance_on!(PenpalB, ksm_location.clone(), &receiver);
+	let receiver_dots_before = assets_balance_on!(PenpalB, dot_at_kusama_parachains_latest.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalA>(para_to_para_through_hop_sender_assertions);
@@ -568,14 +532,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_ksms_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_location.clone(), &sender)
-	});
-	let sender_dots_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
-	});
+	let sender_ksms_after = assets_balance_on!(PenpalA, ksm_location.clone(), &sender);
+	let sender_dots_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let dots_in_sender_reserve_on_ahk_after = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &sov_of_sender_on_ah)
@@ -588,14 +546,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	});
 	let ksms_in_receiver_reserve_on_ahk_after =
 		<AssetHubKusama as Chain>::account_data_of(sov_of_receiver_on_ah).free;
-	let receiver_ksms_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_location, &receiver)
-	});
-	let receiver_dots_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest, &receiver)
-	});
+	let receiver_ksms_after = assets_balance_on!(PenpalB, ksm_location, &receiver);
+	let receiver_dots_after = assets_balance_on!(PenpalB, dot_at_kusama_parachains_latest, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert_eq!(sender_ksms_after, sender_ksms_before - ksm_to_send);
@@ -861,10 +813,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	AssetHubKusama::fund_accounts(vec![(sov_penpal_on_ah.clone(), amount_to_send * 2)]);
 
 	// Query initial balances
-	let sender_balance_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_balance_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_before = AssetHubKusama::execute_with(|| {
 		<AssetHubKusama as AssetHubKusamaPallet>::Balances::free_balance(sov_penpal_on_ah.clone())
 	});
@@ -917,10 +866,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_balance_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_balance_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_after = AssetHubKusama::execute_with(|| {
 		<AssetHubKusama as AssetHubKusamaPallet>::Balances::free_balance(sov_penpal_on_ah.clone())
 	});

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
@@ -15,7 +15,7 @@
 
 use super::reserve_transfer::*;
 use crate::{
-	assets_balance_on, foreign_balance_on,
+	assets_balance_on,
 	tests::teleport::do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using_xt,
 	*,
 };

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/hybrid_transfers.rs
@@ -258,7 +258,7 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - native_amount_to_send);
 	// Sender's balance is reduced by foreign amount sent
 	assert_eq!(sender_dots_after, sender_dots_before - foreign_amount_to_send);
@@ -404,8 +404,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_native_after < sender_native_before - native_amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_native_after, sender_native_before - native_amount_to_send);
 	// Sender's balance is reduced by foreign amount sent
 	assert_eq!(sender_dots_after, sender_dots_before - foreign_amount_to_send);
 	// Receiver's balance is increased
@@ -597,8 +597,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_ksms_after < sender_ksms_before - ksm_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_ksms_after, sender_ksms_before - ksm_to_send);
 	assert_eq!(sender_dots_after, sender_dots_before - dot_to_send);
 	// Sovereign accounts on reserve are changed accordingly
 	assert_eq!(
@@ -927,8 +927,8 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	let receiver_balance_after =
 		Kusama::execute_with(|| <Kusama as KusamaPallet>::Balances::free_balance(receiver.clone()));
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_balance_after < sender_balance_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_balance_after, sender_balance_before - amount_to_send);
 	// Sovereign account on AH is reduced by amount sent
 	assert_eq!(sov_penpal_on_ah_after, sov_penpal_on_ah_before - amount_to_send);
 	// Receiver's balance is increased

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
@@ -42,18 +42,6 @@ macro_rules! foreign_balance_on {
 }
 
 #[macro_export]
-macro_rules! assets_balance_on {
-	( $chain:ident, $id:expr, $who:expr ) => {
-		emulated_integration_tests_common::impls::paste::paste! {
-			<$chain>::execute_with(|| {
-				type Assets = <$chain as [<$chain Pallet>]>::Assets;
-				<Assets as Inspect<_>>::balance($id, $who)
-			})
-		}
-	};
-}
-
-#[macro_export]
 macro_rules! asset_exists_on {
 	( $chain:ident, $id:expr ) => {
 		emulated_integration_tests_common::impls::paste::paste! {

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
@@ -54,6 +54,18 @@ macro_rules! assets_balance_on {
 }
 
 #[macro_export]
+macro_rules! asset_exists_on {
+	( $chain:ident, $id:expr ) => {
+		emulated_integration_tests_common::impls::paste::paste! {
+			<$chain>::execute_with(|| {
+				type Assets = <$chain as [<$chain Pallet>]>::Assets;
+				<Assets as frame_support::traits::fungibles::Inspect<_>>::asset_exists($id)
+			})
+		}
+	};
+}
+
+#[macro_export]
 macro_rules! create_pool_with_ksm_on {
 	// default amounts
 	( $chain:ident, $asset_id:expr, $is_foreign:expr, $asset_owner:expr ) => {

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -1325,15 +1325,12 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
-	PenpalA::execute_with(|| {
-		use frame_support::traits::tokens::fungibles::Mutate;
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
-			usdt_from_asset_hub.clone(),
-			&sender,
-			asset_amount_to_send + fee_amount_to_send,
-		));
-	});
+	PenpalA::mint_foreign_asset(
+		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
+		usdt_from_asset_hub.clone(),
+		sender.clone(),
+		asset_amount_to_send + fee_amount_to_send,
+	);
 
 	// Prepare assets to transfer.
 	let assets: Assets =

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -630,7 +630,7 @@ fn reserve_transfer_ksm_from_relay_to_para() {
 	let sender_balance_after = test.sender.balance;
 	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &receiver);
 
-	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	// Sender's balance is reduced by amount sent plus delivery fees
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's asset balance is increased
 	assert!(receiver_assets_after > receiver_assets_before);
@@ -751,7 +751,7 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 	let receiver_assets_after =
 		assets_balance_on!(PenpalA, system_para_native_asset_location, &receiver);
 
-	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	// Sender's balance is reduced by amount sent plus delivery fees
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's assets is increased
 	assert!(receiver_assets_after > receiver_assets_before);

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -1258,7 +1258,11 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	// Setup the pool so we can swap the custom asset for native asset to pay for fees.
-	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(
+		PenpalB,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
 
 	let assets: Assets = vec![(
 		[PalletInstance(ASSETS_PALLET_ID), GeneralIndex(usdt_id.into())],
@@ -1360,7 +1364,11 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	);
 	create_pool_with_ksm_on!(AssetHubKusama, usdt, false, AssetHubKusamaSender::get());
 	// We also need a pool between KSM and USDT on PenpalB.
-	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(
+		PenpalB,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	PenpalA::execute_with(|| {

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -617,10 +617,7 @@ fn reserve_transfer_ksm_from_relay_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<Kusama>(relay_to_para_sender_assertions);
@@ -630,10 +627,7 @@ fn reserve_transfer_ksm_from_relay_to_para() {
 
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
-	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
@@ -688,10 +682,7 @@ fn reserve_transfer_ksm_from_para_to_relay() {
 	let mut test = ParaToRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -701,10 +692,7 @@ fn reserve_transfer_ksm_from_para_to_relay() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &sender)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &sender);
 	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
@@ -747,10 +735,7 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubKusama>(system_para_to_para_sender_assertions);
@@ -760,10 +745,7 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
-	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &receiver)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalA, system_para_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
@@ -818,10 +800,7 @@ fn reserve_transfer_ksm_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -831,10 +810,7 @@ fn reserve_transfer_ksm_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &sender)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalA, system_para_native_asset_location, &sender);
 	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
@@ -908,17 +884,8 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
-	});
-	let receiver_foreign_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_foreign_asset_location.clone(),
-			&receiver,
-		)
-	});
+	let receiver_system_native_assets_before = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_before = assets_balance_on!(PenpalA, system_para_foreign_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubKusama>(system_para_to_para_assets_sender_assertions);
@@ -932,14 +899,8 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
-	});
-	let receiver_foreign_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_foreign_asset_location, &receiver)
-	});
+	let receiver_system_native_assets_after = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_after = assets_balance_on!(PenpalA, system_para_foreign_asset_location, &receiver);
 	// Sender's balance is reduced
 	assert!(sender_balance_after < sender_balance_before);
 	// Receiver's foreign asset balance is increased
@@ -1034,14 +995,8 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(para_test_args);
 
 	// Query initial balances
-	let sender_system_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal.clone(), &sender)
-	});
-	let sender_foreign_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal.clone(), &sender)
-	});
+	let sender_system_assets_before = assets_balance_on!(PenpalA, system_asset_location_on_penpal.clone(), &sender);
+	let sender_foreign_assets_before = assets_balance_on!(PenpalA, asset_location_on_penpal.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 	let receiver_assets_before = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
@@ -1055,14 +1010,8 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_system_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal, &sender)
-	});
-	let sender_foreign_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal, &sender)
-	});
+	let sender_system_assets_after = assets_balance_on!(PenpalA, system_asset_location_on_penpal, &sender);
+	let sender_foreign_assets_after = assets_balance_on!(PenpalA, asset_location_on_penpal, &sender);
 	let receiver_balance_after = test.receiver.balance;
 	let receiver_assets_after = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
@@ -1119,14 +1068,8 @@ fn reserve_transfer_ksm_from_para_to_para_through_relay() {
 	let mut test = ParaToParaThroughRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalA>(para_to_para_through_hop_sender_assertions);
@@ -1136,14 +1079,8 @@ fn reserve_transfer_ksm_from_para_to_para_through_relay() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::*;
+use crate::{assets_balance_on, foreign_balance_on, *};
 use emulated_integration_tests_common::xcm_helpers::fee_asset;
 use kusama_system_emulated_network::{
 	kusama_emulated_chain::kusama_runtime::Dmp,
@@ -48,7 +48,7 @@ fn para_to_relay_sender_assertions(t: ParaToRelayTest) {
 		PenpalA,
 		vec![
 			// Amount to reserve transfer is transferred to Parachain's Sovereign account
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, amount, .. }
 			) => {
 				asset_id: *asset_id == KsmLocation::get(),
@@ -96,7 +96,7 @@ pub fn system_para_to_para_receiver_assertions(t: SystemParaToParaTest) {
 		assert_expected_events!(
 			PenpalB,
 			vec![
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == relative_id,
 					who: *who == t.receiver.account_id,
 				},
@@ -111,7 +111,7 @@ fn relay_to_para_assets_receiver_assertions(t: RelayToParaTest) {
 	assert_expected_events!(
 		PenpalA,
 		vec![
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 				asset_id: *asset_id == KsmLocation::get(),
 				who: *who == t.receiver.account_id,
 			},
@@ -156,7 +156,7 @@ pub fn para_to_system_para_sender_assertions(t: ParaToSystemParaTest) {
 		assert_expected_events!(
 			PenpalA,
 			vec![
-				RuntimeEvent::ForeignAssets(
+				RuntimeEvent::Assets(
 					pallet_assets::Event::Withdrawn { asset_id, who, amount }
 				) => {
 					asset_id: *asset_id == expected_id,
@@ -222,14 +222,14 @@ fn para_to_system_para_assets_sender_assertions(t: ParaToSystemParaTest) {
 		PenpalA,
 		vec![
 			// Fees amount to reserve transfer is burned from Parachains's sender account
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == system_para_native_asset_location,
 				who: *who == t.sender.account_id,
 			},
 			// Amount to reserve transfer is burned from Parachains's sender account
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, amount }
 			) => {
 				asset_id: *asset_id == reservable_asset_location,
@@ -252,11 +252,11 @@ fn system_para_to_para_assets_receiver_assertions(t: SystemParaToParaTest) {
 	assert_expected_events!(
 		PenpalA,
 		vec![
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 				asset_id: *asset_id == KsmLocation::get(),
 				who: *who == t.receiver.account_id,
 			},
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, amount }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, amount }) => {
 				asset_id: *asset_id == system_para_asset_location,
 				who: *who == t.receiver.account_id,
 				amount: *amount == t.args.amount,
@@ -300,7 +300,9 @@ fn para_to_system_para_assets_receiver_assertions(t: ParaToSystemParaTest) {
 	);
 }
 
-pub fn para_to_para_through_hop_sender_assertions<Hop: Clone>(t: Test<PenpalA, PenpalB, Hop>) {
+pub fn para_to_para_through_hop_sender_assertions<Hop: Clone>(
+	t: Test<PenpalA, PenpalB, Hop, TestArgs<Location>>,
+) {
 	type RuntimeEvent = <PenpalA as Chain>::RuntimeEvent;
 
 	PenpalA::assert_xcm_pallet_attempted_complete(None);
@@ -311,7 +313,7 @@ pub fn para_to_para_through_hop_sender_assertions<Hop: Clone>(t: Test<PenpalA, P
 			PenpalA,
 			vec![
 				// Amount to reserve transfer is transferred to Parachain's Sovereign account
-				RuntimeEvent::ForeignAssets(
+				RuntimeEvent::Assets(
 					pallet_assets::Event::Withdrawn { asset_id, who, amount: transferred_amount },
 				) => {
 					asset_id: *asset_id == expected_id,
@@ -352,7 +354,9 @@ fn para_to_para_relay_hop_assertions(t: ParaToParaThroughRelayTest) {
 	);
 }
 
-pub fn para_to_para_through_hop_receiver_assertions<Hop: Clone>(t: Test<PenpalA, PenpalB, Hop>) {
+pub fn para_to_para_through_hop_receiver_assertions<Hop: Clone>(
+	t: Test<PenpalA, PenpalB, Hop, TestArgs<Location>>,
+) {
 	type RuntimeEvent = <PenpalB as Chain>::RuntimeEvent;
 
 	PenpalB::assert_xcmp_queue_success(None);
@@ -361,7 +365,7 @@ pub fn para_to_para_through_hop_receiver_assertions<Hop: Clone>(t: Test<PenpalA,
 		assert_expected_events!(
 			PenpalB,
 			vec![
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == expected_id,
 					who: *who == t.receiver.account_id,
 				},
@@ -614,7 +618,7 @@ fn reserve_transfer_ksm_from_relay_to_para() {
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
 	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
 	});
 
@@ -627,7 +631,7 @@ fn reserve_transfer_ksm_from_relay_to_para() {
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
 	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
@@ -685,7 +689,7 @@ fn reserve_transfer_ksm_from_para_to_relay() {
 
 	// Query initial balances
 	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_balance_before = test.receiver.balance;
@@ -698,7 +702,7 @@ fn reserve_transfer_ksm_from_para_to_relay() {
 
 	// Query final balances
 	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &sender)
 	});
 	let receiver_balance_after = test.receiver.balance;
@@ -744,7 +748,7 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
 	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
 	});
 
@@ -757,7 +761,7 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
 	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &receiver)
 	});
 
@@ -815,7 +819,7 @@ fn reserve_transfer_ksm_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &sender)
 	});
 	let receiver_balance_before = test.receiver.balance;
@@ -828,7 +832,7 @@ fn reserve_transfer_ksm_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &sender)
 	});
 	let receiver_balance_after = test.receiver.balance;
@@ -905,11 +909,11 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
 	let receiver_system_native_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
 	});
 	let receiver_foreign_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(
 			system_para_foreign_asset_location.clone(),
 			&receiver,
@@ -929,11 +933,11 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
 	let receiver_system_native_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
 	});
 	let receiver_foreign_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_foreign_asset_location, &receiver)
 	});
 	// Sender's balance is reduced
@@ -1031,11 +1035,11 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_system_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal.clone(), &sender)
 	});
 	let sender_foreign_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal.clone(), &sender)
 	});
 	let receiver_balance_before = test.receiver.balance;
@@ -1052,11 +1056,11 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_system_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal, &sender)
 	});
 	let sender_foreign_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal, &sender)
 	});
 	let receiver_balance_after = test.receiver.balance;
@@ -1116,11 +1120,11 @@ fn reserve_transfer_ksm_from_para_to_para_through_relay() {
 
 	// Query initial balances
 	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
 	});
 
@@ -1133,11 +1137,11 @@ fn reserve_transfer_ksm_from_para_to_para_through_relay() {
 
 	// Query final balances
 	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
@@ -1220,7 +1224,7 @@ fn system_para_to_penpal_receiver_assertions(t: SystemParaToParaTest) {
 		assert_expected_events!(
 			PenpalB,
 			vec![
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == relative_id,
 					who: *who == t.receiver.account_id,
 				},
@@ -1254,7 +1258,7 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	// Setup the pool so we can swap the custom asset for native asset to pay for fees.
-	create_pool_with_ksm_on!(PenpalB, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
 
 	let assets: Assets = vec![(
 		[PalletInstance(ASSETS_PALLET_ID), GeneralIndex(usdt_id.into())],
@@ -1286,7 +1290,7 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 		Balances::free_balance(&sender)
 	});
 	let receiver_initial_balance =
-		foreign_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
+		assets_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
 
 	fn usdt_sender_assertions(_t: SystemParaToParaTest) {
 		AssetHubKusama::assert_xcm_pallet_attempted_complete(None);
@@ -1305,7 +1309,7 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 		type Balances = <AssetHubKusama as AssetHubKusamaPallet>::Balances;
 		Balances::free_balance(&sender)
 	});
-	let receiver_after_balance = foreign_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
+	let receiver_after_balance = assets_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
 
 	assert!(sender_after_native_balance < sender_initial_native_balance);
 	// Sender account's balance decreases.
@@ -1356,12 +1360,12 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	);
 	create_pool_with_ksm_on!(AssetHubKusama, usdt, false, AssetHubKusamaSender::get());
 	// We also need a pool between KSM and USDT on PenpalB.
-	create_pool_with_ksm_on!(PenpalB, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	PenpalA::execute_with(|| {
 		use frame_support::traits::tokens::fungibles::Mutate;
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
 			usdt_from_asset_hub.clone(),
 			&sender,
@@ -1444,7 +1448,7 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 			assert_expected_events!(
 				PenpalA,
 				vec![
-					RuntimeEvent::ForeignAssets(
+					RuntimeEvent::Assets(
 						pallet_assets::Event::Withdrawn { asset_id, who, amount: transferred_amount },
 					) => {
 						asset_id: *asset_id == expected_id,
@@ -1464,7 +1468,7 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 			assert_expected_events!(
 				PenpalB,
 				vec![
-					RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+					RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 						asset_id: *asset_id == expected_id,
 						who: *who == t.receiver.account_id,
 					},
@@ -1474,9 +1478,9 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	}
 
 	// Query initial balances
-	let sender_assets_before = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let sender_assets_before = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
 	let receiver_assets_before =
-		foreign_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
+		assets_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
 	test.set_assertion::<PenpalA>(usdt_sender_assertions);
 	test.set_assertion::<AssetHubKusama>(usdt_hop_assertions);
 	test.set_assertion::<PenpalB>(usdt_receiver_assertions);
@@ -1484,8 +1488,8 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
-	let receiver_assets_after = foreign_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
+	let sender_assets_after = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
 
 	// Sender's balance is reduced by amount
 	assert!(sender_assets_after < sender_assets_before - asset_amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -617,7 +617,8 @@ fn reserve_transfer_ksm_from_relay_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &receiver);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<Kusama>(relay_to_para_sender_assertions);
@@ -682,7 +683,8 @@ fn reserve_transfer_ksm_from_para_to_relay() {
 	let mut test = ParaToRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let sender_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -735,7 +737,8 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubKusama>(system_para_to_para_sender_assertions);
@@ -745,7 +748,8 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
-	let receiver_assets_after = assets_balance_on!(PenpalA, system_para_native_asset_location, &receiver);
+	let receiver_assets_after =
+		assets_balance_on!(PenpalA, system_para_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
@@ -800,7 +804,8 @@ fn reserve_transfer_ksm_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &sender);
+	let sender_assets_before =
+		assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -810,7 +815,8 @@ fn reserve_transfer_ksm_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = assets_balance_on!(PenpalA, system_para_native_asset_location, &sender);
+	let sender_assets_after =
+		assets_balance_on!(PenpalA, system_para_native_asset_location, &sender);
 	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
@@ -884,8 +890,10 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_before = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
-	let receiver_foreign_assets_before = assets_balance_on!(PenpalA, system_para_foreign_asset_location.clone(), &receiver);
+	let receiver_system_native_assets_before =
+		assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_before =
+		assets_balance_on!(PenpalA, system_para_foreign_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubKusama>(system_para_to_para_assets_sender_assertions);
@@ -899,8 +907,10 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_after = assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
-	let receiver_foreign_assets_after = assets_balance_on!(PenpalA, system_para_foreign_asset_location, &receiver);
+	let receiver_system_native_assets_after =
+		assets_balance_on!(PenpalA, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_after =
+		assets_balance_on!(PenpalA, system_para_foreign_asset_location, &receiver);
 	// Sender's balance is reduced
 	assert!(sender_balance_after < sender_balance_before);
 	// Receiver's foreign asset balance is increased
@@ -995,8 +1005,10 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(para_test_args);
 
 	// Query initial balances
-	let sender_system_assets_before = assets_balance_on!(PenpalA, system_asset_location_on_penpal.clone(), &sender);
-	let sender_foreign_assets_before = assets_balance_on!(PenpalA, asset_location_on_penpal.clone(), &sender);
+	let sender_system_assets_before =
+		assets_balance_on!(PenpalA, system_asset_location_on_penpal.clone(), &sender);
+	let sender_foreign_assets_before =
+		assets_balance_on!(PenpalA, asset_location_on_penpal.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 	let receiver_assets_before = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
@@ -1010,8 +1022,10 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_system_assets_after = assets_balance_on!(PenpalA, system_asset_location_on_penpal, &sender);
-	let sender_foreign_assets_after = assets_balance_on!(PenpalA, asset_location_on_penpal, &sender);
+	let sender_system_assets_after =
+		assets_balance_on!(PenpalA, system_asset_location_on_penpal, &sender);
+	let sender_foreign_assets_after =
+		assets_balance_on!(PenpalA, asset_location_on_penpal, &sender);
 	let receiver_balance_after = test.receiver.balance;
 	let receiver_assets_after = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::Assets;
@@ -1068,8 +1082,10 @@ fn reserve_transfer_ksm_from_para_to_para_through_relay() {
 	let mut test = ParaToParaThroughRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
-	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &receiver);
+	let sender_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalA>(para_to_para_through_hop_sender_assertions);
@@ -1079,7 +1095,8 @@ fn reserve_transfer_ksm_from_para_to_para_through_relay() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let sender_assets_after =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{assets_balance_on, foreign_balance_on, *};
+use crate::{assets_balance_on, *};
 use emulated_integration_tests_common::xcm_helpers::fee_asset;
 use kusama_system_emulated_network::{
 	kusama_emulated_chain::kusama_runtime::Dmp,

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -635,7 +635,7 @@ fn reserve_transfer_ksm_from_relay_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's asset balance is increased
 	assert!(receiver_assets_after > receiver_assets_before);
@@ -707,8 +707,8 @@ fn reserve_transfer_ksm_from_para_to_relay() {
 	});
 	let receiver_balance_after = test.receiver.balance;
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_assets_after < sender_assets_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	// Receiver's asset balance is increased
 	assert!(receiver_balance_after > receiver_balance_before);
 	// Receiver's asset balance increased by `amount_to_send - delivery_fees - bought_execution`;
@@ -765,7 +765,7 @@ fn reserve_transfer_ksm_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's assets is increased
 	assert!(receiver_assets_after > receiver_assets_before);
@@ -837,8 +837,8 @@ fn reserve_transfer_ksm_from_para_to_asset_hub() {
 	});
 	let receiver_balance_after = test.receiver.balance;
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_assets_after < sender_assets_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	// Receiver's balance is increased
 	assert!(receiver_balance_after > receiver_balance_before);
 	// Receiver's balance increased by `amount_to_send - delivery_fees - bought_execution`;
@@ -1145,8 +1145,8 @@ fn reserve_transfer_ksm_from_para_to_para_through_relay() {
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_assets_after < sender_assets_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	// Receiver's balance is increased
 	assert!(receiver_assets_after > receiver_assets_before);
 }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/swap.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/swap.rs
@@ -114,8 +114,7 @@ fn swap_locally_on_chain_using_local_assets() {
 #[test]
 fn swap_locally_on_chain_using_foreign_assets() {
 	let asset_native = Box::new(asset_hub_kusama_runtime::xcm_config::KsmLocation::get());
-	let asset_location_on_penpal: Location =
-		PenpalA::execute_with(PenpalLocalPen2Asset::get);
+	let asset_location_on_penpal: Location = PenpalA::execute_with(PenpalLocalPen2Asset::get);
 	let foreign_asset_at_asset_hub_kusama =
 		Location::new(1, [Parachain(PenpalA::para_id().into())])
 			.appended_with(asset_location_on_penpal)

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/swap.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/swap.rs
@@ -15,7 +15,6 @@
 
 use crate::*;
 use emulated_integration_tests_common::test_xcm_fee_querying_apis_work_for_asset_hub;
-use kusama_system_emulated_network::penpal_emulated_chain::LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub;
 use sp_runtime::ModuleError;
 use system_parachains_constants::kusama::currency::SYSTEM_PARA_EXISTENTIAL_DEPOSIT;
 
@@ -116,7 +115,7 @@ fn swap_locally_on_chain_using_local_assets() {
 fn swap_locally_on_chain_using_foreign_assets() {
 	let asset_native = Box::new(asset_hub_kusama_runtime::xcm_config::KsmLocation::get());
 	let asset_location_on_penpal: Location =
-		PenpalA::execute_with(PenpalLocalTeleportableToAssetHub::get);
+		PenpalA::execute_with(PenpalLocalPen2Asset::get);
 	let foreign_asset_at_asset_hub_kusama =
 		Location::new(1, [Parachain(PenpalA::para_id().into())])
 			.appended_with(asset_location_on_penpal)

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/teleport.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/teleport.rs
@@ -13,12 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::*;
+use crate::{assets_balance_on, *};
 use emulated_integration_tests_common::xcm_helpers::non_fee_asset;
-use kusama_system_emulated_network::{
-	kusama_emulated_chain::kusama_runtime::Dmp,
-	penpal_emulated_chain::LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
-};
+use kusama_system_emulated_network::kusama_emulated_chain::kusama_runtime::Dmp;
 
 fn penpal_to_ah_foreign_assets_sender_assertions(t: ParaToSystemParaTest) {
 	type RuntimeEvent = <PenpalA as Chain>::RuntimeEvent;
@@ -31,7 +28,7 @@ fn penpal_to_ah_foreign_assets_sender_assertions(t: ParaToSystemParaTest) {
 	assert_expected_events!(
 		PenpalA,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == system_para_native_asset_location,
@@ -99,7 +96,7 @@ fn ah_to_penpal_foreign_assets_receiver_assertions(t: SystemParaToParaTest) {
 				amount: *amount == expected_asset_amount,
 			},
 			// native asset for fee is deposited to receiver
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 				asset_id: *asset_id == Location::parent(),
 				who: *who == t.receiver.account_id,
 			},
@@ -224,11 +221,7 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 ) {
 	// Init values for Parachain
 	let fee_amount_to_send: Balance = ASSET_HUB_KUSAMA_ED * 100000;
-	let asset_location_on_penpal = PenpalA::execute_with(PenpalLocalTeleportableToAssetHub::get);
-	let asset_id_on_penpal = match asset_location_on_penpal.last() {
-		Some(Junction::GeneralIndex(id)) => *id as u32,
-		_ => unreachable!(),
-	};
+	let asset_location_on_penpal = PenpalA::execute_with(PenpalLocalPen2Asset::get);
 	let asset_amount_to_send = ASSET_HUB_KUSAMA_ED * 1000;
 	let asset_owner = PenpalAssetOwner::get();
 	let system_para_native_asset_location = KsmLocation::get();
@@ -254,9 +247,9 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 		fee_amount_to_send * 2,
 	);
 	// No need to create the asset (only mint) as it exists in genesis.
-	PenpalA::mint_asset(
+	PenpalA::mint_foreign_asset(
 		<PenpalA as Chain>::RuntimeOrigin::signed(asset_owner.clone()),
-		asset_id_on_penpal,
+		asset_location_on_penpal.clone(),
 		sender.clone(),
 		asset_amount_to_send,
 	);
@@ -274,7 +267,7 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 	// Init values for System Parachain
 	let foreign_asset_at_asset_hub_kusama =
 		Location::new(1, [Parachain(PenpalA::para_id().into())])
-			.appended_with(asset_location_on_penpal)
+			.appended_with(asset_location_on_penpal.clone())
 			.unwrap();
 	let penpal_to_ah_beneficiary_id = AssetHubKusamaReceiver::get();
 
@@ -287,25 +280,21 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			penpal_to_ah_beneficiary_id,
 			asset_amount_to_send,
 			penpal_assets,
-			Some(asset_id_on_penpal),
+			Some(asset_location_on_penpal.clone()),
 			fee_asset_index,
 		),
 	};
 	let mut penpal_to_ah = ParaToSystemParaTest::new(penpal_to_ah_test_args);
-	let penpal_sender_balance_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location.clone(),
-			&PenpalASender::get(),
-		)
-	});
+	let penpal_sender_balance_before = assets_balance_on!(
+		PenpalA,
+		system_para_native_asset_location.clone(),
+		&PenpalASender::get()
+	);
 
 	let ah_receiver_balance_before = penpal_to_ah.receiver.balance;
 
-	let penpal_sender_assets_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalASender::get())
-	});
+	let penpal_sender_assets_before =
+		assets_balance_on!(PenpalA, asset_location_on_penpal.clone(), &PenpalASender::get());
 	let ah_receiver_assets_before = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(
@@ -319,20 +308,16 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 	penpal_to_ah.set_dispatchable::<PenpalA>(para_to_ah_dispatchable);
 	penpal_to_ah.assert();
 
-	let penpal_sender_balance_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location.clone(),
-			&PenpalASender::get(),
-		)
-	});
+	let penpal_sender_balance_after = assets_balance_on!(
+		PenpalA,
+		system_para_native_asset_location.clone(),
+		&PenpalASender::get()
+	);
 
 	let ah_receiver_balance_after = penpal_to_ah.receiver.balance;
 
-	let penpal_sender_assets_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalASender::get())
-	});
+	let penpal_sender_assets_after =
+		assets_balance_on!(PenpalA, asset_location_on_penpal.clone(), &PenpalASender::get());
 	let ah_receiver_assets_after = AssetHubKusama::execute_with(|| {
 		type Assets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(
@@ -394,20 +379,18 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			ah_to_penpal_beneficiary_id,
 			asset_amount_to_send,
 			ah_assets,
-			Some(asset_id_on_penpal),
+			Some(asset_location_on_penpal.clone()),
 			fee_asset_index,
 		),
 	};
 	let mut ah_to_penpal = SystemParaToParaTest::new(ah_to_penpal_test_args);
 
 	let ah_sender_balance_before = ah_to_penpal.sender.balance;
-	let penpal_receiver_balance_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location.clone(),
-			&PenpalAReceiver::get(),
-		)
-	});
+	let penpal_receiver_balance_before = assets_balance_on!(
+		PenpalA,
+		system_para_native_asset_location.clone(),
+		&PenpalAReceiver::get()
+	);
 
 	let ah_sender_assets_before = AssetHubKusama::execute_with(|| {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
@@ -416,10 +399,8 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			&AssetHubKusamaSender::get(),
 		)
 	});
-	let penpal_receiver_assets_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalAReceiver::get())
-	});
+	let penpal_receiver_assets_before =
+		assets_balance_on!(PenpalA, asset_location_on_penpal.clone(), &PenpalAReceiver::get());
 
 	ah_to_penpal.set_assertion::<AssetHubKusama>(ah_to_penpal_foreign_assets_sender_assertions);
 	ah_to_penpal.set_assertion::<PenpalA>(ah_to_penpal_foreign_assets_receiver_assertions);
@@ -427,13 +408,8 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 	ah_to_penpal.assert();
 
 	let ah_sender_balance_after = ah_to_penpal.sender.balance;
-	let penpal_receiver_balance_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location,
-			&PenpalAReceiver::get(),
-		)
-	});
+	let penpal_receiver_balance_after =
+		assets_balance_on!(PenpalA, system_para_native_asset_location, &PenpalAReceiver::get());
 
 	let ah_sender_assets_after = AssetHubKusama::execute_with(|| {
 		type ForeignAssets = <AssetHubKusama as AssetHubKusamaPallet>::ForeignAssets;
@@ -442,10 +418,8 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			&AssetHubKusamaSender::get(),
 		)
 	});
-	let penpal_receiver_assets_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalAReceiver::get())
-	});
+	let penpal_receiver_assets_after =
+		assets_balance_on!(PenpalA, asset_location_on_penpal.clone(), &PenpalAReceiver::get());
 
 	// Sender's balance is reduced
 	assert!(ah_sender_balance_after < ah_sender_balance_before);

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
@@ -124,14 +124,12 @@ fn transact_from_para_to_para_through_asset_hub() {
 	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
-	PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
-			usdt_from_asset_hub.clone(),
-			&sender,
-			fee_amount_to_send,
-		));
-	});
+	PenpalA::mint_foreign_asset(
+		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
+		usdt_from_asset_hub.clone(),
+		sender.clone(),
+		fee_amount_to_send,
+	);
 
 	PenpalA::mint_foreign_asset(
 		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
@@ -112,12 +112,20 @@ fn transact_from_para_to_para_through_asset_hub() {
 		1_000_000_000_000,
 		20_000_000_000
 	);
-	create_pool_with_ksm_on!(PenpalA, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
-	create_pool_with_ksm_on!(PenpalB, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(
+		PenpalA,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
+	create_foreign_pool_with_native_on!(
+		PenpalB,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
 			usdt_from_asset_hub.clone(),
 			&sender,
@@ -134,9 +142,9 @@ fn transact_from_para_to_para_through_asset_hub() {
 
 	let receiver = PenpalBReceiver::get();
 
-	let sender_assets_before = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let sender_assets_before = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
 	let receiver_assets_before =
-		foreign_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
+		assets_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
 
 	let usdt_to_send: Asset = (usdt_from_asset_hub.clone(), fee_amount_to_send).into();
 	let asset_location_on_penpal_a =
@@ -170,8 +178,8 @@ fn transact_from_para_to_para_through_asset_hub() {
 		penpal_b_assertions(foreign_asset_at_penpal_b, expected_creator, receiver.clone());
 	});
 
-	let sender_assets_after = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
-	let receiver_assets_after = foreign_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
+	let sender_assets_after = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
 
 	assert_eq!(sender_assets_after, sender_assets_before - fee_amount_to_send);
 	assert!(receiver_assets_after > receiver_assets_before);
@@ -204,7 +212,7 @@ fn penpal_b_assertions(
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Created { asset_id, creator, owner }
 			) => {
 				asset_id: *asset_id == expected_asset,
@@ -265,7 +273,7 @@ fn transact_using_authorized_alias_from_para_to_asset_hub_and_back_to_para() {
 	});
 
 	let sender_usdt_on_penpal_before =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 	let sender_usdt_on_ah_before = assets_balance_on!(AssetHubKusama, USDT_ID, &sender);
 
 	let call = <AssetHubKusama as Chain>::RuntimeCall::AssetConversion(
@@ -388,7 +396,7 @@ fn transact_using_authorized_alias_from_para_to_asset_hub_and_back_to_para() {
 
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubKusama, USDT_ID, &sender);
 	let sender_usdt_on_penpal_after =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	assert_eq!(
 		sender_usdt_on_penpal_after,
@@ -443,7 +451,7 @@ fn transact_using_sov_account_from_para_to_asset_hub_and_back_to_para() {
 	);
 
 	let sender_usdt_on_penpal_before =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 	let sender_usdt_on_ah_before =
 		assets_balance_on!(AssetHubKusama, USDT_ID, &sov_of_sender_on_asset_hub);
 
@@ -567,7 +575,7 @@ fn transact_using_sov_account_from_para_to_asset_hub_and_back_to_para() {
 	let sender_usdt_on_ah_after =
 		assets_balance_on!(AssetHubKusama, USDT_ID, &sov_of_sender_on_asset_hub);
 	let sender_usdt_on_penpal_after =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	assert_eq!(
 		sender_usdt_on_penpal_after,

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{assets_balance_on, create_pool_with_ksm_on, foreign_balance_on, *};
+use crate::{assets_balance_on, create_pool_with_ksm_on, *};
 use asset_hub_kusama_runtime::xcm_config::KsmLocation;
 use frame_support::traits::tokens::fungibles::Mutate;
 use xcm::latest::AssetTransferFilter;

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/transact.rs
@@ -395,8 +395,7 @@ fn transact_using_authorized_alias_from_para_to_asset_hub_and_back_to_para() {
 	});
 
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubKusama, USDT_ID, &sender);
-	let sender_usdt_on_penpal_after =
-		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+	let sender_usdt_on_penpal_after = assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	assert_eq!(
 		sender_usdt_on_penpal_after,
@@ -574,8 +573,7 @@ fn transact_using_sov_account_from_para_to_asset_hub_and_back_to_para() {
 
 	let sender_usdt_on_ah_after =
 		assets_balance_on!(AssetHubKusama, USDT_ID, &sov_of_sender_on_asset_hub);
-	let sender_usdt_on_penpal_after =
-		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+	let sender_usdt_on_penpal_after = assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	assert_eq!(
 		sender_usdt_on_penpal_after,

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
@@ -16,9 +16,9 @@
 //! Tests for XCM fee estimation in the runtime.
 
 use crate::{
-	assert_expected_events, bx, AssetHubKusama, Chain, ParaToParaThroughAHTest, PenpalA,
-	PenpalAPallet, PenpalASender, PenpalAssetOwner, PenpalB, PenpalBPallet, PenpalBReceiver,
-	TestArgs, TestContext, TransferType,
+	assert_expected_events, assets_balance_on, bx, AssetHubKusama, Chain,
+	ParaToParaThroughAHTest, PenpalA, PenpalAPallet, PenpalASender, PenpalAssetOwner, PenpalB,
+	PenpalBPallet, PenpalBReceiver, TestArgs, TestContext, TransferType,
 };
 use emulated_integration_tests_common::impls::{Parachain, TestExt};
 use frame_support::{
@@ -182,18 +182,12 @@ fn multi_hop_works() {
 	AssetHubKusama::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic.
-	let sender_assets_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sender_balance_before = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_before = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &beneficiary_id);
 	let receiver_balance_before = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -205,18 +199,12 @@ fn multi_hop_works() {
 	test.set_dispatchable::<PenpalA>(transfer_assets_para_to_para_through_ah_dispatchable);
 	test.assert();
 
-	let sender_assets_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sender_balance_after = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_after = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &beneficiary_id);
 	let receiver_balance_after = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -556,14 +544,8 @@ fn multi_hop_pay_fees_works() {
 	AssetHubKusama::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic with exact fees.
-	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &beneficiary_id);
 
 	test.set_assertion::<PenpalA>(pay_fees_sender_assertions);
 	test.set_assertion::<AssetHubKusama>(pay_fees_hop_assertions);
@@ -576,14 +558,8 @@ fn multi_hop_pay_fees_works() {
 	test.set_call(call);
 	test.assert();
 
-	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &beneficiary_id);
 
 	// We know the exact fees on every hop.
 	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
@@ -24,7 +24,7 @@ use emulated_integration_tests_common::impls::{Parachain, TestExt};
 use frame_support::{
 	dispatch::RawOrigin,
 	sp_runtime::{traits::Dispatchable, DispatchResult},
-	traits::fungibles::Inspect,
+	traits::{fungible, fungibles::Inspect},
 };
 use xcm::prelude::*;
 use xcm_runtime_apis::{
@@ -94,7 +94,7 @@ fn multi_hop_works() {
 			.unwrap();
 		assert_eq!(messages_to_query.len(), 1);
 		remote_message = messages_to_query[0].clone();
-		let asset_id_for_delivery_fees = VersionedAssetId::from(Location::parent());
+		let asset_id_for_delivery_fees = VersionedAssetId::from(Location::here());
 		let delivery_fees = Runtime::query_delivery_fees(
 			destination_to_query.clone(),
 			remote_message.clone(),
@@ -151,19 +151,6 @@ fn multi_hop_works() {
 		intermediate_delivery_fees_amount = get_amount_from_versioned_assets(delivery_fees);
 	});
 
-	// Get the final execution fees in the destination.
-	let mut final_execution_fees = 0;
-	<PenpalB as TestExt>::execute_with(|| {
-		type Runtime = <PenpalA as Chain>::Runtime;
-
-		let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
-		final_execution_fees = Runtime::query_weight_to_asset_fee(
-			weight,
-			VersionedAssetId::from(AssetId(Parent.into())),
-		)
-		.unwrap();
-	});
-
 	// Dry-running is done.
 	PenpalA::reset_ext();
 	AssetHubKusama::reset_ext();
@@ -176,16 +163,40 @@ fn multi_hop_works() {
 		sender.clone(),
 		amount_to_send * 2,
 	);
+
+	// Get the final execution fees at the destination.
+	//
+	// Note: We need to do this after resetting the externalities to get an accurate value here.
+	// This is because the dry-run on Asset Hub does affect the liquidity pool distribution on
+	// PenpalB which affects the assets amount we have to pay.
+	let mut final_execution_fees = 0;
+	<PenpalB as TestExt>::execute_with(|| {
+		type Runtime = <PenpalB as Chain>::Runtime;
+
+		let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
+		final_execution_fees =
+			Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::from(Location::parent()))
+				.unwrap();
+	});
+
 	AssetHubKusama::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic.
 	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+	});
+	let sender_balance_before = PenpalA::execute_with(|| {
+		type Balances = <PenpalA as PenpalAPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
 	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
+		type Assets = <PenpalB as PenpalBPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
+	});
+	let receiver_balance_before = PenpalB::execute_with(|| {
+		type Balances = <PenpalB as PenpalBPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
 	});
 
 	test.set_assertion::<PenpalA>(sender_assertions);
@@ -195,21 +206,32 @@ fn multi_hop_works() {
 	test.assert();
 
 	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+	});
+	let sender_balance_after = PenpalA::execute_with(|| {
+		type Balances = <PenpalA as PenpalAPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
 	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
+		type Assets = <PenpalB as PenpalBPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
+	});
+	let receiver_balance_after = PenpalB::execute_with(|| {
+		type Balances = <PenpalB as PenpalBPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
 	});
 
 	// We know the exact fees on every hop.
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	assert_eq!(
-		sender_assets_after,
-		sender_assets_before - amount_to_send - delivery_fees_amount /* This is charged directly
-		                                                              * from the sender's
-		                                                              * account. */
+		sender_balance_after,
+		// This is charged directly from the sender's account.
+		sender_balance_before - delivery_fees_amount
 	);
+
+	// Receiver native balance is unchanged; received funds in relay asset, and paid in relay asset.
+	assert_eq!(receiver_balance_after, receiver_balance_before);
 	assert_eq!(
 		receiver_assets_after,
 		receiver_assets_before + amount_to_send -
@@ -226,7 +248,7 @@ fn sender_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalA,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, amount }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -247,7 +269,9 @@ fn hop_assertions(test: ParaToParaThroughAHTest) {
 			RuntimeEvent::Balances(
 				pallet_balances::Event::Withdraw { amount, .. }
 			) => {
-				amount: *amount == test.args.amount,
+				// Depends on: XCM execution fees + delivery fees + liquidity pool
+				// swap overhead at the destination.
+				amount: *amount >= test.args.amount * 80/100,
 			},
 		]
 	);
@@ -260,7 +284,7 @@ fn receiver_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Deposited { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -316,7 +340,7 @@ fn pay_fees_sender_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalA,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -347,7 +371,7 @@ fn pay_fees_receiver_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Deposited { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -533,11 +557,11 @@ fn multi_hop_pay_fees_works() {
 
 	// Actually run the extrinsic with exact fees.
 	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
 	});
 
@@ -553,11 +577,11 @@ fn multi_hop_pay_fees_works() {
 	test.assert();
 
 	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
 	});
 

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
@@ -16,9 +16,9 @@
 //! Tests for XCM fee estimation in the runtime.
 
 use crate::{
-	assert_expected_events, assets_balance_on, bx, AssetHubKusama, Chain,
-	ParaToParaThroughAHTest, PenpalA, PenpalAPallet, PenpalASender, PenpalAssetOwner, PenpalB,
-	PenpalBPallet, PenpalBReceiver, TestArgs, TestContext, TransferType,
+	assert_expected_events, assets_balance_on, bx, AssetHubKusama, Chain, ParaToParaThroughAHTest,
+	PenpalA, PenpalAPallet, PenpalASender, PenpalAssetOwner, PenpalB, PenpalBPallet,
+	PenpalBReceiver, TestArgs, TestContext, TransferType,
 };
 use emulated_integration_tests_common::impls::{Parachain, TestExt};
 use frame_support::{
@@ -182,12 +182,14 @@ fn multi_hop_works() {
 	AssetHubKusama::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic.
-	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let sender_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sender_balance_before = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &beneficiary_id);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &beneficiary_id);
 	let receiver_balance_before = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -199,12 +201,14 @@ fn multi_hop_works() {
 	test.set_dispatchable::<PenpalA>(transfer_assets_para_to_para_through_ah_dispatchable);
 	test.assert();
 
-	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let sender_assets_after =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let sender_balance_after = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &beneficiary_id);
+	let receiver_assets_after =
+		assets_balance_on!(PenpalB, relay_native_asset_location, &beneficiary_id);
 	let receiver_balance_after = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -544,8 +548,10 @@ fn multi_hop_pay_fees_works() {
 	AssetHubKusama::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic with exact fees.
-	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
-	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &beneficiary_id);
+	let sender_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &beneficiary_id);
 
 	test.set_assertion::<PenpalA>(pay_fees_sender_assertions);
 	test.set_assertion::<AssetHubKusama>(pay_fees_hop_assertions);
@@ -558,8 +564,10 @@ fn multi_hop_pay_fees_works() {
 	test.set_call(call);
 	test.assert();
 
-	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
-	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &beneficiary_id);
+	let sender_assets_after =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_after =
+		assets_balance_on!(PenpalB, relay_native_asset_location, &beneficiary_id);
 
 	// We know the exact fees on every hop.
 	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/xcm_fee_estimation.rs
@@ -24,7 +24,7 @@ use emulated_integration_tests_common::impls::{Parachain, TestExt};
 use frame_support::{
 	dispatch::RawOrigin,
 	sp_runtime::{traits::Dispatchable, DispatchResult},
-	traits::{fungible, fungibles::Inspect},
+	traits::fungible,
 };
 use xcm::prelude::*;
 use xcm_runtime_apis::{
@@ -169,6 +169,7 @@ fn multi_hop_works() {
 	// Note: We need to do this after resetting the externalities to get an accurate value here.
 	// This is because the dry-run on Asset Hub does affect the liquidity pool distribution on
 	// PenpalB which affects the assets amount we have to pay.
+	// See side-effects: https://github.com/paritytech/polkadot-sdk/issues/11486.
 	let mut final_execution_fees = 0;
 	<PenpalB as TestExt>::execute_with(|| {
 		type Runtime = <PenpalB as Chain>::Runtime;

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/lib.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/lib.rs
@@ -50,7 +50,8 @@ pub use emulated_integration_tests_common::{
 	PROOF_SIZE_THRESHOLD, REF_TIME_THRESHOLD, XCM_V4,
 };
 pub use integration_tests_helpers::{
-	test_parachain_is_trusted_teleporter_for_relay, test_relay_is_trusted_teleporter,
+	assets_balance_on, test_parachain_is_trusted_teleporter_for_relay,
+	test_relay_is_trusted_teleporter,
 };
 pub use parachains_common::{AccountId, Balance};
 pub use polkadot_runtime::{xcm_config::UniversalLocation as PolkadotUniversalLocation, Dmp};

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/lib.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/lib.rs
@@ -40,7 +40,8 @@ pub use asset_hub_polkadot_runtime::xcm_config::{
 };
 pub use asset_test_utils::xcm_helpers;
 pub use emulated_integration_tests_common::{
-	test_parachain_is_trusted_teleporter,
+	create_foreign_pool_with_native_on, create_foreign_pool_with_parent_native_on,
+	local_penpal_asset, test_parachain_is_trusted_teleporter,
 	xcm_emulator::{
 		assert_expected_events, bx, helpers::weight_within_threshold, Chain, Parachain as Para,
 		RelayChain as Relay, Test, TestArgs, TestContext, TestExt,
@@ -66,6 +67,7 @@ pub use polkadot_system_emulated_network::{
 	coretime_polkadot_emulated_chain::CoretimePolkadotParaPallet as CoretimePolkadotPallet,
 	penpal_emulated_chain::{
 		penpal_runtime::xcm_config::{
+			LocalPen2Asset as PenpalLocalPen2Asset,
 			LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,
 			LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
 			UniversalLocation as PenpalUniversalLocation,
@@ -98,10 +100,10 @@ pub type RelayToSystemParaTest = Test<Polkadot, AssetHubPolkadot>;
 pub type RelayToParaTest = Test<Polkadot, PenpalB>;
 pub type ParaToRelayTest = Test<PenpalA, Polkadot>;
 pub type SystemParaToRelayTest = Test<AssetHubPolkadot, Polkadot>;
-pub type SystemParaToParaTest = Test<AssetHubPolkadot, PenpalB>;
-pub type ParaToSystemParaTest = Test<PenpalB, AssetHubPolkadot>;
-pub type ParaToParaThroughRelayTest = Test<PenpalB, PenpalA, Polkadot>;
-pub type ParaToParaThroughAHTest = Test<PenpalB, PenpalA, AssetHubPolkadot>;
+pub type SystemParaToParaTest = Test<AssetHubPolkadot, PenpalB, (), TestArgs<Location>>;
+pub type ParaToSystemParaTest = Test<PenpalB, AssetHubPolkadot, (), TestArgs<Location>>;
+pub type ParaToParaThroughRelayTest = Test<PenpalB, PenpalA, Polkadot, TestArgs<Location>>;
+pub type ParaToParaThroughAHTest = Test<PenpalB, PenpalA, AssetHubPolkadot, TestArgs<Location>>;
 pub type RelayToParaThroughAHTest = Test<Polkadot, PenpalB, AssetHubPolkadot>;
 pub type PenpalToRelayThroughAHTest = Test<PenpalB, Polkadot, AssetHubPolkadot>;
 

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/exchange_asset.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/exchange_asset.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{assets_balance_on, create_pool_with_dot_on, foreign_balance_on, *};
+use crate::{assets_balance_on, create_pool_with_dot_on, *};
 use asset_hub_polkadot_runtime::{
 	xcm_config::DotLocation, Balances, ExistentialDeposit, ForeignAssets, PolkadotXcm,
 	RuntimeOrigin,

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/exchange_asset.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/exchange_asset.rs
@@ -295,8 +295,7 @@ fn exchange_asset_from_penpal_via_asset_hub_back_to_penpal() {
 
 	// Query final balances
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubPolkadot, USDT_ID, &sender);
-	let sender_usdt_on_penpal_after =
-		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+	let sender_usdt_on_penpal_after = assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	// Receiver's balance is increased by usdt amount we got from exchange
 	assert_eq!(

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/exchange_asset.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/exchange_asset.rs
@@ -193,7 +193,7 @@ fn exchange_asset_from_penpal_via_asset_hub_back_to_penpal() {
 
 	// Query initial balances
 	let sender_usdt_on_penpal_before =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 	let sender_usdt_on_ah_before = assets_balance_on!(AssetHubPolkadot, USDT_ID, &sender);
 
 	let asset_hub_location_penpal_pov = PenpalA::sibling_location_of(AssetHubPolkadot::para_id());
@@ -296,7 +296,7 @@ fn exchange_asset_from_penpal_via_asset_hub_back_to_penpal() {
 	// Query final balances
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubPolkadot, USDT_ID, &sender);
 	let sender_usdt_on_penpal_after =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	// Receiver's balance is increased by usdt amount we got from exchange
 	assert_eq!(

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/foreign_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/foreign_assets.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{
-	asset_exists_on, assets_balance_on, foreign_balance_on,
+	asset_exists_on, assets_balance_on,
 	tests::send::penpal_register_foreign_asset_on_asset_hub, *,
 };
 use xcm::latest::AssetTransferFilter;

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/foreign_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/foreign_assets.rs
@@ -14,8 +14,7 @@
 // limitations under the License.
 
 use crate::{
-	asset_exists_on, assets_balance_on,
-	tests::send::penpal_register_foreign_asset_on_asset_hub, *,
+	asset_exists_on, assets_balance_on, tests::send::penpal_register_foreign_asset_on_asset_hub, *,
 };
 use xcm::latest::AssetTransferFilter;
 

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/foreign_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/foreign_assets.rs
@@ -13,7 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{tests::send::penpal_register_foreign_asset_on_asset_hub, *};
+use crate::{
+	asset_exists_on, assets_balance_on, foreign_balance_on,
+	tests::send::penpal_register_foreign_asset_on_asset_hub, *,
+};
 use xcm::latest::AssetTransferFilter;
 
 // Registers a new asset on Penpal, then registers it over XCM as foreign asset on Asset Hub.
@@ -22,44 +25,34 @@ use xcm::latest::AssetTransferFilter;
 // between Penpal and AH.
 pub fn set_up_foreign_asset(
 	sender: sp_runtime::AccountId32,
-	asset_id_on_penpal: u32,
+	asset_location_on_penpal: Location,
 	asset_amount_to_send: u128,
 	teleportable: bool,
 ) -> (Location, Location) {
 	let asset_owner = PenpalAssetOwner::get();
 
 	// Give the sender enough native
-	PenpalA::mint_foreign_asset(
-		<PenpalA as Chain>::RuntimeOrigin::signed(asset_owner.clone()),
-		DotLocation::get(),
-		sender.clone(),
-		asset_amount_to_send,
-	);
+	PenpalA::fund_accounts(vec![(sender.clone(), asset_amount_to_send)]);
 
 	// Create the asset on Penpal
 	let to_fund = asset_amount_to_send * 2;
-	PenpalA::force_create_asset(
-		asset_id_on_penpal,
+	PenpalA::force_create_foreign_asset(
+		asset_location_on_penpal.clone(),
 		asset_owner.clone(),
 		true,
 		ASSET_MIN_BALANCE,
 		vec![(sender.clone(), to_fund)],
 	);
-	PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		assert!(Assets::asset_exists(asset_id_on_penpal));
-	});
-	let asset_location_on_penpal = Location::new(
-		0,
-		[
-			Junction::PalletInstance(ASSETS_PALLET_ID),
-			Junction::GeneralIndex(asset_id_on_penpal.into()),
-		],
-	);
+
+	asset_exists_on!(PenpalA, asset_location_on_penpal.clone());
 
 	// Setup a pool on Penpal between native asset and newly created asset, so we can pay fees using
 	// new asset directly.
-	create_pool_with_dot_on!(PenpalA, asset_location_on_penpal.clone(), false, asset_owner.clone());
+	create_foreign_pool_with_native_on!(
+		PenpalA,
+		asset_location_on_penpal.clone(),
+		asset_owner.clone()
+	);
 
 	// Register asset on Asset Hub using XCM
 	let penpal_sovereign_account = AssetHubPolkadot::sovereign_account_id_of(
@@ -73,10 +66,9 @@ pub fn set_up_foreign_asset(
 
 	// Setup a pool on Asset Hub between native asset and newly created asset, so we can pay fees
 	// using new asset directly.
-	create_pool_with_dot_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubPolkadot,
 		foreign_asset_at_asset_hub.clone(),
-		true,
 		penpal_sovereign_account.clone()
 	);
 
@@ -146,16 +138,16 @@ pub fn penpal_set_foreign_asset_reserves_on_asset_hub(
 fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 	let sender = PenpalASender::get();
 	let receiver = AssetHubPolkadotReceiver::get();
-	let new_asset_id = 42;
+	let new_asset_id = local_penpal_asset(42);
 	let asset_amount_to_send = ASSET_HUB_POLKADOT_ED * 10_000;
 	let (asset_location_on_penpal, foreign_asset_location_on_ah) =
-		set_up_foreign_asset(sender.clone(), new_asset_id, asset_amount_to_send, true);
+		set_up_foreign_asset(sender.clone(), new_asset_id.clone(), asset_amount_to_send, true);
 
 	////////////////////////////////
 	// Teleport it from Penpal to AH
 	////////////////////////////////
 
-	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_before =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -192,7 +184,7 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 		.unwrap();
 	});
 
-	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_after =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -243,7 +235,7 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 	let asset_amount_to_send = ah_receiver_balance_after;
 	let ah_sender_balance_before =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah.clone(), &receiver);
-	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	let dest = AssetHubPolkadot::sibling_location_of(PenpalA::para_id());
 	// execute xcm from asset hub to penpal
@@ -300,7 +292,7 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 
 	let ah_sender_balance_after =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah, &receiver);
-	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	assert!(ah_sender_balance_after < ah_sender_balance_before);
 	assert!(penpal_receiver_balance_after > penpal_receiver_balance_before);
@@ -316,16 +308,16 @@ fn bidirectional_teleport_foreign_asset_between_penpal_and_asset_hub() {
 fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 	let sender = PenpalASender::get();
 	let receiver = AssetHubPolkadotReceiver::get();
-	let new_asset_id = 42;
+	let new_asset_id = local_penpal_asset(42);
 	let asset_amount_to_send = ASSET_HUB_POLKADOT_ED * 10_000;
 	let (asset_location_on_penpal, foreign_asset_location_on_ah) =
-		set_up_foreign_asset(sender.clone(), new_asset_id, asset_amount_to_send, false);
+		set_up_foreign_asset(sender.clone(), new_asset_id.clone(), asset_amount_to_send, false);
 
 	////////////////////////////////////////
 	// Reserve-transfer it from Penpal to AH
 	////////////////////////////////////////
 
-	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_before =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -381,7 +373,7 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 		));
 	});
 
-	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_sender_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 	let ah_receiver_balance_after =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah.clone(), &receiver);
 
@@ -395,7 +387,7 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 	let asset_amount_to_send = ah_receiver_balance_after;
 	let ah_sender_balance_before =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah.clone(), &receiver);
-	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_before = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	let dest = AssetHubPolkadot::sibling_location_of(PenpalA::para_id());
 	// execute xcm from asset hub to penpal
@@ -451,7 +443,7 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 
 	let ah_sender_balance_after =
 		foreign_balance_on!(AssetHubPolkadot, foreign_asset_location_on_ah, &receiver);
-	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id, &sender);
+	let penpal_receiver_balance_after = assets_balance_on!(PenpalA, new_asset_id.clone(), &sender);
 
 	assert!(ah_sender_balance_after < ah_sender_balance_before);
 	assert!(penpal_receiver_balance_after > penpal_receiver_balance_before);
@@ -462,10 +454,10 @@ fn bidirectional_reserve_transfer_foreign_asset_between_penpal_and_asset_hub() {
 #[test]
 fn verify_foreign_asset_origin_checks() {
 	let sender = PenpalASender::get();
-	let new_asset_id = 42;
+	let new_asset_id = local_penpal_asset(42);
 	let asset_amount_to_send = ASSET_HUB_POLKADOT_ED * 10_000;
 	let (_, foreign_asset_location_on_ah) =
-		set_up_foreign_asset(sender.clone(), new_asset_id, asset_amount_to_send, false);
+		set_up_foreign_asset(sender.clone(), new_asset_id.clone(), asset_amount_to_send, false);
 
 	let penpal_sovereign = AssetHubPolkadot::sovereign_account_id_of(
 		AssetHubPolkadot::sibling_location_of(PenpalA::para_id()),

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
@@ -250,14 +250,8 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
-	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &receiver)
-	});
-	let receiver_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &receiver)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalB, native_asset_location.clone(), &receiver);
+	let receiver_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubPolkadot>(system_para_to_para_sender_assertions);
@@ -271,14 +265,8 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
-	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &receiver)
-	});
-	let receiver_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &receiver)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalB, native_asset_location, &receiver);
+	let receiver_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - native_amount_to_send);
@@ -392,14 +380,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(test_args);
 
 	// Query initial balances
-	let sender_native_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &sender)
-	});
-	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
-	});
+	let sender_native_before = assets_balance_on!(PenpalB, native_asset_location.clone(), &sender);
+	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let receiver_native_before = test.receiver.balance;
 	let receiver_ksm_before = AssetHubPolkadot::execute_with(|| {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
@@ -413,14 +395,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_native_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &sender)
-	});
-	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
-	});
+	let sender_native_after = assets_balance_on!(PenpalB, native_asset_location, &sender);
+	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let receiver_native_after = test.receiver.balance;
 	let receiver_ksm_after = AssetHubPolkadot::execute_with(|| {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
@@ -554,14 +530,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	let mut test = ParaToParaThroughAHTest::new(test_args);
 
 	// Query initial balances
-	let sender_dot_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_location.clone(), &sender)
-	});
-	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
-	});
+	let sender_dot_before = assets_balance_on!(PenpalB, dot_location.clone(), &sender);
+	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let dot_in_sender_reserve_on_ahp_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_of_sender_on_ah.clone()).free;
 	let ksm_in_sender_reserve_on_ahp_before = AssetHubPolkadot::execute_with(|| {
@@ -574,14 +544,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sov_of_receiver_on_ah)
 	});
-	let receiver_dot_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_location.clone(), &receiver)
-	});
-	let receiver_ksm_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &receiver)
-	});
+	let receiver_dot_before = assets_balance_on!(PenpalA, dot_location.clone(), &receiver);
+	let receiver_ksm_before = assets_balance_on!(PenpalA, ksm_at_polkadot_parachains_latest.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalB>(para_to_para_through_hop_sender_assertions);
@@ -591,14 +555,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_dot_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_location.clone(), &sender)
-	});
-	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
-	});
+	let sender_dot_after = assets_balance_on!(PenpalB, dot_location.clone(), &sender);
+	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let ksm_in_sender_reserve_on_ahp_after = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sov_of_sender_on_ah)
@@ -611,14 +569,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	});
 	let dot_in_receiver_reserve_on_ahp_after =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_of_receiver_on_ah).free;
-	let receiver_dot_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_location, &receiver)
-	});
-	let receiver_ksm_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &receiver)
-	});
+	let receiver_dot_after = assets_balance_on!(PenpalA, dot_location, &receiver);
+	let receiver_ksm_after = assets_balance_on!(PenpalA, ksm_at_polkadot_parachains_latest, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert_eq!(sender_dot_after, sender_dot_before - dot_to_send);
@@ -886,10 +838,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	AssetHubPolkadot::fund_accounts(vec![(sov_penpal_on_ah.clone(), amount_to_send * 2)]);
 
 	// Query initial balances
-	let sender_balance_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_balance_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_before = AssetHubPolkadot::execute_with(|| {
 		<AssetHubPolkadot as AssetHubPolkadotPallet>::Balances::free_balance(
 			sov_penpal_on_ah.clone(),
@@ -945,10 +894,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_balance_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_balance_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_after = AssetHubPolkadot::execute_with(|| {
 		<AssetHubPolkadot as AssetHubPolkadotPallet>::Balances::free_balance(
 			sov_penpal_on_ah.clone(),

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
@@ -15,7 +15,7 @@
 
 use super::reserve_transfer::*;
 use crate::{
-	foreign_balance_on,
+	assets_balance_on, foreign_balance_on,
 	tests::teleport::do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using_xt,
 	*,
 };
@@ -251,11 +251,11 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
 	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &receiver)
 	});
 	let receiver_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &receiver)
 	});
 
@@ -272,11 +272,11 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
 	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &receiver)
 	});
 	let receiver_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &receiver)
 	});
 
@@ -393,11 +393,11 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_native_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location.clone(), &sender)
 	});
 	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
 	});
 	let receiver_native_before = test.receiver.balance;
@@ -414,11 +414,11 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_native_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(native_asset_location, &sender)
 	});
 	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
 	});
 	let receiver_native_after = test.receiver.balance;
@@ -555,11 +555,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query initial balances
 	let sender_dot_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_location.clone(), &sender)
 	});
 	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
 	});
 	let dot_in_sender_reserve_on_ahp_before =
@@ -575,11 +575,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		<Assets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sov_of_receiver_on_ah)
 	});
 	let receiver_dot_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_location.clone(), &receiver)
 	});
 	let receiver_ksm_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &receiver)
 	});
 
@@ -592,11 +592,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query final balances
 	let sender_dot_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_location.clone(), &sender)
 	});
 	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
 	});
 	let ksm_in_sender_reserve_on_ahp_after = AssetHubPolkadot::execute_with(|| {
@@ -612,11 +612,11 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	let dot_in_receiver_reserve_on_ahp_after =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_of_receiver_on_ah).free;
 	let receiver_dot_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_location, &receiver)
 	});
 	let receiver_ksm_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &receiver)
 	});
 
@@ -715,14 +715,14 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 
 	// PenpalB has a pool between USDT and DOT so fees can be paid with USDT by automatically
 	// swapping them for DOT.
-	create_pool_with_dot_on!(PenpalB, usdt_location.clone(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalB, usdt_location.clone(), PenpalAssetOwner::get());
 
 	// Sender starts with a lot of USDT.
-	let sender_balance_before = foreign_balance_on!(PenpalA, usdt_location.clone(), &sender);
+	let sender_balance_before = assets_balance_on!(PenpalA, usdt_location.clone(), &sender);
 	assert_eq!(sender_balance_before, 10_000_000_000_000);
 
 	// Receiver has no USDT.
-	let receiver_balance_before = foreign_balance_on!(PenpalB, usdt_location.clone(), &receiver);
+	let receiver_balance_before = assets_balance_on!(PenpalB, usdt_location.clone(), &receiver);
 	assert_eq!(receiver_balance_before, 0);
 
 	let test_args = TestContext {
@@ -750,7 +750,7 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 		assert_expected_events!(
 			PenpalA,
 			vec![
-				Event::ForeignAssets(
+				Event::Assets(
 					pallet_assets::Event::Withdrawn { asset_id, amount, .. }
 				) => {
 					asset_id: *asset_id == usdt_location.clone(),
@@ -801,7 +801,7 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 			PenpalB,
 			vec![
 				// Final amount gets deposited to receiver.
-				Event::ForeignAssets(
+				Event::Assets(
 					pallet_assets::Event::Deposited { asset_id, who, .. }
 				) => {
 					asset_id: *asset_id == usdt_location,
@@ -823,11 +823,11 @@ fn usdt_only_transfer_from_para_to_para_through_asset_hub() {
 	test.assert();
 
 	// Sender has less USDT after the transfer.
-	let sender_balance_after = foreign_balance_on!(PenpalA, usdt_location.clone(), &sender);
+	let sender_balance_after = assets_balance_on!(PenpalA, usdt_location.clone(), &sender);
 	assert_eq!(sender_balance_after, 9_000_000_000_000);
 
 	// Receiver gets `transfer_amount` minus fees.
-	let receiver_balance_after = foreign_balance_on!(PenpalB, usdt_location.clone(), &receiver);
+	let receiver_balance_after = assets_balance_on!(PenpalB, usdt_location.clone(), &receiver);
 	assert!(receiver_balance_after > receiver_balance_before);
 }
 
@@ -887,7 +887,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 
 	// Query initial balances
 	let sender_balance_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let sov_penpal_on_ah_before = AssetHubPolkadot::execute_with(|| {
@@ -946,7 +946,7 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 
 	// Query final balances
 	let sender_balance_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let sov_penpal_on_ah_after = AssetHubPolkadot::execute_with(|| {

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
@@ -280,7 +280,7 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - native_amount_to_send);
 	// Sender's balance is reduced by foreign amount sent
 	assert_eq!(sender_ksm_after, sender_ksm_before - foreign_amount_to_send);
@@ -427,8 +427,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_native_after < sender_native_before - native_amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_native_after, sender_native_before - native_amount_to_send);
 	// Sender's balance is reduced by foreign amount sent
 	assert_eq!(sender_ksm_after, sender_ksm_before - foreign_amount_to_send);
 	// Receiver's balance is increased
@@ -620,8 +620,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_dot_after < sender_dot_before - dot_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_dot_after, sender_dot_before - dot_to_send);
 	assert_eq!(sender_ksm_after, sender_ksm_before - ksm_to_send);
 	// Sovereign accounts on reserve are changed accordingly
 	assert_eq!(
@@ -958,8 +958,8 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 		<Polkadot as PolkadotPallet>::Balances::free_balance(receiver.clone())
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_balance_after < sender_balance_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_balance_after, sender_balance_before - amount_to_send);
 	// Sovereign account on AH is reduced by amount sent
 	assert_eq!(sov_penpal_on_ah_after, sov_penpal_on_ah_before - amount_to_send);
 	// Receiver's balance is increased

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
@@ -250,8 +250,10 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
-	let receiver_assets_before = assets_balance_on!(PenpalB, native_asset_location.clone(), &receiver);
-	let receiver_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &receiver);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalB, native_asset_location.clone(), &receiver);
+	let receiver_ksm_before =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubPolkadot>(system_para_to_para_sender_assertions);
@@ -266,7 +268,8 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
 	let receiver_assets_after = assets_balance_on!(PenpalB, native_asset_location, &receiver);
-	let receiver_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest, &receiver);
+	let receiver_ksm_after =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - native_amount_to_send);
@@ -381,7 +384,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_native_before = assets_balance_on!(PenpalB, native_asset_location.clone(), &sender);
-	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
+	let sender_ksm_before =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let receiver_native_before = test.receiver.balance;
 	let receiver_ksm_before = AssetHubPolkadot::execute_with(|| {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
@@ -396,7 +400,8 @@ fn transfer_foreign_assets_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_native_after = assets_balance_on!(PenpalB, native_asset_location, &sender);
-	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
+	let sender_ksm_after =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let receiver_native_after = test.receiver.balance;
 	let receiver_ksm_after = AssetHubPolkadot::execute_with(|| {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
@@ -531,7 +536,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query initial balances
 	let sender_dot_before = assets_balance_on!(PenpalB, dot_location.clone(), &sender);
-	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
+	let sender_ksm_before =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let dot_in_sender_reserve_on_ahp_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_of_sender_on_ah.clone()).free;
 	let ksm_in_sender_reserve_on_ahp_before = AssetHubPolkadot::execute_with(|| {
@@ -545,7 +551,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 		<Assets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sov_of_receiver_on_ah)
 	});
 	let receiver_dot_before = assets_balance_on!(PenpalA, dot_location.clone(), &receiver);
-	let receiver_ksm_before = assets_balance_on!(PenpalA, ksm_at_polkadot_parachains_latest.clone(), &receiver);
+	let receiver_ksm_before =
+		assets_balance_on!(PenpalA, ksm_at_polkadot_parachains_latest.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalB>(para_to_para_through_hop_sender_assertions);
@@ -556,7 +563,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 
 	// Query final balances
 	let sender_dot_after = assets_balance_on!(PenpalB, dot_location.clone(), &sender);
-	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
+	let sender_ksm_after =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let ksm_in_sender_reserve_on_ahp_after = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sov_of_sender_on_ah)
@@ -570,7 +578,8 @@ fn transfer_foreign_assets_from_para_to_para_through_asset_hub() {
 	let dot_in_receiver_reserve_on_ahp_after =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_of_receiver_on_ah).free;
 	let receiver_dot_after = assets_balance_on!(PenpalA, dot_location, &receiver);
-	let receiver_ksm_after = assets_balance_on!(PenpalA, ksm_at_polkadot_parachains_latest, &receiver);
+	let receiver_ksm_after =
+		assets_balance_on!(PenpalA, ksm_at_polkadot_parachains_latest, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert_eq!(sender_dot_after, sender_dot_before - dot_to_send);
@@ -838,7 +847,8 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	AssetHubPolkadot::fund_accounts(vec![(sov_penpal_on_ah.clone(), amount_to_send * 2)]);
 
 	// Query initial balances
-	let sender_balance_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let sender_balance_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_before = AssetHubPolkadot::execute_with(|| {
 		<AssetHubPolkadot as AssetHubPolkadotPallet>::Balances::free_balance(
 			sov_penpal_on_ah.clone(),
@@ -894,7 +904,8 @@ fn transfer_native_asset_from_penpal_to_relay_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_balance_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let sender_balance_after =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sov_penpal_on_ah_after = AssetHubPolkadot::execute_with(|| {
 		<AssetHubPolkadot as AssetHubPolkadotPallet>::Balances::free_balance(
 			sov_penpal_on_ah.clone(),

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
@@ -15,7 +15,7 @@
 
 use super::reserve_transfer::*;
 use crate::{
-	assets_balance_on, foreign_balance_on,
+	assets_balance_on,
 	tests::teleport::do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using_xt,
 	*,
 };

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/hybrid_transfers.rs
@@ -271,7 +271,7 @@ fn transfer_foreign_assets_from_asset_hub_to_para() {
 	let receiver_ksm_after =
 		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest, &receiver);
 
-	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	// Sender's balance is reduced by amount sent plus delivery fees
 	assert!(sender_balance_after < sender_balance_before - native_amount_to_send);
 	// Sender's balance is reduced by foreign amount sent
 	assert_eq!(sender_ksm_after, sender_ksm_before - foreign_amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
@@ -43,18 +43,6 @@ macro_rules! foreign_balance_on {
 }
 
 #[macro_export]
-macro_rules! assets_balance_on {
-	( $chain:ident, $id:expr, $who:expr ) => {
-		emulated_integration_tests_common::impls::paste::paste! {
-			<$chain>::execute_with(|| {
-				type Assets = <$chain as [<$chain Pallet>]>::Assets;
-				<Assets as Inspect<_>>::balance($id, $who)
-			})
-		}
-	};
-}
-
-#[macro_export]
 macro_rules! asset_exists_on {
 	( $chain:ident, $id:expr ) => {
 		emulated_integration_tests_common::impls::paste::paste! {

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
@@ -55,6 +55,18 @@ macro_rules! assets_balance_on {
 }
 
 #[macro_export]
+macro_rules! asset_exists_on {
+	( $chain:ident, $id:expr ) => {
+		emulated_integration_tests_common::impls::paste::paste! {
+			<$chain>::execute_with(|| {
+				type Assets = <$chain as [<$chain Pallet>]>::Assets;
+				<Assets as frame_support::traits::fungibles::Inspect<_>>::asset_exists($id)
+			})
+		}
+	};
+}
+
+#[macro_export]
 macro_rules! create_pool_with_dot_on {
 	// default amounts
 	( $chain:ident, $asset_id:expr, $is_foreign:expr, $asset_owner:expr ) => {

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -1207,7 +1207,11 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	// Setup the pool so we can swap the custom asset for native asset to pay for fees.
-	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(
+		PenpalB,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
 
 	let assets: Assets = vec![(
 		[PalletInstance(ASSETS_PALLET_ID), GeneralIndex(usdt_id.into())],
@@ -1309,7 +1313,11 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	);
 	create_pool_with_dot_on!(AssetHubPolkadot, usdt, false, AssetHubPolkadotSender::get());
 	// We also need a pool between DOT and USDT on PenpalB.
-	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(
+		PenpalB,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	PenpalA::execute_with(|| {

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -1274,15 +1274,12 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
-	PenpalA::execute_with(|| {
-		use frame_support::traits::tokens::fungibles::Mutate;
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
-			usdt_from_asset_hub.clone(),
-			&sender,
-			asset_amount_to_send + fee_amount_to_send,
-		));
-	});
+	PenpalA::mint_foreign_asset(
+		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
+		usdt_from_asset_hub.clone(),
+		sender.clone(),
+		asset_amount_to_send + fee_amount_to_send,
+	);
 
 	// Prepare assets to transfer.
 	let assets: Assets =

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -635,7 +635,7 @@ fn reserve_transfer_dot_from_relay_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's asset balance is increased
 	assert!(receiver_assets_after > receiver_assets_before);
@@ -707,8 +707,8 @@ fn reserve_transfer_dot_from_para_to_relay() {
 	});
 	let receiver_balance_after = test.receiver.balance;
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_assets_after < sender_assets_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	// Receiver's asset balance is increased
 	assert!(receiver_balance_after > receiver_balance_before);
 	// Receiver's asset balance increased by `amount_to_send - delivery_fees - bought_execution`;
@@ -765,7 +765,7 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's assets is increased
 	assert!(receiver_assets_after > receiver_assets_before);
@@ -839,8 +839,8 @@ fn reserve_transfer_dot_from_para_to_asset_hub() {
 	});
 	let receiver_balance_after = test.receiver.balance;
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_assets_after < sender_assets_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	// Receiver's balance is increased
 	assert!(receiver_balance_after > receiver_balance_before);
 	// Receiver's balance increased by `amount_to_send - delivery_fees - bought_execution`;
@@ -1149,8 +1149,8 @@ fn reserve_transfer_dot_from_para_to_para_through_relay() {
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
-	// Sender's balance is reduced by amount sent plus delivery fees
-	assert!(sender_assets_after < sender_assets_before - amount_to_send);
+	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	// Receiver's balance is increased
 	assert!(receiver_assets_after > receiver_assets_before);
 }

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -630,7 +630,7 @@ fn reserve_transfer_dot_from_relay_to_para() {
 	let sender_balance_after = test.sender.balance;
 	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &receiver);
 
-	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	// Sender's balance is reduced by amount sent plus delivery fees
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's asset balance is increased
 	assert!(receiver_assets_after > receiver_assets_before);
@@ -751,7 +751,7 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 	let receiver_assets_after =
 		assets_balance_on!(PenpalB, system_para_native_asset_location, &receiver);
 
-	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
+	// Sender's balance is reduced by amount sent plus delivery fees
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
 	// Receiver's assets is increased
 	assert!(receiver_assets_after > receiver_assets_before);

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{assets_balance_on, create_pool_with_dot_on, foreign_balance_on, *};
+use crate::{assets_balance_on, create_pool_with_dot_on, *};
 use emulated_integration_tests_common::{xcm_helpers::fee_asset, RESERVABLE_ASSET_ID};
 use polkadot_system_emulated_network::{
 	penpal_emulated_chain::LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{create_pool_with_dot_on, foreign_balance_on, *};
+use crate::{assets_balance_on, create_pool_with_dot_on, foreign_balance_on, *};
 use emulated_integration_tests_common::{xcm_helpers::fee_asset, RESERVABLE_ASSET_ID};
 use polkadot_system_emulated_network::{
 	penpal_emulated_chain::LocalReservableFromAssetHub as PenpalLocalReservableFromAssetHub,
@@ -48,7 +48,7 @@ fn para_to_relay_sender_assertions(t: ParaToRelayTest) {
 		PenpalA,
 		vec![
 			// Amount to reserve transfer is transferred to Parachain's Sovereign account
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, amount, .. }
 			) => {
 				asset_id: *asset_id == DotLocation::get(),
@@ -96,7 +96,7 @@ pub fn system_para_to_para_receiver_assertions(t: SystemParaToParaTest) {
 		assert_expected_events!(
 			PenpalB,
 			vec![
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == relative_id,
 					who: *who == t.receiver.account_id,
 				},
@@ -111,7 +111,7 @@ fn relay_to_para_assets_receiver_assertions(t: RelayToParaTest) {
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 				asset_id: *asset_id == DotLocation::get(),
 				who: *who == t.receiver.account_id,
 			},
@@ -156,7 +156,7 @@ pub fn para_to_system_para_sender_assertions(t: ParaToSystemParaTest) {
 		assert_expected_events!(
 			PenpalA,
 			vec![
-				RuntimeEvent::ForeignAssets(
+				RuntimeEvent::Assets(
 					pallet_assets::Event::Withdrawn { asset_id, who, amount }
 				) => {
 					asset_id: *asset_id == expected_id,
@@ -223,14 +223,14 @@ fn para_to_system_para_assets_sender_assertions(t: ParaToSystemParaTest) {
 		PenpalB,
 		vec![
 			// Fees amount to reserve transfer is burned from Parachains's sender account
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == system_para_native_asset_location,
 				who: *who == t.sender.account_id,
 			},
 			// Amount to reserve transfer is burned from Parachains's sender account
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, amount }
 			) => {
 				asset_id: *asset_id == reservable_asset_location,
@@ -253,11 +253,11 @@ fn system_para_to_para_assets_receiver_assertions(t: SystemParaToParaTest) {
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 				asset_id: *asset_id == DotLocation::get(),
 				who: *who == t.receiver.account_id,
 			},
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, amount }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, amount }) => {
 				asset_id: *asset_id == system_para_asset_location,
 				who: *who == t.receiver.account_id,
 				amount: *amount == t.args.amount,
@@ -300,7 +300,9 @@ fn para_to_system_para_assets_receiver_assertions(t: ParaToSystemParaTest) {
 	);
 }
 
-pub fn para_to_para_through_hop_sender_assertions<Hop: Clone>(t: Test<PenpalB, PenpalA, Hop>) {
+pub fn para_to_para_through_hop_sender_assertions<Hop: Clone>(
+	t: Test<PenpalB, PenpalA, Hop, TestArgs<Location>>,
+) {
 	type RuntimeEvent = <PenpalB as Chain>::RuntimeEvent;
 
 	PenpalB::assert_xcm_pallet_attempted_complete(None);
@@ -311,7 +313,7 @@ pub fn para_to_para_through_hop_sender_assertions<Hop: Clone>(t: Test<PenpalB, P
 			PenpalB,
 			vec![
 				// Amount to reserve transfer is transferred to Parachain's Sovereign account
-				RuntimeEvent::ForeignAssets(
+				RuntimeEvent::Assets(
 					pallet_assets::Event::Withdrawn { asset_id, who, amount: transferred_amount },
 				) => {
 					asset_id: *asset_id == expected_id,
@@ -352,7 +354,9 @@ fn para_to_para_relay_hop_assertions(t: ParaToParaThroughRelayTest) {
 	);
 }
 
-pub fn para_to_para_through_hop_receiver_assertions<Hop: Clone>(t: Test<PenpalB, PenpalA, Hop>) {
+pub fn para_to_para_through_hop_receiver_assertions<Hop: Clone>(
+	t: Test<PenpalB, PenpalA, Hop, TestArgs<Location>>,
+) {
 	type RuntimeEvent = <PenpalA as Chain>::RuntimeEvent;
 
 	PenpalA::assert_xcmp_queue_success(None);
@@ -361,7 +365,7 @@ pub fn para_to_para_through_hop_receiver_assertions<Hop: Clone>(t: Test<PenpalB,
 		assert_expected_events!(
 			PenpalA,
 			vec![
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == expected_id,
 					who: *who == t.receiver.account_id,
 				},
@@ -614,7 +618,7 @@ fn reserve_transfer_dot_from_relay_to_para() {
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
 	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
 	});
 
@@ -627,7 +631,7 @@ fn reserve_transfer_dot_from_relay_to_para() {
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
 	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
@@ -685,7 +689,7 @@ fn reserve_transfer_dot_from_para_to_relay() {
 
 	// Query initial balances
 	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_balance_before = test.receiver.balance;
@@ -698,7 +702,7 @@ fn reserve_transfer_dot_from_para_to_relay() {
 
 	// Query final balances
 	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &sender)
 	});
 	let receiver_balance_after = test.receiver.balance;
@@ -744,7 +748,7 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
 	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
 	});
 
@@ -757,7 +761,7 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
 	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &receiver)
 	});
 
@@ -817,7 +821,7 @@ fn reserve_transfer_dot_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &sender)
 	});
 	let receiver_balance_before = test.receiver.balance;
@@ -830,7 +834,7 @@ fn reserve_transfer_dot_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &sender)
 	});
 	let receiver_balance_after = test.receiver.balance;
@@ -908,11 +912,11 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
 	let receiver_system_native_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
 	});
 	let receiver_foreign_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(
 			system_para_foreign_asset_location.clone(),
 			&receiver,
@@ -932,11 +936,11 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
 	let receiver_system_native_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
 	});
 	let receiver_foreign_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_para_foreign_asset_location, &receiver)
 	});
 	// Sender's balance is reduced
@@ -1035,11 +1039,11 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 
 	// Query initial balances
 	let sender_system_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal.clone(), &sender)
 	});
 	let sender_foreign_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal.clone(), &sender)
 	});
 	let receiver_balance_before = test.receiver.balance;
@@ -1056,11 +1060,11 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 
 	// Query final balances
 	let sender_system_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal, &sender)
 	});
 	let sender_foreign_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal, &sender)
 	});
 	let receiver_balance_after = test.receiver.balance;
@@ -1120,11 +1124,11 @@ fn reserve_transfer_dot_from_para_to_para_through_relay() {
 
 	// Query initial balances
 	let sender_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
 	});
 
@@ -1137,11 +1141,11 @@ fn reserve_transfer_dot_from_para_to_para_through_relay() {
 
 	// Query final balances
 	let sender_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
 	});
 
@@ -1169,7 +1173,7 @@ fn system_para_to_penpal_receiver_assertions(t: SystemParaToParaTest) {
 		assert_expected_events!(
 			PenpalB,
 			vec![
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == relative_id,
 					who: *who == t.receiver.account_id,
 				},
@@ -1203,7 +1207,7 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	// Setup the pool so we can swap the custom asset for native asset to pay for fees.
-	create_pool_with_dot_on!(PenpalB, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
 
 	let assets: Assets = vec![(
 		[PalletInstance(ASSETS_PALLET_ID), GeneralIndex(usdt_id.into())],
@@ -1235,7 +1239,7 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 		Balances::free_balance(&sender)
 	});
 	let receiver_initial_balance =
-		foreign_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
+		assets_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
 
 	fn usdt_sender_assertions(_t: SystemParaToParaTest) {
 		AssetHubPolkadot::assert_xcm_pallet_attempted_complete(None);
@@ -1254,7 +1258,7 @@ fn reserve_transfer_usdt_from_asset_hub_to_para() {
 		type Balances = <AssetHubPolkadot as AssetHubPolkadotPallet>::Balances;
 		Balances::free_balance(&sender)
 	});
-	let receiver_after_balance = foreign_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
+	let receiver_after_balance = assets_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
 
 	assert!(sender_after_native_balance < sender_initial_native_balance);
 	// Sender account's balance decreases.
@@ -1305,12 +1309,12 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	);
 	create_pool_with_dot_on!(AssetHubPolkadot, usdt, false, AssetHubPolkadotSender::get());
 	// We also need a pool between DOT and USDT on PenpalB.
-	create_pool_with_dot_on!(PenpalB, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	PenpalA::execute_with(|| {
 		use frame_support::traits::tokens::fungibles::Mutate;
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
 			usdt_from_asset_hub.clone(),
 			&sender,
@@ -1393,7 +1397,7 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 			assert_expected_events!(
 				PenpalA,
 				vec![
-					RuntimeEvent::ForeignAssets(
+					RuntimeEvent::Assets(
 						pallet_assets::Event::Withdrawn { asset_id, who, amount: transferred_amount },
 					) => {
 						asset_id: *asset_id == expected_id,
@@ -1413,7 +1417,7 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 			assert_expected_events!(
 				PenpalB,
 				vec![
-					RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+					RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 						asset_id: *asset_id == expected_id,
 						who: *who == t.receiver.account_id,
 					},
@@ -1423,9 +1427,9 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	}
 
 	// Query initial balances
-	let sender_assets_before = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let sender_assets_before = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
 	let receiver_assets_before =
-		foreign_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
+		assets_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
 	test.set_assertion::<PenpalA>(usdt_sender_assertions);
 	test.set_assertion::<AssetHubPolkadot>(usdt_hop_assertions);
 	test.set_assertion::<PenpalB>(usdt_receiver_assertions);
@@ -1433,8 +1437,8 @@ fn reserve_transfer_usdt_from_para_to_para_through_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
-	let receiver_assets_after = foreign_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
+	let sender_assets_after = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
 
 	// Sender's balance is reduced by amount
 	assert!(sender_assets_after < sender_assets_before - asset_amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -617,7 +617,8 @@ fn reserve_transfer_dot_from_relay_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &receiver);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<Polkadot>(relay_to_para_sender_assertions);
@@ -682,7 +683,8 @@ fn reserve_transfer_dot_from_para_to_relay() {
 	let mut test = ParaToRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
+	let sender_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -735,7 +737,8 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubPolkadot>(system_para_to_para_sender_assertions);
@@ -745,7 +748,8 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
-	let receiver_assets_after = assets_balance_on!(PenpalB, system_para_native_asset_location, &receiver);
+	let receiver_assets_after =
+		assets_balance_on!(PenpalB, system_para_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
@@ -802,7 +806,8 @@ fn reserve_transfer_dot_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &sender);
+	let sender_assets_before =
+		assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -812,7 +817,8 @@ fn reserve_transfer_dot_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = assets_balance_on!(PenpalB, system_para_native_asset_location, &sender);
+	let sender_assets_after =
+		assets_balance_on!(PenpalB, system_para_native_asset_location, &sender);
 	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
@@ -887,8 +893,10 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_before = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
-	let receiver_foreign_assets_before = assets_balance_on!(PenpalB, system_para_foreign_asset_location.clone(), &receiver);
+	let receiver_system_native_assets_before =
+		assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_before =
+		assets_balance_on!(PenpalB, system_para_foreign_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubPolkadot>(system_para_to_para_assets_sender_assertions);
@@ -902,8 +910,10 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_after = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
-	let receiver_foreign_assets_after = assets_balance_on!(PenpalB, system_para_foreign_asset_location, &receiver);
+	let receiver_system_native_assets_after =
+		assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_after =
+		assets_balance_on!(PenpalB, system_para_foreign_asset_location, &receiver);
 	// Sender's balance is reduced
 	assert!(sender_balance_after < sender_balance_before);
 	// Receiver's foreign asset balance is increased
@@ -999,8 +1009,10 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(para_test_args);
 
 	// Query initial balances
-	let sender_system_assets_before = assets_balance_on!(PenpalB, system_asset_location_on_penpal.clone(), &sender);
-	let sender_foreign_assets_before = assets_balance_on!(PenpalB, asset_location_on_penpal.clone(), &sender);
+	let sender_system_assets_before =
+		assets_balance_on!(PenpalB, system_asset_location_on_penpal.clone(), &sender);
+	let sender_foreign_assets_before =
+		assets_balance_on!(PenpalB, asset_location_on_penpal.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 	let receiver_assets_before = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
@@ -1014,8 +1026,10 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_system_assets_after = assets_balance_on!(PenpalB, system_asset_location_on_penpal, &sender);
-	let sender_foreign_assets_after = assets_balance_on!(PenpalB, asset_location_on_penpal, &sender);
+	let sender_system_assets_after =
+		assets_balance_on!(PenpalB, system_asset_location_on_penpal, &sender);
+	let sender_foreign_assets_after =
+		assets_balance_on!(PenpalB, asset_location_on_penpal, &sender);
 	let receiver_balance_after = test.receiver.balance;
 	let receiver_assets_after = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
@@ -1072,8 +1086,10 @@ fn reserve_transfer_dot_from_para_to_para_through_relay() {
 	let mut test = ParaToParaThroughRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
-	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &receiver);
+	let sender_assets_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalB>(para_to_para_through_hop_sender_assertions);
@@ -1083,7 +1099,8 @@ fn reserve_transfer_dot_from_para_to_para_through_relay() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let sender_assets_after =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -617,10 +617,7 @@ fn reserve_transfer_dot_from_relay_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<Polkadot>(relay_to_para_sender_assertions);
@@ -630,10 +627,7 @@ fn reserve_transfer_dot_from_relay_to_para() {
 
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
-	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
@@ -688,10 +682,7 @@ fn reserve_transfer_dot_from_para_to_relay() {
 	let mut test = ParaToRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -701,10 +692,7 @@ fn reserve_transfer_dot_from_para_to_relay() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &sender)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &sender);
 	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
@@ -747,10 +735,7 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 
 	// Query initial balances
 	let sender_balance_before = test.sender.balance;
-	let receiver_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubPolkadot>(system_para_to_para_sender_assertions);
@@ -760,10 +745,7 @@ fn reserve_transfer_dot_from_asset_hub_to_para() {
 
 	// Query final balances
 	let sender_balance_after = test.sender.balance;
-	let receiver_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &receiver)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalB, system_para_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert!(sender_balance_after < sender_balance_before - amount_to_send);
@@ -820,10 +802,7 @@ fn reserve_transfer_dot_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 
 	// Set assertions and dispatchables
@@ -833,10 +812,7 @@ fn reserve_transfer_dot_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location, &sender)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalB, system_para_native_asset_location, &sender);
 	let receiver_balance_after = test.receiver.balance;
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
@@ -911,17 +887,8 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
-	});
-	let receiver_foreign_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_foreign_asset_location.clone(),
-			&receiver,
-		)
-	});
+	let receiver_system_native_assets_before = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_before = assets_balance_on!(PenpalB, system_para_foreign_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<AssetHubPolkadot>(system_para_to_para_assets_sender_assertions);
@@ -935,14 +902,8 @@ fn reserve_transfer_multiple_assets_from_asset_hub_to_para() {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
 		<Assets as Inspect<_>>::balance(RESERVABLE_ASSET_ID, &sender)
 	});
-	let receiver_system_native_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_native_asset_location.clone(), &receiver)
-	});
-	let receiver_foreign_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_para_foreign_asset_location, &receiver)
-	});
+	let receiver_system_native_assets_after = assets_balance_on!(PenpalB, system_para_native_asset_location.clone(), &receiver);
+	let receiver_foreign_assets_after = assets_balance_on!(PenpalB, system_para_foreign_asset_location, &receiver);
 	// Sender's balance is reduced
 	assert!(sender_balance_after < sender_balance_before);
 	// Receiver's foreign asset balance is increased
@@ -1038,14 +999,8 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	let mut test = ParaToSystemParaTest::new(para_test_args);
 
 	// Query initial balances
-	let sender_system_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal.clone(), &sender)
-	});
-	let sender_foreign_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal.clone(), &sender)
-	});
+	let sender_system_assets_before = assets_balance_on!(PenpalB, system_asset_location_on_penpal.clone(), &sender);
+	let sender_foreign_assets_before = assets_balance_on!(PenpalB, asset_location_on_penpal.clone(), &sender);
 	let receiver_balance_before = test.receiver.balance;
 	let receiver_assets_before = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
@@ -1059,14 +1014,8 @@ fn reserve_transfer_multiple_assets_from_para_to_asset_hub() {
 	test.assert();
 
 	// Query final balances
-	let sender_system_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(system_asset_location_on_penpal, &sender)
-	});
-	let sender_foreign_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(asset_location_on_penpal, &sender)
-	});
+	let sender_system_assets_after = assets_balance_on!(PenpalB, system_asset_location_on_penpal, &sender);
+	let sender_foreign_assets_after = assets_balance_on!(PenpalB, asset_location_on_penpal, &sender);
 	let receiver_balance_after = test.receiver.balance;
 	let receiver_assets_after = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::Assets;
@@ -1123,14 +1072,8 @@ fn reserve_transfer_dot_from_para_to_para_through_relay() {
 	let mut test = ParaToParaThroughRelayTest::new(test_args);
 
 	// Query initial balances
-	let sender_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &receiver)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &receiver);
 
 	// Set assertions and dispatchables
 	test.set_assertion::<PenpalB>(para_to_para_through_hop_sender_assertions);
@@ -1140,14 +1083,8 @@ fn reserve_transfer_dot_from_para_to_para_through_relay() {
 	test.assert();
 
 	// Query final balances
-	let sender_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &receiver)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &receiver);
 
 	// Sender's balance is reduced by amount sent (delivery fees are charged in native tokens).
 	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/swap.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/swap.rs
@@ -15,7 +15,6 @@
 
 use crate::*;
 use emulated_integration_tests_common::test_xcm_fee_querying_apis_work_for_asset_hub;
-use polkadot_system_emulated_network::penpal_emulated_chain::LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub;
 use system_parachains_constants::polkadot::currency::SYSTEM_PARA_EXISTENTIAL_DEPOSIT;
 
 #[test]
@@ -123,7 +122,7 @@ fn swap_locally_on_chain_using_local_assets() {
 fn swap_locally_on_chain_using_foreign_assets() {
 	let asset_native = Box::new(asset_hub_polkadot_runtime::xcm_config::DotLocation::get());
 	let asset_location_on_penpal: Location =
-		PenpalA::execute_with(PenpalLocalTeleportableToAssetHub::get);
+		PenpalA::execute_with(PenpalLocalPen2Asset::get);
 	let foreign_asset_at_asset_hub_polkadot =
 		Location::new(1, [Parachain(PenpalA::para_id().into())])
 			.appended_with(asset_location_on_penpal)

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/swap.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/swap.rs
@@ -121,8 +121,7 @@ fn swap_locally_on_chain_using_local_assets() {
 #[test]
 fn swap_locally_on_chain_using_foreign_assets() {
 	let asset_native = Box::new(asset_hub_polkadot_runtime::xcm_config::DotLocation::get());
-	let asset_location_on_penpal: Location =
-		PenpalA::execute_with(PenpalLocalPen2Asset::get);
+	let asset_location_on_penpal: Location = PenpalA::execute_with(PenpalLocalPen2Asset::get);
 	let foreign_asset_at_asset_hub_polkadot =
 		Location::new(1, [Parachain(PenpalA::para_id().into())])
 			.appended_with(asset_location_on_penpal)

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/teleport.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/teleport.rs
@@ -13,13 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::*;
+use crate::{assets_balance_on, *};
 use asset_hub_polkadot_runtime::xcm_config::XcmConfig as AssetHubPolkadotXcmConfig;
 use emulated_integration_tests_common::xcm_helpers::non_fee_asset;
-use polkadot_system_emulated_network::{
-	penpal_emulated_chain::LocalTeleportableToAssetHub as PenpalLocalTeleportableToAssetHub,
-	polkadot_emulated_chain::polkadot_runtime::Dmp,
-};
+use polkadot_system_emulated_network::polkadot_emulated_chain::polkadot_runtime::Dmp;
 
 fn penpal_to_ah_foreign_assets_sender_assertions(t: ParaToSystemParaTest) {
 	type RuntimeEvent = <PenpalB as Chain>::RuntimeEvent;
@@ -32,7 +29,7 @@ fn penpal_to_ah_foreign_assets_sender_assertions(t: ParaToSystemParaTest) {
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == system_para_native_asset_location,
@@ -101,7 +98,7 @@ fn ah_to_penpal_foreign_assets_receiver_assertions(t: SystemParaToParaTest) {
 				amount: *amount == expected_asset_amount,
 			},
 			// native asset for fee is deposited to receiver
-			RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+			RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 				asset_id: *asset_id == Location::parent(),
 				who: *who == t.receiver.account_id,
 			},
@@ -226,11 +223,7 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 ) {
 	// Init values for Parachain
 	let fee_amount_to_send: Balance = ASSET_HUB_POLKADOT_ED * 10000;
-	let asset_location_on_penpal = PenpalA::execute_with(PenpalLocalTeleportableToAssetHub::get);
-	let asset_id_on_penpal = match asset_location_on_penpal.last() {
-		Some(GeneralIndex(id)) => *id as u32,
-		_ => unreachable!(),
-	};
+	let asset_location_on_penpal = PenpalA::execute_with(PenpalLocalPen2Asset::get);
 	let asset_amount_to_send = ASSET_HUB_POLKADOT_ED * 1000;
 	let asset_owner = PenpalAssetOwner::get();
 	let system_para_native_asset_location = DotLocation::get();
@@ -256,9 +249,9 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 		fee_amount_to_send * 2,
 	);
 	// No need to create the asset (only mint) as it exists in genesis.
-	PenpalB::mint_asset(
+	PenpalB::mint_foreign_asset(
 		<PenpalB as Chain>::RuntimeOrigin::signed(asset_owner.clone()),
-		asset_id_on_penpal,
+		asset_location_on_penpal.clone(),
 		sender.clone(),
 		asset_amount_to_send,
 	);
@@ -274,10 +267,9 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 	)]);
 
 	// Init values for System Parachain
-	let asset_location_on_penpal_v4: Location = asset_location_on_penpal.clone();
 	let foreign_asset_at_asset_hub_polkadot =
 		Location::new(1, [Parachain(PenpalB::para_id().into())])
-			.appended_with(asset_location_on_penpal_v4)
+			.appended_with(asset_location_on_penpal.clone())
 			.unwrap();
 	let penpal_to_ah_beneficiary_id = AssetHubPolkadotReceiver::get();
 
@@ -290,25 +282,21 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			penpal_to_ah_beneficiary_id,
 			asset_amount_to_send,
 			penpal_assets,
-			Some(asset_id_on_penpal),
+			Some(asset_location_on_penpal.clone()),
 			fee_asset_index,
 		),
 	};
 	let mut penpal_to_ah = ParaToSystemParaTest::new(penpal_to_ah_test_args);
-	let penpal_sender_balance_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location.clone(),
-			&PenpalBSender::get(),
-		)
-	});
+	let penpal_sender_balance_before = assets_balance_on!(
+		PenpalB,
+		system_para_native_asset_location.clone(),
+		&PenpalBSender::get()
+	);
 
 	let ah_receiver_balance_before = penpal_to_ah.receiver.balance;
 
-	let penpal_sender_assets_before = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalBSender::get())
-	});
+	let penpal_sender_assets_before =
+		assets_balance_on!(PenpalB, asset_location_on_penpal.clone(), &PenpalBSender::get());
 	let ah_receiver_assets_before = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(
@@ -322,20 +310,16 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 	penpal_to_ah.set_dispatchable::<PenpalB>(para_to_ah_dispatchable);
 	penpal_to_ah.assert();
 
-	let penpal_sender_balance_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location.clone(),
-			&PenpalBSender::get(),
-		)
-	});
+	let penpal_sender_balance_after = assets_balance_on!(
+		PenpalB,
+		system_para_native_asset_location.clone(),
+		&PenpalBSender::get()
+	);
 
 	let ah_receiver_balance_after = penpal_to_ah.receiver.balance;
 
-	let penpal_sender_assets_after = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalBSender::get())
-	});
+	let penpal_sender_assets_after =
+		assets_balance_on!(PenpalB, asset_location_on_penpal.clone(), &PenpalBSender::get());
 	let ah_receiver_assets_after = AssetHubPolkadot::execute_with(|| {
 		type Assets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
 		<Assets as Inspect<_>>::balance(
@@ -397,20 +381,18 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			ah_to_penpal_beneficiary_id,
 			asset_amount_to_send,
 			ah_assets,
-			Some(asset_id_on_penpal),
+			Some(asset_location_on_penpal.clone()),
 			fee_asset_index,
 		),
 	};
 	let mut ah_to_penpal = SystemParaToParaTest::new(ah_to_penpal_test_args);
 
 	let ah_sender_balance_before = ah_to_penpal.sender.balance;
-	let penpal_receiver_balance_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location.clone(),
-			&PenpalBReceiver::get(),
-		)
-	});
+	let penpal_receiver_balance_before = assets_balance_on!(
+		PenpalB,
+		system_para_native_asset_location.clone(),
+		&PenpalBReceiver::get()
+	);
 
 	let ah_sender_assets_before = AssetHubPolkadot::execute_with(|| {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
@@ -419,10 +401,8 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			&AssetHubPolkadotSender::get(),
 		)
 	});
-	let penpal_receiver_assets_before = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalBReceiver::get())
-	});
+	let penpal_receiver_assets_before =
+		assets_balance_on!(PenpalB, asset_location_on_penpal.clone(), &PenpalBReceiver::get());
 
 	ah_to_penpal.set_assertion::<AssetHubPolkadot>(ah_to_penpal_foreign_assets_sender_assertions);
 	ah_to_penpal.set_assertion::<PenpalB>(ah_to_penpal_foreign_assets_receiver_assertions);
@@ -430,13 +410,8 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 	ah_to_penpal.assert();
 
 	let ah_sender_balance_after = ah_to_penpal.sender.balance;
-	let penpal_receiver_balance_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(
-			system_para_native_asset_location,
-			&PenpalBReceiver::get(),
-		)
-	});
+	let penpal_receiver_balance_after =
+		assets_balance_on!(PenpalB, system_para_native_asset_location, &PenpalBReceiver::get());
 
 	let ah_sender_assets_after = AssetHubPolkadot::execute_with(|| {
 		type ForeignAssets = <AssetHubPolkadot as AssetHubPolkadotPallet>::ForeignAssets;
@@ -445,10 +420,8 @@ pub fn do_bidirectional_teleport_foreign_assets_between_para_and_asset_hub_using
 			&AssetHubPolkadotSender::get(),
 		)
 	});
-	let penpal_receiver_assets_after = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(asset_id_on_penpal, &PenpalBReceiver::get())
-	});
+	let penpal_receiver_assets_after =
+		assets_balance_on!(PenpalB, asset_location_on_penpal.clone(), &PenpalBReceiver::get());
 
 	// Sender's balance is reduced
 	assert!(ah_sender_balance_after < ah_sender_balance_before);

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
@@ -125,9 +125,17 @@ fn transact_from_para_to_para_through_asset_hub() {
 		20_000_000_000
 	);
 	// We also need a pool between DOT and USDT on PenpalA.
-	create_foreign_pool_with_native_on!(PenpalA, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(
+		PenpalA,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
 	// We also need a pool between DOT and USDT on PenpalB.
-	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(
+		PenpalB,
+		PenpalUsdtFromAssetHub::get(),
+		PenpalAssetOwner::get()
+	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	PenpalA::execute_with(|| {
@@ -434,8 +442,7 @@ fn transact_using_authorized_alias_from_para_to_asset_hub_and_back_to_para() {
 
 	// Query final balances
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubPolkadot, USDT_ID, &sender);
-	let sender_usdt_on_penpal_after =
-		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+	let sender_usdt_on_penpal_after = assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	// Receiver's balance is increased by usdt amount we got from exchange
 	assert_eq!(
@@ -627,8 +634,7 @@ fn transact_using_sov_account_from_para_to_asset_hub_and_back_to_para() {
 	// Query final balances
 	let sender_usdt_on_ah_after =
 		assets_balance_on!(AssetHubPolkadot, USDT_ID, &sov_of_sender_on_asset_hub);
-	let sender_usdt_on_penpal_after =
-		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+	let sender_usdt_on_penpal_after = assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	// Receiver's balance is increased by usdt amount we got from exchange
 	assert_eq!(

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
@@ -125,13 +125,13 @@ fn transact_from_para_to_para_through_asset_hub() {
 		20_000_000_000
 	);
 	// We also need a pool between DOT and USDT on PenpalA.
-	create_pool_with_dot_on!(PenpalA, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalA, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
 	// We also need a pool between DOT and USDT on PenpalB.
-	create_pool_with_dot_on!(PenpalB, PenpalUsdtFromAssetHub::get(), true, PenpalAssetOwner::get());
+	create_foreign_pool_with_native_on!(PenpalB, PenpalUsdtFromAssetHub::get(), PenpalAssetOwner::get());
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
 	PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
 			usdt_from_asset_hub.clone(),
 			&sender,
@@ -151,9 +151,9 @@ fn transact_from_para_to_para_through_asset_hub() {
 	let receiver = PenpalBReceiver::get();
 
 	// Query initial balances
-	let sender_assets_before = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let sender_assets_before = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
 	let receiver_assets_before =
-		foreign_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
+		assets_balance_on!(PenpalB, usdt_from_asset_hub.clone(), &receiver);
 
 	// Now register a new asset on PenpalB from PenpalA/sender account while paying fees using USDT
 	// (going through Asset Hub)
@@ -195,8 +195,8 @@ fn transact_from_para_to_para_through_asset_hub() {
 	});
 
 	// Query final balances
-	let sender_assets_after = foreign_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
-	let receiver_assets_after = foreign_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
+	let sender_assets_after = assets_balance_on!(PenpalA, usdt_from_asset_hub.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalB, usdt_from_asset_hub, &receiver);
 
 	// Sender's balance is reduced by amount
 	assert_eq!(sender_assets_after, sender_assets_before - fee_amount_to_send);
@@ -232,7 +232,7 @@ fn penpal_b_assertions(
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Created { asset_id, creator, owner }
 			) => {
 				asset_id: *asset_id == expected_asset,
@@ -303,7 +303,7 @@ fn transact_using_authorized_alias_from_para_to_asset_hub_and_back_to_para() {
 
 	// Query initial balances
 	let sender_usdt_on_penpal_before =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 	let sender_usdt_on_ah_before = assets_balance_on!(AssetHubPolkadot, USDT_ID, &sender);
 
 	// Encoded `swap_tokens_for_exact_tokens` call to be executed in AH
@@ -435,7 +435,7 @@ fn transact_using_authorized_alias_from_para_to_asset_hub_and_back_to_para() {
 	// Query final balances
 	let sender_usdt_on_ah_after = assets_balance_on!(AssetHubPolkadot, USDT_ID, &sender);
 	let sender_usdt_on_penpal_after =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	// Receiver's balance is increased by usdt amount we got from exchange
 	assert_eq!(
@@ -497,7 +497,7 @@ fn transact_using_sov_account_from_para_to_asset_hub_and_back_to_para() {
 
 	// Query initial balances
 	let sender_usdt_on_penpal_before =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 	let sender_usdt_on_ah_before =
 		assets_balance_on!(AssetHubPolkadot, USDT_ID, &sov_of_sender_on_asset_hub);
 
@@ -628,7 +628,7 @@ fn transact_using_sov_account_from_para_to_asset_hub_and_back_to_para() {
 	let sender_usdt_on_ah_after =
 		assets_balance_on!(AssetHubPolkadot, USDT_ID, &sov_of_sender_on_asset_hub);
 	let sender_usdt_on_penpal_after =
-		foreign_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
+		assets_balance_on!(PenpalA, usdt_penpal_pov.clone(), &sender);
 
 	// Receiver's balance is increased by usdt amount we got from exchange
 	assert_eq!(

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{assets_balance_on, create_pool_with_dot_on, foreign_balance_on, *};
+use crate::{assets_balance_on, create_pool_with_dot_on, *};
 use asset_hub_polkadot_runtime::xcm_config::DotLocation;
 use frame_support::traits::tokens::fungibles::Mutate;
 use xcm::latest::AssetTransferFilter;

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/transact.rs
@@ -138,14 +138,12 @@ fn transact_from_para_to_para_through_asset_hub() {
 	);
 
 	let usdt_from_asset_hub = PenpalUsdtFromAssetHub::get();
-	PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		assert_ok!(<ForeignAssets as Mutate<_>>::mint_into(
-			usdt_from_asset_hub.clone(),
-			&sender,
-			fee_amount_to_send,
-		));
-	});
+	PenpalA::mint_foreign_asset(
+		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
+		usdt_from_asset_hub.clone(),
+		sender.clone(),
+		fee_amount_to_send,
+	);
 
 	// Give the sender enough Relay tokens to pay for local delivery fees.
 	PenpalA::mint_foreign_asset(

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
@@ -30,7 +30,7 @@ use frame_support::{
 	assert_ok,
 	dispatch::RawOrigin,
 	sp_runtime::{traits::Dispatchable, DispatchResult},
-	traits::{fungible, fungibles::Inspect},
+	traits::fungible,
 	BoundedVec,
 };
 use xcm::{latest::AssetTransferFilter, prelude::*};
@@ -177,6 +177,7 @@ fn multi_hop_works() {
 	// Note: We need to do this after resetting the externalities to get an accurate value here.
 	// This is because the dry-run on Asset Hub does affect the liquidity pool distribution on
 	// PenpalA which affects the assets amount we have to pay.
+	// See side-effects: https://github.com/paritytech/polkadot-sdk/issues/11486.
 	let mut final_execution_fees = 0;
 	<PenpalA as TestExt>::execute_with(|| {
 		type Runtime = <PenpalA as Chain>::Runtime;

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
@@ -16,11 +16,11 @@
 //! Tests for XCM fee estimation in the runtime.
 
 use crate::{
-	assert_expected_events, bx, create_pool_with_dot_on, AssetHubPolkadot,
-	AssetHubPolkadotAssetOwner, AssetHubPolkadotPallet, AssetHubPolkadotSender, Chain,
-	ParaToParaThroughAHTest, PenpalA, PenpalAPallet, PenpalAReceiver, PenpalAssetOwner, PenpalB,
-	PenpalBPallet, PenpalBSender, PenpalUsdtFromAssetHub, TestArgs, TestContext, TransferType,
-	ASSETS_PALLET_ID,
+	assert_expected_events, bx, create_foreign_pool_with_native_on, create_pool_with_dot_on,
+	AssetHubPolkadot, AssetHubPolkadotAssetOwner, AssetHubPolkadotPallet, AssetHubPolkadotSender,
+	Chain, ParaToParaThroughAHTest, PenpalA, PenpalAPallet, PenpalAReceiver, PenpalAssetOwner,
+	PenpalB, PenpalBPallet, PenpalBSender, PenpalUsdtFromAssetHub, TestArgs, TestContext,
+	TransferType, ASSETS_PALLET_ID,
 };
 use emulated_integration_tests_common::{
 	impls::{Parachain, TestExt},
@@ -30,7 +30,7 @@ use frame_support::{
 	assert_ok,
 	dispatch::RawOrigin,
 	sp_runtime::{traits::Dispatchable, DispatchResult},
-	traits::fungibles::Inspect,
+	traits::{fungible, fungibles::Inspect},
 	BoundedVec,
 };
 use xcm::{latest::AssetTransferFilter, prelude::*};
@@ -102,7 +102,7 @@ fn multi_hop_works() {
 			.unwrap();
 		assert_eq!(messages_to_query.len(), 1);
 		remote_message = messages_to_query[0].clone();
-		let asset_id_for_delivery_fees = VersionedAssetId::from(Location::parent());
+		let asset_id_for_delivery_fees = VersionedAssetId::from(Location::here());
 		let delivery_fees = Runtime::query_delivery_fees(
 			destination_to_query.clone(),
 			remote_message.clone(),
@@ -159,19 +159,6 @@ fn multi_hop_works() {
 		intermediate_delivery_fees_amount = get_amount_from_versioned_assets(delivery_fees);
 	});
 
-	// Get the final execution fees in the destination.
-	let mut final_execution_fees = 0;
-	<PenpalA as TestExt>::execute_with(|| {
-		type Runtime = <PenpalA as Chain>::Runtime;
-
-		let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
-		final_execution_fees = Runtime::query_weight_to_asset_fee(
-			weight,
-			VersionedAssetId::from(AssetId(Location::parent())),
-		)
-		.unwrap();
-	});
-
 	// Dry-running is done.
 	PenpalB::reset_ext();
 	AssetHubPolkadot::reset_ext();
@@ -184,16 +171,40 @@ fn multi_hop_works() {
 		sender.clone(),
 		amount_to_send * 2,
 	);
+
+	// Get the final execution fees at the destination.
+	//
+	// Note: We need to do this after resetting the externalities to get an accurate value here.
+	// This is because the dry-run on Asset Hub does affect the liquidity pool distribution on
+	// PenpalA which affects the assets amount we have to pay.
+	let mut final_execution_fees = 0;
+	<PenpalA as TestExt>::execute_with(|| {
+		type Runtime = <PenpalA as Chain>::Runtime;
+
+		let weight = Runtime::query_xcm_weight(intermediate_remote_message.clone()).unwrap();
+		final_execution_fees =
+			Runtime::query_weight_to_asset_fee(weight, VersionedAssetId::from(Location::parent()))
+				.unwrap();
+	});
+
 	AssetHubPolkadot::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic.
 	let sender_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+		type Assets = <PenpalB as PenpalBPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+	});
+	let sender_balance_before = PenpalB::execute_with(|| {
+		type Balances = <PenpalB as PenpalBPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
 	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
+	});
+	let receiver_balance_before = PenpalA::execute_with(|| {
+		type Balances = <PenpalA as PenpalAPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
 	});
 
 	test.set_assertion::<PenpalB>(sender_assertions);
@@ -203,21 +214,32 @@ fn multi_hop_works() {
 	test.assert();
 
 	let sender_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+		type Assets = <PenpalB as PenpalBPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
+	});
+	let sender_balance_after = PenpalB::execute_with(|| {
+		type Balances = <PenpalB as PenpalBPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
 	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
+		<Assets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
+	});
+	let receiver_balance_after = PenpalA::execute_with(|| {
+		type Balances = <PenpalA as PenpalAPallet>::Balances;
+		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
 	});
 
 	// We know the exact fees on every hop.
+	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);
 	assert_eq!(
-		sender_assets_after,
-		sender_assets_before - amount_to_send - delivery_fees_amount /* This is charged directly
-		                                                              * from the sender's
-		                                                              * account. */
+		sender_balance_after,
+		// This is charged directly from the sender's account.
+		sender_balance_before - delivery_fees_amount
 	);
+
+	// Receiver native balance is unchanged; received funds in relay asset, and paid in relay asset.
+	assert_eq!(receiver_balance_after, receiver_balance_before);
 	assert_eq!(
 		receiver_assets_after,
 		receiver_assets_before + amount_to_send -
@@ -234,7 +256,7 @@ fn sender_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, amount }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -255,7 +277,9 @@ fn hop_assertions(test: ParaToParaThroughAHTest) {
 			RuntimeEvent::Balances(
 				pallet_balances::Event::Withdraw { amount, .. }
 			) => {
-				amount: *amount == test.args.amount,
+				// Depends on: XCM execution fees + delivery fees + liquidity pool
+				// swap overhead at the destination.
+				amount: *amount >= test.args.amount * 80/100,
 			},
 		]
 	);
@@ -268,7 +292,7 @@ fn receiver_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalA,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Deposited { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -316,7 +340,7 @@ fn pay_fees_sender_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalB,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Withdrawn { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -347,7 +371,7 @@ fn pay_fees_receiver_assertions(test: ParaToParaThroughAHTest) {
 	assert_expected_events!(
 		PenpalA,
 		vec![
-			RuntimeEvent::ForeignAssets(
+			RuntimeEvent::Assets(
 				pallet_assets::Event::Deposited { asset_id, who, .. }
 			) => {
 				asset_id: *asset_id == Location::parent(),
@@ -534,11 +558,11 @@ fn multi_hop_pay_fees_works() {
 
 	// Actually run the extrinsic with exact fees.
 	let sender_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
 	});
 
@@ -554,11 +578,11 @@ fn multi_hop_pay_fees_works() {
 	test.assert();
 
 	let sender_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
 	});
 	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
 	});
 
@@ -655,12 +679,11 @@ fn usdt_fee_estimation_in_usdt_works() {
 		1_000_000_000_000, // 100 DOT
 		200_000_000        // 200 USDT
 	);
-	create_pool_with_dot_on!(
+	create_foreign_pool_with_native_on!(
 		PenpalB,
 		usdt_location_on_penpal.clone(),
-		true,
 		PenpalAssetOwner::get(),
-		1_000_000_000_000, // 100 DOT
+		1_000_000_000_000, // 100 PEN
 		200_000_000        // 200 USDT
 	);
 	let beneficiary_id = PenpalAReceiver::get();

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
@@ -190,12 +190,14 @@ fn multi_hop_works() {
 	AssetHubPolkadot::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic.
-	let sender_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let sender_assets_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sender_balance_before = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &beneficiary_id);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &beneficiary_id);
 	let receiver_balance_before = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -207,12 +209,14 @@ fn multi_hop_works() {
 	test.set_dispatchable::<PenpalB>(transfer_assets_para_to_para_through_ah_dispatchable);
 	test.assert();
 
-	let sender_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let sender_assets_after =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sender_balance_after = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &beneficiary_id);
+	let receiver_assets_after =
+		assets_balance_on!(PenpalA, relay_native_asset_location, &beneficiary_id);
 	let receiver_balance_after = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -545,8 +549,10 @@ fn multi_hop_pay_fees_works() {
 	AssetHubPolkadot::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic with exact fees.
-	let sender_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
-	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &beneficiary_id);
+	let sender_assets_before =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before =
+		assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &beneficiary_id);
 
 	test.set_assertion::<PenpalB>(pay_fees_sender_assertions);
 	test.set_assertion::<AssetHubPolkadot>(pay_fees_hop_assertions);
@@ -559,8 +565,10 @@ fn multi_hop_pay_fees_works() {
 	test.set_call(call);
 	test.assert();
 
-	let sender_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
-	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &beneficiary_id);
+	let sender_assets_after =
+		assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_after =
+		assets_balance_on!(PenpalA, relay_native_asset_location, &beneficiary_id);
 
 	// We know the exact fees on every hop.
 	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/xcm_fee_estimation.rs
@@ -16,11 +16,11 @@
 //! Tests for XCM fee estimation in the runtime.
 
 use crate::{
-	assert_expected_events, bx, create_foreign_pool_with_native_on, create_pool_with_dot_on,
-	AssetHubPolkadot, AssetHubPolkadotAssetOwner, AssetHubPolkadotPallet, AssetHubPolkadotSender,
-	Chain, ParaToParaThroughAHTest, PenpalA, PenpalAPallet, PenpalAReceiver, PenpalAssetOwner,
-	PenpalB, PenpalBPallet, PenpalBSender, PenpalUsdtFromAssetHub, TestArgs, TestContext,
-	TransferType, ASSETS_PALLET_ID,
+	assert_expected_events, assets_balance_on, bx, create_foreign_pool_with_native_on,
+	create_pool_with_dot_on, AssetHubPolkadot, AssetHubPolkadotAssetOwner, AssetHubPolkadotPallet,
+	AssetHubPolkadotSender, Chain, ParaToParaThroughAHTest, PenpalA, PenpalAPallet,
+	PenpalAReceiver, PenpalAssetOwner, PenpalB, PenpalBPallet, PenpalBSender,
+	PenpalUsdtFromAssetHub, TestArgs, TestContext, TransferType, ASSETS_PALLET_ID,
 };
 use emulated_integration_tests_common::{
 	impls::{Parachain, TestExt},
@@ -190,18 +190,12 @@ fn multi_hop_works() {
 	AssetHubPolkadot::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic.
-	let sender_assets_before = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sender_balance_before = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
-	});
+	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &beneficiary_id);
 	let receiver_balance_before = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -213,18 +207,12 @@ fn multi_hop_works() {
 	test.set_dispatchable::<PenpalB>(transfer_assets_para_to_para_through_ah_dispatchable);
 	test.assert();
 
-	let sender_assets_after = PenpalB::execute_with(|| {
-		type Assets = <PenpalB as PenpalBPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
 	let sender_balance_after = PenpalB::execute_with(|| {
 		type Balances = <PenpalB as PenpalBPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&sender)
 	});
-	let receiver_assets_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
-	});
+	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &beneficiary_id);
 	let receiver_balance_after = PenpalA::execute_with(|| {
 		type Balances = <PenpalA as PenpalAPallet>::Balances;
 		<Balances as fungible::Inspect<_>>::balance(&beneficiary_id)
@@ -557,14 +545,8 @@ fn multi_hop_pay_fees_works() {
 	AssetHubPolkadot::fund_accounts(vec![(sov_of_sender_on_ah, amount_to_send * 2)]);
 
 	// Actually run the extrinsic with exact fees.
-	let sender_assets_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &beneficiary_id)
-	});
+	let sender_assets_before = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_before = assets_balance_on!(PenpalA, relay_native_asset_location.clone(), &beneficiary_id);
 
 	test.set_assertion::<PenpalB>(pay_fees_sender_assertions);
 	test.set_assertion::<AssetHubPolkadot>(pay_fees_hop_assertions);
@@ -577,14 +559,8 @@ fn multi_hop_pay_fees_works() {
 	test.set_call(call);
 	test.assert();
 
-	let sender_assets_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location.clone(), &sender)
-	});
-	let receiver_assets_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(relay_native_asset_location, &beneficiary_id)
-	});
+	let sender_assets_after = assets_balance_on!(PenpalB, relay_native_asset_location.clone(), &sender);
+	let receiver_assets_after = assets_balance_on!(PenpalA, relay_native_asset_location, &beneficiary_id);
 
 	// We know the exact fees on every hop.
 	assert_eq!(sender_assets_after, sender_assets_before - amount_to_send);

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/lib.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/lib.rs
@@ -44,6 +44,7 @@ pub use emulated_integration_tests_common::{
 	xcm_helpers::{xcm_transact_paid_execution, xcm_transact_unpaid_execution},
 	ASSETS_PALLET_ID, PROOF_SIZE_THRESHOLD, REF_TIME_THRESHOLD, XCM_V4,
 };
+pub use integration_tests_helpers::assets_balance_on;
 pub use kusama_polkadot_system_emulated_network::{
 	asset_hub_kusama_emulated_chain::{
 		genesis::ED as ASSET_HUB_KUSAMA_ED, AssetHubKusamaParaPallet as AssetHubKusamaPallet,

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
@@ -476,7 +476,8 @@ fn send_ksm_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkadot() 
 	);
 	let ksm_in_reserve_on_kah_before =
 		<AssetHubKusama as Chain>::account_data_of(sov_pah_on_kah.clone()).free;
-	let sender_ksm_before = assets_balance_on!(PenpalA, ksm_at_kusama_parachains_latest.clone(), &sender);
+	let sender_ksm_before =
+		assets_balance_on!(PenpalA, ksm_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_ksm_before =
 		foreign_balance_on_ah_polkadot(ksm_at_asset_hub_polkadot.clone(), &receiver);
 
@@ -592,7 +593,8 @@ fn send_back_dot_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkad
 	AssetHubPolkadot::fund_accounts(vec![(sov_kah_on_pah.clone(), amount * 2)]);
 
 	// balances before
-	let sender_dot_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
+	let sender_dot_before =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_dot_before = <AssetHubPolkadot as Chain>::account_data_of(receiver.clone()).free;
 
 	// send DOTs over the bridge, KSMs only used to pay fees on local AH, pay with DOT on remote AH

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tests::*;
+use crate::{assets_balance_on, tests::*};
 
 fn send_assets_over_bridge<F: FnOnce()>(send_fn: F) {
 	// fund the KAH's SA on BHR for paying bridge transport fees
@@ -476,10 +476,7 @@ fn send_ksm_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkadot() 
 	);
 	let ksm_in_reserve_on_kah_before =
 		<AssetHubKusama as Chain>::account_data_of(sov_pah_on_kah.clone()).free;
-	let sender_ksm_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_kusama_parachains_latest.clone(), &sender)
-	});
+	let sender_ksm_before = assets_balance_on!(PenpalA, ksm_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_ksm_before =
 		foreign_balance_on_ah_polkadot(ksm_at_asset_hub_polkadot.clone(), &receiver);
 
@@ -536,10 +533,7 @@ fn send_ksm_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkadot() 
 		);
 	});
 
-	let sender_ksm_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_kusama_parachains_latest, &sender)
-	});
+	let sender_ksm_after = assets_balance_on!(PenpalA, ksm_at_kusama_parachains_latest, &sender);
 	let receiver_ksm_after = foreign_balance_on_ah_polkadot(ksm_at_asset_hub_polkadot, &receiver);
 	let ksm_in_reserve_on_kah_after =
 		<AssetHubKusama as Chain>::account_data_of(sov_pah_on_kah.clone()).free;
@@ -598,10 +592,7 @@ fn send_back_dot_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkad
 	AssetHubPolkadot::fund_accounts(vec![(sov_kah_on_pah.clone(), amount * 2)]);
 
 	// balances before
-	let sender_dot_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
-	});
+	let sender_dot_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest.clone(), &sender);
 	let receiver_dot_before = <AssetHubPolkadot as Chain>::account_data_of(receiver.clone()).free;
 
 	// send DOTs over the bridge, KSMs only used to pay fees on local AH, pay with DOT on remote AH
@@ -678,10 +669,7 @@ fn send_back_dot_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkad
 		);
 	});
 
-	let sender_dot_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest, &sender)
-	});
+	let sender_dot_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains_latest, &sender);
 	let receiver_dot_after = <AssetHubPolkadot as Chain>::account_data_of(receiver).free;
 
 	// Sender's balance is reduced by sent "amount"

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/asset_transfers.rs
@@ -477,7 +477,7 @@ fn send_ksm_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkadot() 
 	let ksm_in_reserve_on_kah_before =
 		<AssetHubKusama as Chain>::account_data_of(sov_pah_on_kah.clone()).free;
 	let sender_ksm_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_kusama_parachains_latest.clone(), &sender)
 	});
 	let receiver_ksm_before =
@@ -537,7 +537,7 @@ fn send_ksm_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkadot() 
 	});
 
 	let sender_ksm_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_kusama_parachains_latest, &sender)
 	});
 	let receiver_ksm_after = foreign_balance_on_ah_polkadot(ksm_at_asset_hub_polkadot, &receiver);
@@ -599,7 +599,7 @@ fn send_back_dot_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkad
 
 	// balances before
 	let sender_dot_before = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest.clone(), &sender)
 	});
 	let receiver_dot_before = <AssetHubPolkadot as Chain>::account_data_of(receiver.clone()).free;
@@ -679,7 +679,7 @@ fn send_back_dot_from_penpal_kusama_through_asset_hub_kusama_to_asset_hub_polkad
 	});
 
 	let sender_dot_after = PenpalA::execute_with(|| {
-		type ForeignAssets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalA as PenpalAPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_kusama_parachains_latest, &sender)
 	});
 	let receiver_dot_after = <AssetHubPolkadot as Chain>::account_data_of(receiver).free;

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
@@ -27,6 +27,18 @@ mod snowbridge {
 	pub const WETH: [u8; 20] = hex_literal::hex!("87d1f7fdfEe7f651FaBc8bFCB6E086C278b77A7d");
 }
 
+#[macro_export]
+macro_rules! assets_balance_on {
+	( $chain:ident, $id:expr, $who:expr ) => {
+		emulated_integration_tests_common::impls::paste::paste! {
+			<$chain>::execute_with(|| {
+				type Assets = <$chain as [<$chain Pallet>]>::Assets;
+				<Assets as Inspect<_>>::balance($id, $who)
+			})
+		}
+	};
+}
+
 pub(crate) fn asset_hub_polkadot_location() -> Location {
 	Location::new(2, [GlobalConsensus(Polkadot), Parachain(AssetHubPolkadot::para_id().into())])
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
@@ -27,18 +27,6 @@ mod snowbridge {
 	pub const WETH: [u8; 20] = hex_literal::hex!("87d1f7fdfEe7f651FaBc8bFCB6E086C278b77A7d");
 }
 
-#[macro_export]
-macro_rules! assets_balance_on {
-	( $chain:ident, $id:expr, $who:expr ) => {
-		emulated_integration_tests_common::impls::paste::paste! {
-			<$chain>::execute_with(|| {
-				type Assets = <$chain as [<$chain Pallet>]>::Assets;
-				<Assets as Inspect<_>>::balance($id, $who)
-			})
-		}
-	};
-}
-
 pub(crate) fn asset_hub_polkadot_location() -> Location {
 	Location::new(2, [GlobalConsensus(Polkadot), Parachain(AssetHubPolkadot::para_id().into())])
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/lib.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/lib.rs
@@ -35,6 +35,7 @@ pub use bp_messages::LegacyLaneId;
 // Cumulus
 pub use emulated_integration_tests_common::{
 	accounts::{ALICE, BOB},
+	create_foreign_pool_with_native_on, create_foreign_pool_with_parent_native_on,
 	impls::Inspect,
 	test_parachain_is_trusted_teleporter, test_parachain_is_trusted_teleporter_for_relay,
 	test_relay_is_trusted_teleporter,

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/lib.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/lib.rs
@@ -46,7 +46,10 @@ pub use emulated_integration_tests_common::{
 	xcm_helpers::{xcm_transact_paid_execution, xcm_transact_unpaid_execution},
 	ASSETS_PALLET_ID, PROOF_SIZE_THRESHOLD, REF_TIME_THRESHOLD, XCM_V4,
 };
-pub use integration_tests_helpers::common::snowbridge::{MIN_ETHER_BALANCE, WETH};
+pub use integration_tests_helpers::{
+	assets_balance_on,
+	common::snowbridge::{MIN_ETHER_BALANCE, WETH},
+};
 pub use kusama_polkadot_system_emulated_network::{
 	asset_hub_kusama_emulated_chain::{
 		genesis::ED as ASSET_HUB_KUSAMA_ED, AssetHubKusamaParaPallet as AssetHubKusamaPallet,

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/aliases.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/aliases.rs
@@ -32,7 +32,9 @@ fn account_on_sibling_chain_cannot_alias_into_same_local_account() {
 	// origin and target are the same account on different chains
 	let origin: AccountId = [1; 32].into();
 	let target = origin.clone();
-	let fees = POLKADOT_ED * 10;
+	// Depends on: XCM execution fees + liquidity pool swap overhead at the
+	// destination (asset conversion cost from relay token to native).
+	let fees = POLKADOT_ED * 20;
 
 	PenpalB::mint_foreign_asset(
 		<PenpalB as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
@@ -63,7 +65,9 @@ fn account_on_sibling_chain_cannot_alias_into_different_local_account() {
 	// origin and target are different accounts on different chains
 	let origin: AccountId = [1; 32].into();
 	let target: AccountId = [2; 32].into();
-	let fees = POLKADOT_ED * 10;
+	// Depends on: XCM execution fees + liquidity pool swap overhead at the
+	// destination (asset conversion cost from relay token to native).
+	let fees = POLKADOT_ED * 20;
 
 	PenpalB::mint_foreign_asset(
 		<PenpalB as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
@@ -92,7 +96,9 @@ fn authorized_cross_chain_aliases() {
 	let origin: AccountId = [100; 32].into();
 	let bad_origin: AccountId = [150; 32].into();
 	let target: AccountId = [200; 32].into();
-	let fees = POLKADOT_ED * 10;
+	// Depends on: XCM execution fees + liquidity pool swap overhead at the
+	// destination (asset conversion cost from relay token to native).
+	let fees = POLKADOT_ED * 20;
 
 	let pal_admin = <PenpalB as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get());
 	PenpalB::mint_foreign_asset(pal_admin.clone(), Location::parent(), origin.clone(), fees * 10);

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
@@ -475,7 +475,8 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama(
 	);
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
-	let sender_dot_before = assets_balance_on!(PenpalB, dot_at_polkadot_parachains.clone(), &sender);
+	let sender_dot_before =
+		assets_balance_on!(PenpalB, dot_at_polkadot_parachains.clone(), &sender);
 	let receiver_dot_before =
 		foreign_balance_on_ah_kusama(dot_at_asset_hub_kusama.clone(), &receiver);
 
@@ -582,8 +583,10 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama_
 	);
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
-	let sender_dot_before = assets_balance_on!(PenpalB, dot_at_polkadot_parachains.clone(), &sender);
-	let receiver_dot_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
+	let sender_dot_before =
+		assets_balance_on!(PenpalB, dot_at_polkadot_parachains.clone(), &sender);
+	let receiver_dot_before =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
 
 	// Send dot over bridge
 	{
@@ -722,7 +725,8 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama_t
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
 	let sender_dot_before = <Polkadot as Chain>::account_data_of(sender.clone()).free;
-	let receiver_dot_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
+	let receiver_dot_before =
+		assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
 
 	// Send dot from Polkadot to PAH over bridge to KAH then onto Penpal parachain
 	{
@@ -880,7 +884,8 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	AssetHubKusama::fund_accounts(vec![(sov_pah_on_kah.clone(), amount * 2)]);
 
 	// balances before
-	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
+	let sender_ksm_before =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let receiver_ksm_before = <AssetHubKusama as Chain>::account_data_of(receiver.clone()).free;
 
 	// send KSMs over the bridge, DOTs only used to pay fees on local AH, pay with KSM on remote AH
@@ -1026,8 +1031,10 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	AssetHubKusama::fund_accounts(vec![(sov_pah_on_kah.clone(), amount * 2)]);
 
 	// balances before
-	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains.clone(), &sender);
-	let receiver_ksm_before = assets_balance_on!(PenpalA, ksm_at_kusama_parachains.clone(), &receiver);
+	let sender_ksm_before =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains.clone(), &sender);
+	let receiver_ksm_before =
+		assets_balance_on!(PenpalA, ksm_at_kusama_parachains.clone(), &receiver);
 
 	// send KSMs over the bridge, all fees paid with KSM along the way
 	{
@@ -1136,7 +1143,8 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	});
 
 	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains, &sender);
-	let receiver_ksm_after = assets_balance_on!(PenpalA, ksm_at_kusama_parachains.clone(), &receiver);
+	let receiver_ksm_after =
+		assets_balance_on!(PenpalA, ksm_at_kusama_parachains.clone(), &receiver);
 
 	// Sender's balance is reduced by sent "amount"
 	assert_eq!(sender_ksm_after, sender_ksm_before - amount);
@@ -1208,7 +1216,8 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	Kusama::fund_accounts(vec![(<Kusama as KusamaPallet>::XcmPallet::check_account(), amount)]);
 
 	// balances before
-	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains.clone(), &sender);
+	let sender_ksm_before =
+		assets_balance_on!(PenpalB, ksm_at_polkadot_parachains.clone(), &sender);
 	let receiver_ksm_before = <Kusama as Chain>::account_data_of(receiver.clone()).free;
 
 	// send KSMs over the bridge, all fees paid with KSM along the way

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::tests::*;
+use crate::{assets_balance_on, tests::*};
 use bp_bridge_hub_polkadot::snowbridge::EthereumNetwork;
 use snowbridge_inbound_queue_primitives::EthereumLocationsConverterFor;
 use xcm_executor::traits::ConvertLocation;
@@ -475,10 +475,7 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama(
 	);
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
-	let sender_dot_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains.clone(), &sender)
-	});
+	let sender_dot_before = assets_balance_on!(PenpalB, dot_at_polkadot_parachains.clone(), &sender);
 	let receiver_dot_before =
 		foreign_balance_on_ah_kusama(dot_at_asset_hub_kusama.clone(), &receiver);
 
@@ -531,10 +528,7 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama(
 		);
 	});
 
-	let sender_dot_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains, &sender)
-	});
+	let sender_dot_after = assets_balance_on!(PenpalB, dot_at_polkadot_parachains, &sender);
 	let receiver_dot_after = foreign_balance_on_ah_kusama(dot_at_asset_hub_kusama, &receiver);
 	let dot_in_reserve_on_pah_after =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
@@ -588,14 +582,8 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama_
 	);
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
-	let sender_dot_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains.clone(), &sender)
-	});
-	let receiver_dot_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &receiver)
-	});
+	let sender_dot_before = assets_balance_on!(PenpalB, dot_at_polkadot_parachains.clone(), &sender);
+	let receiver_dot_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
 
 	// Send dot over bridge
 	{
@@ -657,14 +645,8 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama_
 		PenpalA::assert_xcmp_queue_success(None);
 	});
 
-	let sender_dot_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains, &sender)
-	});
-	let receiver_dot_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
-	});
+	let sender_dot_after = assets_balance_on!(PenpalB, dot_at_polkadot_parachains, &sender);
+	let receiver_dot_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains, &receiver);
 	let dot_in_reserve_on_pah_after =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
 
@@ -740,10 +722,7 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama_t
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
 	let sender_dot_before = <Polkadot as Chain>::account_data_of(sender.clone()).free;
-	let receiver_dot_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &receiver)
-	});
+	let receiver_dot_before = assets_balance_on!(PenpalA, dot_at_kusama_parachains.clone(), &receiver);
 
 	// Send dot from Polkadot to PAH over bridge to KAH then onto Penpal parachain
 	{
@@ -838,10 +817,7 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama_t
 	});
 
 	let sender_dot_after = <Polkadot as Chain>::account_data_of(sender.clone()).free;
-	let receiver_dot_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
-	});
+	let receiver_dot_after = assets_balance_on!(PenpalA, dot_at_kusama_parachains, &receiver);
 	let dot_in_reserve_on_pah_after =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
 
@@ -904,10 +880,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	AssetHubKusama::fund_accounts(vec![(sov_pah_on_kah.clone(), amount * 2)]);
 
 	// balances before
-	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
-	});
+	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest.clone(), &sender);
 	let receiver_ksm_before = <AssetHubKusama as Chain>::account_data_of(receiver.clone()).free;
 
 	// send KSMs over the bridge, DOTs only used to pay fees on local AH, pay with KSM on remote AH
@@ -983,10 +956,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 		);
 	});
 
-	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &sender)
-	});
+	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains_latest, &sender);
 	let receiver_ksm_after = <AssetHubKusama as Chain>::account_data_of(receiver).free;
 
 	// Sender's balance is reduced by sent "amount"
@@ -1056,14 +1026,8 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	AssetHubKusama::fund_accounts(vec![(sov_pah_on_kah.clone(), amount * 2)]);
 
 	// balances before
-	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
-	});
-	let receiver_ksm_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(ksm_at_kusama_parachains.clone(), &receiver)
-	});
+	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains.clone(), &sender);
+	let receiver_ksm_before = assets_balance_on!(PenpalA, ksm_at_kusama_parachains.clone(), &receiver);
 
 	// send KSMs over the bridge, all fees paid with KSM along the way
 	{
@@ -1171,14 +1135,8 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 		PenpalA::assert_xcmp_queue_success(None);
 	});
 
-	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains, &sender)
-	});
-	let receiver_ksm_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::Assets;
-		<Assets as Inspect<_>>::balance(ksm_at_kusama_parachains.clone(), &receiver)
-	});
+	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains, &sender);
+	let receiver_ksm_after = assets_balance_on!(PenpalA, ksm_at_kusama_parachains.clone(), &receiver);
 
 	// Sender's balance is reduced by sent "amount"
 	assert_eq!(sender_ksm_after, sender_ksm_before - amount);
@@ -1250,10 +1208,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	Kusama::fund_accounts(vec![(<Kusama as KusamaPallet>::XcmPallet::check_account(), amount)]);
 
 	// balances before
-	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
-	});
+	let sender_ksm_before = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains.clone(), &sender);
 	let receiver_ksm_before = <Kusama as Chain>::account_data_of(receiver.clone()).free;
 
 	// send KSMs over the bridge, all fees paid with KSM along the way
@@ -1359,10 +1314,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 		);
 	});
 
-	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
-		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains, &sender)
-	});
+	let sender_ksm_after = assets_balance_on!(PenpalB, ksm_at_polkadot_parachains, &sender);
 	let receiver_ksm_after = <Kusama as Chain>::account_data_of(receiver.clone()).free;
 
 	// Sender's balance is reduced by sent "amount"

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/asset_transfers.rs
@@ -44,10 +44,9 @@ fn set_up_dot_for_penpal_polkadot_through_pah_to_kah(
 	let dot_at_asset_hub_kusama = bridged_dot_at_ah_kusama();
 	let reserves = vec![(asset_hub_polkadot_global_location(), false).into()];
 	create_foreign_on_ah_kusama(dot_at_asset_hub_kusama.clone(), true, reserves);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubKusama,
 		dot_at_asset_hub_kusama.clone(),
-		true,
 		AssetHubKusamaSender::get()
 	);
 
@@ -102,10 +101,9 @@ fn send_dot_usdt_and_weth_from_asset_hub_polkadot_to_asset_hub_kusama() {
 
 	let reserves = vec![(asset_hub_polkadot_global_location(), false).into()];
 	create_foreign_on_ah_kusama(bridged_dot_at_asset_hub_kusama.clone(), true, reserves);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubKusama,
 		bridged_dot_at_asset_hub_kusama.clone(),
-		true,
 		AssetHubKusamaSender::get()
 	);
 
@@ -202,10 +200,9 @@ fn send_dot_usdt_and_weth_from_asset_hub_polkadot_to_asset_hub_kusama() {
 	);
 	let reserves = vec![(asset_hub_polkadot_global_location(), false).into()];
 	create_foreign_on_ah_kusama(bridged_usdt_at_asset_hub_kusama.clone(), true, reserves);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubKusama,
 		bridged_usdt_at_asset_hub_kusama.clone(),
-		true,
 		AssetHubKusamaSender::get()
 	);
 
@@ -359,10 +356,9 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama()
 
 	let reserves = vec![(asset_hub_polkadot_global_location(), false).into()];
 	create_foreign_on_ah_kusama(bridged_dot_at_ah_kusama.clone(), true, reserves);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubKusama,
 		bridged_dot_at_ah_kusama.clone(),
-		true,
 		AssetHubKusamaSender::get()
 	);
 
@@ -480,7 +476,7 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama(
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
 	let sender_dot_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains.clone(), &sender)
 	});
 	let receiver_dot_before =
@@ -536,7 +532,7 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama(
 	});
 
 	let sender_dot_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains, &sender)
 	});
 	let receiver_dot_after = foreign_balance_on_ah_kusama(dot_at_asset_hub_kusama, &receiver);
@@ -580,7 +576,11 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama_
 			)],
 		));
 	});
-	create_pool_with_native_on!(PenpalA, dot_at_kusama_parachains.clone(), true, asset_owner);
+	create_foreign_pool_with_native_on!(
+		PenpalA,
+		dot_at_kusama_parachains.clone(),
+		asset_owner.clone()
+	);
 
 	let sov_kah_on_pah = AssetHubPolkadot::sovereign_account_of_parachain_on_other_global_consensus(
 		Kusama,
@@ -589,11 +589,11 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama_
 	let dot_in_reserve_on_pah_before =
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
 	let sender_dot_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains.clone(), &sender)
 	});
 	let receiver_dot_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &receiver)
 	});
 
@@ -658,11 +658,11 @@ fn send_dot_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_kusama_
 	});
 
 	let sender_dot_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(dot_at_polkadot_parachains, &sender)
 	});
 	let receiver_dot_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
 	});
 	let dot_in_reserve_on_pah_after =
@@ -689,10 +689,9 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama_t
 	// create foreign DOT on AH Kusama
 	let reserves = vec![(asset_hub_polkadot_global_location(), false).into()];
 	create_foreign_on_ah_kusama(dot_at_kusama_parachains.clone(), true, reserves);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubKusama,
 		dot_at_kusama_parachains.clone(),
-		true,
 		AssetHubKusamaSender::get()
 	);
 	// create foreign DOT on Penpal Kusama
@@ -714,7 +713,11 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama_t
 			)],
 		));
 	});
-	create_pool_with_native_on!(PenpalA, dot_at_kusama_parachains.clone(), true, asset_owner);
+	create_foreign_pool_with_native_on!(
+		PenpalA,
+		dot_at_kusama_parachains.clone(),
+		asset_owner.clone()
+	);
 
 	Polkadot::execute_with(|| {
 		let root_origin = <Polkadot as Chain>::RuntimeOrigin::root();
@@ -738,7 +741,7 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama_t
 		<AssetHubPolkadot as Chain>::account_data_of(sov_kah_on_pah.clone()).free;
 	let sender_dot_before = <Polkadot as Chain>::account_data_of(sender.clone()).free;
 	let receiver_dot_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains.clone(), &receiver)
 	});
 
@@ -836,7 +839,7 @@ fn send_dot_from_polkadot_relay_through_asset_hub_polkadot_to_asset_hub_kusama_t
 
 	let sender_dot_after = <Polkadot as Chain>::account_data_of(sender.clone()).free;
 	let receiver_dot_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
 		<Assets as Inspect<_>>::balance(dot_at_kusama_parachains, &receiver)
 	});
 	let dot_in_reserve_on_pah_after =
@@ -902,7 +905,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 
 	// balances before
 	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest.clone(), &sender)
 	});
 	let receiver_ksm_before = <AssetHubKusama as Chain>::account_data_of(receiver.clone()).free;
@@ -981,7 +984,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	});
 
 	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains_latest, &sender)
 	});
 	let receiver_ksm_after = <AssetHubKusama as Chain>::account_data_of(receiver).free;
@@ -1013,10 +1016,9 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 		reserves,
 		prefund_accounts,
 	);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubPolkadot,
 		ksm_at_polkadot_parachains.clone(),
-		true,
 		AssetHubKusamaSender::get()
 	);
 	let asset_owner: AccountId = AssetHubPolkadot::account_id_of(ALICE);
@@ -1055,11 +1057,11 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 
 	// balances before
 	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
 	let receiver_ksm_before = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
 		<Assets as Inspect<_>>::balance(ksm_at_kusama_parachains.clone(), &receiver)
 	});
 
@@ -1170,11 +1172,11 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	});
 
 	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains, &sender)
 	});
 	let receiver_ksm_after = PenpalA::execute_with(|| {
-		type Assets = <PenpalA as PenpalAPallet>::ForeignAssets;
+		type Assets = <PenpalA as PenpalAPallet>::Assets;
 		<Assets as Inspect<_>>::balance(ksm_at_kusama_parachains.clone(), &receiver)
 	});
 
@@ -1205,10 +1207,9 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 		reserves,
 		prefund_accounts,
 	);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubPolkadot,
 		ksm_at_polkadot_parachains.clone(),
-		true,
 		AssetHubKusamaSender::get()
 	);
 	let asset_owner: AccountId = AssetHubPolkadot::account_id_of(ALICE);
@@ -1250,7 +1251,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 
 	// balances before
 	let sender_ksm_before = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains.clone(), &sender)
 	});
 	let receiver_ksm_before = <Kusama as Chain>::account_data_of(receiver.clone()).free;
@@ -1359,7 +1360,7 @@ fn send_back_ksm_from_penpal_polkadot_through_asset_hub_polkadot_to_asset_hub_ku
 	});
 
 	let sender_ksm_after = PenpalB::execute_with(|| {
-		type ForeignAssets = <PenpalB as PenpalBPallet>::ForeignAssets;
+		type ForeignAssets = <PenpalB as PenpalBPallet>::Assets;
 		<ForeignAssets as Inspect<_>>::balance(ksm_at_polkadot_parachains, &sender)
 	});
 	let receiver_ksm_after = <Kusama as Chain>::account_data_of(receiver.clone()).free;

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -32,18 +32,6 @@ mod snowbridge_v2_outbound_from_kusama;
 mod snowbridge_v2_rewards;
 mod teleport;
 
-#[macro_export]
-macro_rules! assets_balance_on {
-	( $chain:ident, $id:expr, $who:expr ) => {
-		emulated_integration_tests_common::impls::paste::paste! {
-			<$chain>::execute_with(|| {
-				type Assets = <$chain as [<$chain Pallet>]>::Assets;
-				<Assets as Inspect<_>>::balance($id, $who)
-			})
-		}
-	};
-}
-
 pub(crate) fn asset_hub_kusama_location() -> Location {
 	Location::new(2, [GlobalConsensus(Kusama), Parachain(AssetHubKusama::para_id().into())])
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -32,6 +32,18 @@ mod snowbridge_v2_outbound_from_kusama;
 mod snowbridge_v2_rewards;
 mod teleport;
 
+#[macro_export]
+macro_rules! assets_balance_on {
+	( $chain:ident, $id:expr, $who:expr ) => {
+		emulated_integration_tests_common::impls::paste::paste! {
+			<$chain>::execute_with(|| {
+				type Assets = <$chain as [<$chain Pallet>]>::Assets;
+				<Assets as Inspect<_>>::balance($id, $who)
+			})
+		}
+	};
+}
+
 pub(crate) fn asset_hub_kusama_location() -> Location {
 	Location::new(2, [GlobalConsensus(Kusama), Parachain(AssetHubKusama::para_id().into())])
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge.rs
@@ -150,7 +150,7 @@ fn send_token_from_ethereum_to_penpal() {
 			)],
 		));
 
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::force_create(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::force_create(
 			<PenpalB as Chain>::RuntimeOrigin::root(),
 			weth_asset_location.clone(),
 			asset_hub_sovereign.clone().into(),
@@ -158,7 +158,7 @@ fn send_token_from_ethereum_to_penpal() {
 			1000
 		));
 
-		assert!(<PenpalB as PenpalBPallet>::ForeignAssets::asset_exists(weth_asset_location));
+		assert!(<PenpalB as PenpalBPallet>::Assets::asset_exists(weth_asset_location));
 	});
 
 	BridgeHubPolkadot::execute_with(|| {
@@ -218,7 +218,7 @@ fn send_token_from_ethereum_to_penpal() {
 		assert_expected_events!(
 			PenpalB,
 			vec![
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { .. }) => {},
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { .. }) => {},
 			]
 		);
 	});

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_common.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_common.rs
@@ -19,12 +19,13 @@ use asset_hub_polkadot_runtime::xcm_config::{
 };
 use bp_bridge_hub_polkadot::snowbridge::EthereumNetwork;
 use emulated_integration_tests_common::{
-	create_pool_with_native_on, PenpalBPen2TeleportableAssetLocation,
+	create_foreign_pool_with_native_on, create_foreign_pool_with_parent_native_on,
+	PenpalBPen2TeleportableAssetLocation,
 };
 use frame_support::traits::fungibles::Mutate;
 use hex_literal::hex;
 use polkadot_system_emulated_network::penpal_emulated_chain::{
-	penpal_runtime::xcm_config::{CheckingAccount, TELEPORTABLE_ASSET_ID},
+	penpal_runtime::xcm_config::{CheckingAccount, LocalPen2Asset},
 	PenpalAssetOwner,
 };
 use snowbridge_core::AssetMetadata;
@@ -268,62 +269,62 @@ pub fn prefund_accounts_on_penpal_b() {
 		(sudo_account.clone(), INITIAL_FUND),
 	]);
 	PenpalB::execute_with(|| {
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			Location::parent(),
 			&PenpalBReceiver::get(),
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			Location::parent(),
 			&PenpalBSender::get(),
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			Location::parent(),
 			&sudo_account,
 			INITIAL_FUND,
 		));
 		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
-			TELEPORTABLE_ASSET_ID,
+			LocalPen2Asset::get(),
 			&PenpalBReceiver::get(),
 			INITIAL_FUND,
 		));
 		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
-			TELEPORTABLE_ASSET_ID,
+			LocalPen2Asset::get(),
 			&PenpalBSender::get(),
 			INITIAL_FUND,
 		));
 		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
-			TELEPORTABLE_ASSET_ID,
+			LocalPen2Asset::get(),
 			&sudo_account,
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			weth_location(),
 			&PenpalBReceiver::get(),
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			weth_location(),
 			&PenpalBSender::get(),
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			weth_location(),
 			&sudo_account,
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			eth_location(),
 			&PenpalBReceiver::get(),
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			eth_location(),
 			&PenpalBSender::get(),
 			INITIAL_FUND,
 		));
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			eth_location(),
 			&sudo_account,
 			INITIAL_FUND,
@@ -412,10 +413,9 @@ pub(crate) fn set_up_foreign_asset_and_dot_pool_on_polkadot_asset_hub(asset: Loc
 			INITIAL_FUND,
 		));
 	});
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubPolkadot,
 		asset,
-		true,
 		ethereum_sovereign.clone(),
 		DOT_POOL_AMOUNT,
 		ETH_POOL_AMOUNT
@@ -427,16 +427,15 @@ pub(crate) fn set_up_eth_and_dot_pool_on_penpal() {
 	let ethereum_sovereign = ethereum_sovereign();
 	PenpalB::fund_accounts(vec![(ethereum_sovereign.clone(), INITIAL_FUND)]);
 	PenpalB::execute_with(|| {
-		assert_ok!(<PenpalB as PenpalBPallet>::ForeignAssets::mint_into(
+		assert_ok!(<PenpalB as PenpalBPallet>::Assets::mint_into(
 			eth_location(),
 			&ethereum_sovereign.clone(),
 			INITIAL_FUND,
 		));
 	});
-	create_pool_with_native_on!(
+	create_foreign_pool_with_native_on!(
 		PenpalB,
 		eth_location(),
-		true,
 		ethereum_sovereign.clone(),
 		DOT_POOL_AMOUNT,
 		ETH_POOL_AMOUNT
@@ -457,10 +456,9 @@ pub(crate) fn set_up_eth_and_ksm_pool_on_kusama_asset_hub() {
 		));
 	});
 	AssetHubKusama::fund_accounts(vec![(sa_of_pah_on_kah.clone(), INITIAL_FUND)]);
-	create_pool_with_native_on!(
+	create_foreign_pool_with_parent_native_on!(
 		AssetHubKusama,
 		eth_location(),
-		true,
 		sa_of_pah_on_kah.clone(),
 		DOT_POOL_AMOUNT,
 		ETH_POOL_AMOUNT

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_inbound.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_inbound.rs
@@ -612,12 +612,12 @@ fn send_token_to_penpal_v2() {
 					pallet_message_queue::Event::Processed { success: true, .. }
 				) => {},
 				// Token was issued to beneficiary
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == token_location,
 					who: *who == beneficiary_acc_bytes.into(),
 				},
 				// Leftover fees was deposited to beneficiary
-				RuntimeEvent::ForeignAssets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
+				RuntimeEvent::Assets(pallet_assets::Event::Deposited { asset_id, who, .. }) => {
 					asset_id: *asset_id == eth_location(),
 					who: *who == beneficiary_acc_bytes.into(),
 				},

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_outbound.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_outbound.rs
@@ -22,7 +22,7 @@ use bridge_hub_polkadot_runtime::{
 };
 use emulated_integration_tests_common::{impls::Decode, PenpalBPen2TeleportableAssetLocation};
 use frame_support::{assert_err_ignore_postinfo, pallet_prelude::TypeInfo, BoundedVec};
-use polkadot_system_emulated_network::penpal_emulated_chain::penpal_runtime::xcm_config::LocalTeleportableToAssetHub;
+use polkadot_system_emulated_network::penpal_emulated_chain::penpal_runtime::xcm_config::LocalPen2Asset;
 use snowbridge_core::{reward::MessageId, AssetMetadata, BasicOperatingMode};
 use snowbridge_outbound_queue_primitives::v2::{ContractCall, DeliveryReceipt};
 use snowbridge_pallet_outbound_queue_v2::Error;
@@ -819,7 +819,7 @@ fn send_message_from_penpal_to_ethereum(sudo: bool) {
 			Asset { id: AssetId(eth_location()), fun: Fungible(REMOTE_FEE_AMOUNT_IN_ETHER) };
 
 		let pna =
-			Asset { id: AssetId(LocalTeleportableToAssetHub::get()), fun: Fungible(TOKEN_AMOUNT) };
+			Asset { id: AssetId(LocalPen2Asset::get()), fun: Fungible(TOKEN_AMOUNT) };
 
 		let ena = Asset { id: AssetId(weth_location()), fun: Fungible(TOKEN_AMOUNT / 2) };
 

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_outbound.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/snowbridge_v2_outbound.rs
@@ -818,8 +818,7 @@ fn send_message_from_penpal_to_ethereum(sudo: bool) {
 		let remote_fee_asset_on_ethereum =
 			Asset { id: AssetId(eth_location()), fun: Fungible(REMOTE_FEE_AMOUNT_IN_ETHER) };
 
-		let pna =
-			Asset { id: AssetId(LocalPen2Asset::get()), fun: Fungible(TOKEN_AMOUNT) };
+		let pna = Asset { id: AssetId(LocalPen2Asset::get()), fun: Fungible(TOKEN_AMOUNT) };
 
 		let ena = Asset { id: AssetId(weth_location()), fun: Fungible(TOKEN_AMOUNT / 2) };
 


### PR DESCRIPTION
Integrated all integration test changes coming from upstream. Closes #1125.

The PR fixes almost all tests, the rest is unrelated as far as I can tell. The changes are 100% identical to the polkadot-sdk integration test changes when the feature was introduced - no surprises found. Hence, I think it is safe to merge this PR as is into the release preparation branch. However, tagging @acatangiu, @franciscoaguirre here so that they can take a look at the isolated changes if they want too.