### PR TITLE
fix(ci): use upstream main as subweight baseline for forked PRs

### DIFF
--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -355,9 +355,7 @@ jobs:
           # PR's (possibly forked) repository. Comparing against `origin/main` would use
           # the fork's `main` as the weight baseline, which may be outdated and produce
           # false diffs (see #714). Always use this repository's `main` as the baseline.
-          git remote add fellowship-base "https://github.com/${{ github.repository }}.git" \
-            || git remote set-url fellowship-base "https://github.com/${{ github.repository }}.git"
-          git fetch fellowship-base main
+          git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/fellowship-base/main
           result=$(subweight compare commits \
             --path-pattern "./**/weights/**/*.rs" \
             --method asymptotic \

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -351,7 +351,13 @@ jobs:
         if: startsWith(steps.get-pr-comment.outputs.group2, 'bench')
         shell: bash
         run: |
-          git fetch
+          # The PR branch is checked out from its own repo, so `origin` points at the
+          # PR's (possibly forked) repository. Comparing against `origin/main` would use
+          # the fork's `main` as the weight baseline, which may be outdated and produce
+          # false diffs (see #714). Always use this repository's `main` as the baseline.
+          git remote add fellowship-base "https://github.com/${{ github.repository }}.git" \
+            || git remote set-url fellowship-base "https://github.com/${{ github.repository }}.git"
+          git fetch fellowship-base main
           result=$(subweight compare commits \
             --path-pattern "./**/weights/**/*.rs" \
             --method asymptotic \
@@ -359,7 +365,7 @@ jobs:
             --no-color \
             --change added changed \
             --ignore-errors \
-            refs/remotes/origin/main refs/heads/${{ needs.get-pr-branch.outputs.pr-branch }})
+            refs/remotes/fellowship-base/main refs/heads/${{ needs.get-pr-branch.outputs.pr-branch }})
           
           # Save the multiline result to the output
           {

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -362,7 +362,13 @@ jobs:
         env:
           PR_BRANCH: ${{ needs.get-pr-branch.outputs.pr-branch }}
         run: |
-          git fetch
+          # The PR branch is checked out from its own repo, so `origin` points at the
+          # PR's (possibly forked) repository. Comparing against `origin/main` would use
+          # the fork's `main` as the weight baseline, which may be outdated and produce
+          # false diffs (see #714). Always use this repository's `main` as the baseline.
+          git remote add fellowship-base "https://github.com/${{ github.repository }}.git" \
+            || git remote set-url fellowship-base "https://github.com/${{ github.repository }}.git"
+          git fetch fellowship-base main
           result=$(subweight compare commits \
             --path-pattern "./**/weights/**/*.rs" \
             --method asymptotic \
@@ -370,7 +376,7 @@ jobs:
             --no-color \
             --change added changed \
             --ignore-errors \
-            refs/remotes/origin/main "refs/heads/$PR_BRANCH")
+            refs/remotes/fellowship-base/main "refs/heads/$PR_BRANCH")
           
           # Save the multiline result to the output
           {

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -366,9 +366,7 @@ jobs:
           # PR's (possibly forked) repository. Comparing against `origin/main` would use
           # the fork's `main` as the weight baseline, which may be outdated and produce
           # false diffs (see #714). Always use this repository's `main` as the baseline.
-          git remote add fellowship-base "https://github.com/${{ github.repository }}.git" \
-            || git remote set-url fellowship-base "https://github.com/${{ github.repository }}.git"
-          git fetch fellowship-base main
+          git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/fellowship-base/main
           result=$(subweight compare commits \
             --path-pattern "./**/weights/**/*.rs" \
             --method asymptotic \

--- a/.github/workflows/cmd.yml
+++ b/.github/workflows/cmd.yml
@@ -361,12 +361,13 @@ jobs:
         shell: bash
         env:
           PR_BRANCH: ${{ needs.get-pr-branch.outputs.pr-branch }}
+          BASE_REPO: ${{ github.repository }}
         run: |
           # The PR branch is checked out from its own repo, so `origin` points at the
           # PR's (possibly forked) repository. Comparing against `origin/main` would use
           # the fork's `main` as the weight baseline, which may be outdated and produce
           # false diffs (see #714). Always use this repository's `main` as the baseline.
-          git fetch "https://github.com/${{ github.repository }}.git" main:refs/remotes/fellowship-base/main
+          git fetch --depth=1 "https://github.com/${BASE_REPO}.git" main:refs/remotes/fellowship-base/main
           result=$(subweight compare commits \
             --path-pattern "./**/weights/**/*.rs" \
             --method asymptotic \


### PR DESCRIPTION
Closes #714

The `cmd` job checks out the PR from its own (possibly forked) repo, so the subweight step compared against the fork's `main` — an outdated baseline that produced false weight diffs. Now it adds a `fellowship-base` remote pointing at this repository and compares against its `main` instead.

- [x] Does not require a CHANGELOG entry