### PR TITLE
collectives: dedup salary asset conversion and reuse AssetHubUsdt default

### DIFF
--- a/system-parachains/collectives/collectives-polkadot/src/fellowship/mod.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/fellowship/mod.rs
@@ -21,6 +21,7 @@ mod tracks;
 use crate::{
 	fellowship::origins::EnsureCanFastPromoteTo,
 	impls::ToParentTreasury,
+	parameters::{FellowshipSalaryAsset, SalaryAssetId},
 	weights,
 	xcm_config::{LocationToAccountId, TreasurerBodyId},
 	AccountId, AssetHubLocation, AssetRateWithNative, Balance, Balances, FellowshipReferenda,
@@ -48,10 +49,8 @@ use polkadot_runtime_common::impls::{
 use polkadot_runtime_constants::{currency::GRAND, time::HOURS, xcm::body::FELLOWSHIP_ADMIN_INDEX};
 use sp_arithmetic::Permill;
 use sp_core::{ConstU128, ConstU32};
-use sp_runtime::traits::{
-	ConstU16, IdentityLookup, Replace, ReplaceWithDefault, TakeFirst, TryConvert,
-};
-use xcm_builder::{AliasesIntoAccountId32, LocatableAssetId, PayOverXcm};
+use sp_runtime::traits::{ConstU16, IdentityLookup, Replace, ReplaceWithDefault, TakeFirst};
+use xcm_builder::{AliasesIntoAccountId32, PayOverXcm};
 
 #[cfg(feature = "runtime-benchmarks")]
 use crate::impls::benchmarks::{OpenHrmpChannel, PayWithEnsure};
@@ -250,20 +249,8 @@ parameter_types! {
 	pub FellowshipSalaryBudget: u128 = crate::dynamic_params::fellowship_salary::SalaryConfig::get().budget;
 }
 
-/// Reads the Fellowship salary asset from the runtime parameters pallet and
-/// resolves it to a [`LocatableAssetId`].
-pub struct SalaryAssetId;
-impl TryConvert<(), LocatableAssetId> for SalaryAssetId {
-	fn try_convert(_: ()) -> Result<LocatableAssetId, ()> {
-		let versioned_asset = *crate::dynamic_params::fellowship_salary::SalaryConfig::get().asset;
-		LocatableAssetConverter::try_convert(versioned_asset).map_err(|_| {
-			frame_support::defensive!("FellowshipSalary asset conversion failed");
-		})
-	}
-}
-
 /// [`PayOverXcm`] setup to pay the Fellowship salary on the AssetHub in the
-/// asset configured via [`crate::dynamic_params::fellowship_salary::Asset`].
+/// asset configured via [`crate::dynamic_params::fellowship_salary::SalaryConfig`].
 pub type FellowshipSalaryPaymaster = PayOverXcm<
 	FellowshipSalaryInteriorLocation,
 	crate::xcm_config::XcmConfig,
@@ -271,7 +258,7 @@ pub type FellowshipSalaryPaymaster = PayOverXcm<
 	ConstU32<{ 6 * HOURS }>,
 	AccountId,
 	(),
-	SalaryAssetId,
+	SalaryAssetId<FellowshipSalaryAsset>,
 	AliasesIntoAccountId32<(), AccountId>,
 >;
 
@@ -388,7 +375,7 @@ impl pallet_treasury::Config<FellowshipTreasuryInstance> for Runtime {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use sp_runtime::traits::MaybeConvert;
+	use sp_runtime::traits::{MaybeConvert, TryConvert};
 
 	type MaxMemberCount =
 		<Runtime as pallet_ranked_collective::Config<FellowshipCollectiveInstance>>::MaxMemberCount;
@@ -408,7 +395,8 @@ mod tests {
 		// Provide minimal externalities, as some runtime storage access may occur.
 		let mut ext = TestExternalities::default();
 		ext.execute_with(|| {
-			let asset = SalaryAssetId::try_convert(()).expect("default salary asset is locatable");
+			let asset = SalaryAssetId::<FellowshipSalaryAsset>::try_convert(())
+				.expect("default salary asset is locatable");
 			assert_eq!(asset.location, Location::new(1, [Parachain(1000)]));
 			assert_eq!(
 				asset.asset_id,

--- a/system-parachains/collectives/collectives-polkadot/src/parameters.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/parameters.rs
@@ -16,6 +16,11 @@
 //! Dynamic parameters.
 
 use super::*;
+use core::marker::PhantomData;
+use frame_support::traits::Get;
+use polkadot_runtime_common::impls::LocatableAssetConverter;
+use sp_runtime::traits::TryConvert;
+use xcm_builder::LocatableAssetId;
 
 /// Dynamic runtime parameters configurable on-chain through [`pallet_parameters`].
 #[dynamic_params(RuntimeParameters, pallet_parameters::Parameters::<Runtime>)]
@@ -35,8 +40,8 @@ pub mod dynamic_params {
 		pub static SalaryConfig: crate::parameters::FellowshipSalaryConfig =
 			crate::parameters::FellowshipSalaryConfig {
 				asset: Box::new(VersionedLocatableAsset::V5 {
-					location: AssetHubLocation::get(),
-					asset_id: AssetId(Location::new(0, [PalletInstance(50), GeneralIndex(1984)])),
+					location: crate::xcm_config::AssetHubUsdt::get().location,
+					asset_id: crate::xcm_config::AssetHubUsdt::get().asset_id,
 				}),
 				budget: 250_000 * 1_000_000,
 			};
@@ -56,12 +61,39 @@ pub mod dynamic_params {
 		pub static SalaryConfig: crate::parameters::SecretarySalaryConfig =
 			crate::parameters::SecretarySalaryConfig {
 				asset: Box::new(VersionedLocatableAsset::V5 {
-					location: AssetHubLocation::get(),
-					asset_id: AssetId(Location::new(0, [PalletInstance(50), GeneralIndex(1984)])),
+					location: crate::xcm_config::AssetHubUsdt::get().location,
+					asset_id: crate::xcm_config::AssetHubUsdt::get().asset_id,
 				}),
 				budget: 13_332 * 1_000_000,
 				salary_rank1: 6666 * 1_000_000,
 			};
+	}
+}
+
+parameter_types! {
+	/// The Fellowship salary asset, read from the [`dynamic_params::fellowship_salary::SalaryConfig`]
+	/// parameter.
+	pub FellowshipSalaryAsset: VersionedLocatableAsset =
+		*dynamic_params::fellowship_salary::SalaryConfig::get().asset;
+	/// The Secretary salary asset, read from the [`dynamic_params::secretary_salary::SalaryConfig`]
+	/// parameter.
+	pub SecretarySalaryAsset: VersionedLocatableAsset =
+		*dynamic_params::secretary_salary::SalaryConfig::get().asset;
+}
+
+/// Resolves a configured [`VersionedLocatableAsset`] to a [`LocatableAssetId`] for use as the
+/// `AssetKind` of a salary [`xcm_builder::PayOverXcm`] paymaster.
+///
+/// `Asset` supplies the configured salary asset (e.g. [`FellowshipSalaryAsset`] or
+/// [`SecretarySalaryAsset`]).
+pub struct SalaryAssetId<Asset>(PhantomData<Asset>);
+impl<Asset: Get<VersionedLocatableAsset>> TryConvert<(), LocatableAssetId>
+	for SalaryAssetId<Asset>
+{
+	fn try_convert(_: ()) -> Result<LocatableAssetId, ()> {
+		LocatableAssetConverter::try_convert(Asset::get()).map_err(|_| {
+			frame_support::defensive!("Salary asset conversion failed");
+		})
 	}
 }
 

--- a/system-parachains/collectives/collectives-polkadot/src/secretary/mod.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/secretary/mod.rs
@@ -16,14 +16,17 @@
 
 //! The Polkadot Secretary Collective.
 
-use crate::{fellowship::FellowshipAdminBodyId, *};
+use crate::{
+	fellowship::FellowshipAdminBodyId,
+	parameters::{SalaryAssetId, SecretarySalaryAsset},
+	*,
+};
 use frame_support::traits::{tokens::GetSalary, EitherOf, Get, MapSuccess, NoOpPoll};
 use frame_system::{pallet_prelude::BlockNumberFor, EnsureRootWithSuccess};
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
-use polkadot_runtime_common::impls::LocatableAssetConverter;
 use sp_core::ConstU32;
-use sp_runtime::traits::{ConstU16, Identity, Replace, TryConvert};
-use xcm_builder::{AliasesIntoAccountId32, LocatableAssetId, PayOverXcm};
+use sp_runtime::traits::{ConstU16, Identity, Replace};
+use xcm_builder::{AliasesIntoAccountId32, PayOverXcm};
 
 /// The Secretary members' ranks.
 pub mod ranks {
@@ -87,18 +90,6 @@ impl GetSalary<u16, AccountId, Balance> for SalaryForRank {
 	}
 }
 
-/// Reads the Fellowship salary asset from the runtime parameters pallet and
-/// resolves it to a [`LocatableAssetId`].
-pub struct SalaryAssetId;
-impl TryConvert<(), LocatableAssetId> for SalaryAssetId {
-	fn try_convert(_: ()) -> Result<LocatableAssetId, ()> {
-		let versioned_asset = *crate::dynamic_params::secretary_salary::SalaryConfig::get().asset;
-		LocatableAssetConverter::try_convert(versioned_asset).map_err(|_| {
-			frame_support::defensive!("SecretarySalary asset conversion failed");
-		})
-	}
-}
-
 /// [`PayOverXcm`] setup to pay the Secretary salary on the AssetHub in the
 /// asset configured via [`crate::dynamic_params::secretary_salary::SalaryConfig`].
 pub type SecretarySalaryPaymaster = PayOverXcm<
@@ -108,7 +99,7 @@ pub type SecretarySalaryPaymaster = PayOverXcm<
 	ConstU32<{ 6 * HOURS }>,
 	AccountId,
 	(),
-	SalaryAssetId,
+	SalaryAssetId<SecretarySalaryAsset>,
 	AliasesIntoAccountId32<(), AccountId>,
 >;
 


### PR DESCRIPTION
Follow-up cleanup on top of #1186 (targets its branch `muharem-fellowship-salary-asset`).

- Extract the per-instance `SalaryAssetId` `TryConvert` (previously duplicated in `fellowship/mod.rs` and `secretary/mod.rs`) into a single generic `SalaryAssetId<Asset>` adapter in `parameters.rs`, parameterized by a `Get<VersionedLocatableAsset>` (`FellowshipSalaryAsset` / `SecretarySalaryAsset`).
- Reuse the existing `xcm_config::AssetHubUsdt` definition for the USDT-on-AssetHub defaults of both dynamic params, instead of re-spelling `location`/`asset_id` in each.