### PR TITLE
[PAH 2.3.0] Filter Staking::reap_stash during validator self stake transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - PAH & KAH: enable `pallet_revive` auto mapping feature ([#1159](https://github.com/polkadot-fellows/runtimes/pull/1159))
 - PAH & KAH: ERC-20 assets precompile `permit()` renamed to `use_permit()` ([#1159](https://github.com/polkadot-fellows/runtimes/pull/1159))
 - PAH: redirect XCM trader fees (native and swap) to `DapStagingAccount` instead of `StakingPot` ([#1159](https://github.com/polkadot-fellows/runtimes/pull/1159))
+- PAH: filter `staking.reap_stash` from both `BaseCallFilter` and the XCM `SafeCallFilter` while the validator self-stake transition to higher bond. See Ref: [#1890](https://polkadot.subsquare.io/referenda/1890) ([#1159](https://github.com/polkadot-fellows/runtimes/pull/1159))
 
 ### Removed
 

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -123,9 +123,9 @@ use frame_support::{
 		fungible::{self, HoldConsideration},
 		fungibles,
 		tokens::imbalance::{ResolveAssetTo, ResolveTo},
-		AsEnsureOriginWithArg, ConstBool, ConstU32, ConstU64, ConstU8, EitherOf, EitherOfDiverse,
-		Equals, InstanceFilter, LinearStoragePrice, NeverEnsureOrigin, PrivilegeCmp,
-		TransformOrigin, WithdrawReasons,
+		AsEnsureOriginWithArg, ConstBool, ConstU32, ConstU64, ConstU8, Contains, EitherOf,
+		EitherOfDiverse, Equals, InstanceFilter, LinearStoragePrice, NeverEnsureOrigin,
+		PrivilegeCmp, TransformOrigin, WithdrawReasons,
 	},
 	weights::{ConstantMultiplier, Weight},
 	PalletId,
@@ -244,9 +244,24 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 0;
 }
 
+/// Calls that are temporarily disabled at the runtime level.
+///
+/// The network is transitioning to a higher validator self-stake requirement
+/// (`MinValidatorBond`). During this transition, `reap_stash` is filtered out to protect
+/// previously-safe validators from getting permissionlessly reaped during the transition period.
+///
+/// The filter is intended to be removed once the transition completes and all active set validators
+/// are consistently above the new minimum. Other staking calls remain permitted.
+pub struct CallFilter;
+impl Contains<RuntimeCall> for CallFilter {
+	fn contains(call: &RuntimeCall) -> bool {
+		!matches!(call, RuntimeCall::Staking(pallet_staking_async::Call::reap_stash { .. }))
+	}
+}
+
 // Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = frame_support::traits::Everything;
+	type BaseCallFilter = CallFilter;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type AccountId = AccountId;
@@ -3121,5 +3136,34 @@ mod tests {
 			ProxyType::NonTransfer.filter(&call),
 			"NonTransfer proxy must allow MultiAssetBounties::propose_curator",
 		);
+	}
+
+	#[test]
+	fn call_filter_blocks_reap_stash() {
+		let call = RuntimeCall::Staking(pallet_staking_async::Call::reap_stash {
+			stash: AccountId::from([0u8; 32]),
+			num_slashing_spans: 0,
+		});
+		assert_eq!(CallFilter::contains(&call), false);
+	}
+
+	#[test]
+	fn call_filter_permits_other_staking_calls() {
+		let bond = RuntimeCall::Staking(pallet_staking_async::Call::bond {
+			value: 1_000_000_000_000,
+			payee: pallet_staking_async::RewardDestination::Stash,
+		});
+		let validate = RuntimeCall::Staking(pallet_staking_async::Call::validate {
+			prefs: pallet_staking_async::ValidatorPrefs::default(),
+		});
+		let chill = RuntimeCall::Staking(pallet_staking_async::Call::chill {});
+		let chill_other = RuntimeCall::Staking(pallet_staking_async::Call::chill_other {
+			stash: AccountId::from([0u8; 32]),
+		});
+
+		assert!(CallFilter::contains(&bond));
+		assert!(CallFilter::contains(&validate));
+		assert!(CallFilter::contains(&chill));
+		assert!(CallFilter::contains(&chill_other));
 	}
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -252,8 +252,8 @@ parameter_types! {
 ///
 /// The filter is intended to be removed once the transition completes and all active set validators
 /// are consistently above the new minimum. Other staking calls remain permitted.
-pub struct CallFilter;
-impl Contains<RuntimeCall> for CallFilter {
+pub struct AllExceptReapStash;
+impl Contains<RuntimeCall> for AllExceptReapStash {
 	fn contains(call: &RuntimeCall) -> bool {
 		!matches!(call, RuntimeCall::Staking(pallet_staking_async::Call::reap_stash { .. }))
 	}
@@ -261,7 +261,7 @@ impl Contains<RuntimeCall> for CallFilter {
 
 // Configure FRAME pallets to include in runtime.
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = CallFilter;
+	type BaseCallFilter = AllExceptReapStash;
 	type BlockWeights = RuntimeBlockWeights;
 	type BlockLength = RuntimeBlockLength;
 	type AccountId = AccountId;
@@ -3144,7 +3144,7 @@ mod tests {
 			stash: AccountId::from([0u8; 32]),
 			num_slashing_spans: 0,
 		});
-		assert_eq!(CallFilter::contains(&call), false);
+		assert_eq!(AllExceptReapStash::contains(&call), false);
 	}
 
 	#[test]
@@ -3161,9 +3161,9 @@ mod tests {
 			stash: AccountId::from([0u8; 32]),
 		});
 
-		assert!(CallFilter::contains(&bond));
-		assert!(CallFilter::contains(&validate));
-		assert!(CallFilter::contains(&chill));
-		assert!(CallFilter::contains(&chill_other));
+		assert!(AllExceptReapStash::contains(&bond));
+		assert!(AllExceptReapStash::contains(&validate));
+		assert!(AllExceptReapStash::contains(&chill));
+		assert!(AllExceptReapStash::contains(&chill_other));
 	}
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -3144,7 +3144,7 @@ mod tests {
 			stash: AccountId::from([0u8; 32]),
 			num_slashing_spans: 0,
 		});
-		assert_eq!(AllExceptReapStash::contains(&call), false);
+		assert!(!AllExceptReapStash::contains(&call));
 	}
 
 	#[test]

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
@@ -17,11 +17,11 @@ use cumulus_primitives_core::ParaId;
 pub use TreasuryAccount as RelayTreasuryPalletAccount;
 
 use super::{
-	treasury, AccountId, AllPalletsWithSystem, AssetConversion, Assets, Balance, Balances,
-	CallFilter, CollatorSelection, DotWeightToFee as WeightToFee, FellowshipAdmin, ForeignAssets,
-	GeneralAdmin, NativeAndAssets, ParachainInfo, ParachainSystem, PolkadotXcm, PoolAssets,
-	PriceForParentDelivery, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin,
-	StakingAdmin, ToKusamaXcmRouter, Treasurer, XcmpQueue,
+	treasury, AccountId, AllExceptReapStash, AllPalletsWithSystem, AssetConversion, Assets,
+	Balance, Balances, CollatorSelection, DotWeightToFee as WeightToFee, FellowshipAdmin,
+	ForeignAssets, GeneralAdmin, NativeAndAssets, ParachainInfo, ParachainSystem, PolkadotXcm,
+	PoolAssets, PriceForParentDelivery, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason,
+	RuntimeOrigin, StakingAdmin, ToKusamaXcmRouter, Treasurer, XcmpQueue,
 };
 use alloc::{collections::BTreeSet, vec, vec::Vec};
 use assets_common::{
@@ -515,7 +515,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalAliases =
 		(bridging::to_kusama::UniversalAliases, bridging::to_ethereum::UniversalAliases);
 	type CallDispatcher = RuntimeCall;
-	type SafeCallFilter = CallFilter;
+	type SafeCallFilter = AllExceptReapStash;
 	type Aliasers = TrustedAliasers;
 	type TransactionalProcessor = FrameTransactionalProcessor;
 	type HrmpNewChannelOpenRequestHandler = ();

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/xcm_config.rs
@@ -18,8 +18,8 @@ pub use TreasuryAccount as RelayTreasuryPalletAccount;
 
 use super::{
 	treasury, AccountId, AllPalletsWithSystem, AssetConversion, Assets, Balance, Balances,
-	CollatorSelection, DotWeightToFee as WeightToFee, FellowshipAdmin, ForeignAssets, GeneralAdmin,
-	NativeAndAssets, ParachainInfo, ParachainSystem, PolkadotXcm, PoolAssets,
+	CallFilter, CollatorSelection, DotWeightToFee as WeightToFee, FellowshipAdmin, ForeignAssets,
+	GeneralAdmin, NativeAndAssets, ParachainInfo, ParachainSystem, PolkadotXcm, PoolAssets,
 	PriceForParentDelivery, Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin,
 	StakingAdmin, ToKusamaXcmRouter, Treasurer, XcmpQueue,
 };
@@ -515,7 +515,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalAliases =
 		(bridging::to_kusama::UniversalAliases, bridging::to_ethereum::UniversalAliases);
 	type CallDispatcher = RuntimeCall;
-	type SafeCallFilter = Everything;
+	type SafeCallFilter = CallFilter;
 	type Aliasers = TrustedAliasers;
 	type TransactionalProcessor = FrameTransactionalProcessor;
 	type HrmpNewChannelOpenRequestHandler = ();


### PR DESCRIPTION
Filter `staking.reap_stash` from both `BaseCallFilter` and the XCM `SafeCallFilter` while the validator self-stake transition to higher bond. 

Also see [ref #1890](https://polkadot.subsquare.io/referenda/1890).