### PR TITLE
KAH: fix recovery benchmarks

### DIFF
--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -1400,7 +1400,14 @@ parameter_types! {
 impl pallet_recovery::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type RuntimeHoldReason = RuntimeHoldReason;
+	// Benchmarks for `finish_attempt` / `cancel_attempt` advance `frame_system`'s block number,
+	// which does not move `RelaychainDataProvider`, causing `NotYetInheritable` /
+	// `NotYetCancelable`. Use `frame_system` under the benchmarking feature so the time-delay
+	// guards can be satisfied.
+	#[cfg(not(feature = "runtime-benchmarks"))]
 	type BlockNumberProvider = RelaychainDataProvider<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BlockNumberProvider = frame_system::Pallet<Runtime>;
 	type Currency = Balances;
 	type FriendGroupsConsideration = HoldConsideration<
 		AccountId,


### PR DESCRIPTION
Recovery benchmarks for `finish_attempt` / `cancel_attempt` [advance](https://github.com/paritytech/polkadot-sdk/blob/25b729730edaa83c8172e0efa5452ab521d29bf7/substrate/frame/recovery/src/benchmarking.rs#L269) `frame_system`'s block number, which does not move `RelaychainDataProvider`, causing `NotYetInheritable` / `NotYetCancelable`. Use `frame_system` under the benchmarking feature so the time-delay guards can be satisfied.

## Local test

```bash
frame-omni-bencher v1 benchmark pallet \
                                                                                     --runtime ./target/production/wbuild/asset-hub-kusama-runtime/asset_hub_kusama_runtime.compact.compressed.wasm \
                                                                                     --pallet pallet_recovery \
                                                                                     --extrinsic 'finish_attempt,cancel_attempt' \
                                                                                     --steps 2 --repeat 1 --heap-pages 4096 --min-duration 0
2026-05-22T11:50:15.827595Z  INFO frame::benchmark::pallet: Initialized runtime log filter to 'INFO'
2026-05-22T11:50:17.489920Z  INFO pallet_collator_selection::pallet: assembling new collators for new session 0 at #0
2026-05-22T11:50:17.489948Z  INFO pallet_collator_selection::pallet: assembling new collators for new session 1 at #0
2026-05-22T11:50:17.490002Z ERROR runtime::revive: Failed to map account d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d (5GrwvaEF...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490012Z ERROR runtime::revive: Failed to map account 8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48 (5FHneW46...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490018Z ERROR runtime::revive: Failed to map account 90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22 (5FLSigC9...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490025Z ERROR runtime::revive: Failed to map account 306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20 (5DAAnrj7...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490032Z ERROR runtime::revive: Failed to map account e659a7a1628cdd93febc04a4e0646ea20e9f5f0ce097d9a05290d4a9e054df4e (5HGjWAeF...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490039Z ERROR runtime::revive: Failed to map account 1cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c (5CiPPseX...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490046Z ERROR runtime::revive: Failed to map account be5ddb1579b72e84524fc29e78609e3caf42e85aa118ebfe0b0ad404b5bdd25f (5GNJqTPy...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490054Z ERROR runtime::revive: Failed to map account fe65717dad0447d715f660a0a58411de509b42e6efb8375f562f58a554d5860e (5HpG9w8E...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490060Z ERROR runtime::revive: Failed to map account 1e07379407fecc4b89eb7dbd287c2c781cfb1907a96947a3eb18e4f8e7198625 (5Ck5SLSH...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490067Z ERROR runtime::revive: Failed to map account e860f1b1c7227f7c22602f53f15af80747814dffd839719731ee3bba6edc126c (5HKPmK9G...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490074Z ERROR runtime::revive: Failed to map account 8ac59e11963af19174d0b94d5d78041c233f55d2e19324665bafdfb62925af2d (5FCfAonR...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490081Z ERROR runtime::revive: Failed to map account 101191192fc877c24d725b337120fa3edc63d227bbc92705db1e2cb65f56981a (5CRmqmsi...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:50:17.490088Z ERROR runtime::revive: Failed to map account 6d6f646c506f745374616b650000000000000000000000000000000000000000 (5EYCAe5c...): Module(ModuleError { index: 60, error: [44, 0, 0, 0], message: Some("AccountAlreadyMapped") })
2026-05-22T11:51:44.903579Z  INFO frame::benchmark::pallet: [  0 % ] Starting benchmark: pallet_recovery::finish_attempt
2026-05-22T11:51:44.920744Z  INFO frame::benchmark::pallet: [ 50 % ] Starting benchmark: pallet_recovery::cancel_attempt
Pallet: "pallet_recovery", Extrinsic: "finish_attempt", Lowest values: [], Highest values: [], Steps: 2, Repeat: 1
Raw Storage Info
========
Storage: `Recovery::Attempt` (r:1 w:1)
Proof: `Recovery::Attempt` (`max_values`: None, `max_size`: Some(180), added: 2655, mode: `MaxEncodedLen`)
Storage: `System::Account` (r:2 w:2)
Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
Storage: `Balances::Holds` (r:2 w:2)
Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(373), added: 2848, mode: `MaxEncodedLen`)
Storage: `Recovery::FriendGroups` (r:1 w:0)
Proof: `Recovery::FriendGroups` (`max_values`: None, `max_size`: Some(3435), added: 5910, mode: `MaxEncodedLen`)
Storage: `Recovery::Inheritor` (r:1 w:1)
Proof: `Recovery::Inheritor` (`max_values`: None, `max_size`: Some(133), added: 2608, mode: `MaxEncodedLen`)

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=    138.1
              µs

Reads = 7
Writes = 6
Recorded proof Size = 8946

Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=    138.1
              µs

Reads = 7
Writes = 6
Recorded proof Size = 8946

Pallet: "pallet_recovery", Extrinsic: "cancel_attempt", Lowest values: [], Highest values: [], Steps: 2, Repeat: 1
Raw Storage Info
========
Storage: `Recovery::Attempt` (r:1 w:1)
Proof: `Recovery::Attempt` (`max_values`: None, `max_size`: Some(180), added: 2655, mode: `MaxEncodedLen`)
Storage: `System::Account` (r:1 w:1)
Proof: `System::Account` (`max_values`: None, `max_size`: Some(128), added: 2603, mode: `MaxEncodedLen`)
Storage: `Balances::Holds` (r:1 w:1)
Proof: `Balances::Holds` (`max_values`: None, `max_size`: Some(373), added: 2848, mode: `MaxEncodedLen`)
Storage: `Recovery::FriendGroups` (r:1 w:0)
Proof: `Recovery::FriendGroups` (`max_values`: None, `max_size`: Some(3435), added: 5910, mode: `MaxEncodedLen`)

Median Slopes Analysis
========
-- Extrinsic Time --

Model:
Time ~=    76.23
              µs

Reads = 4
Writes = 3
Recorded proof Size = 6567

Min Squares Analysis
========
-- Extrinsic Time --

Model:
Time ~=    76.23
              µs

Reads = 4
Writes = 3
```

## Ref in the SDK

https://github.com/paritytech/polkadot-sdk/blob/25b729730edaa83c8172e0efa5452ab521d29bf7/substrate/frame/recovery/src/lib.rs#L305-L312

**Question**: should we use frame_system also outside benchmarking?