### PR TITLE
AHP: pin nomination-pools unbonding bound across the fast-unbond flip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -418,7 +418,7 @@ jobs:
           name: ${{ matrix.runtime.name }}
 
       - name: Check runtime
-        timeout-minutes: 10
+        timeout-minutes: 25
         env:
           RUNTIME_NAME: ${{ matrix.runtime.name }}
           URIS_JSON: ${{ toJSON(matrix.runtime.uris) }}
@@ -438,7 +438,7 @@ jobs:
           for URI in "${URIS[@]}"; do
             echo "Trying $URI..."
             set +e
-            timeout 120 npx @polkadot-api/check-runtime@latest problems "$URI" --wasm "$WASM"
+            timeout 360 npx @polkadot-api/check-runtime@latest problems "$URI" --wasm "$WASM"
             EXIT_CODE=$?
             set -e
             if [ $EXIT_CODE -eq 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- PAH: pin the nomination-pools `TotalUnbondingPools` bound at its historical maximum (32) so lowering the nominator bonding duration via the `AreNominatorsSlashable` fast-unbond flip cannot shrink the bound (32 -> 6) and make oversized `SubPools::with_era` maps undecodable.
+- PAH: pin the nomination-pools `TotalUnbondingPools` bound at its historical maximum (32) so lowering the nominator bonding duration via the `AreNominatorsSlashable` fast-unbond flip cannot shrink the bound (32 -> 6) and make oversized `SubPools::with_era` maps undecodable ([#1201](https://github.com/polkadot-fellows/runtimes/pull/1201))
 
 ## [2.3.0] 04.06.2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- PAH: pin the nomination-pools `TotalUnbondingPools` bound at its historical maximum (32) so lowering the nominator bonding duration via the `AreNominatorsSlashable` fast-unbond flip cannot shrink the bound (32 -> 6) and make oversized `SubPools::with_era` maps undecodable.
+
 ## [2.3.0] 04.06.2026
 
 ### Added

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -3186,8 +3186,9 @@ mod tests {
 			};
 
 			// Pre-flip: nominators slashable, so the nominator bonding duration is the full
-			// `BondingDuration` and the post-unbonding window is the legacy 4. Set explicitly rather
-			// than relying on the storage default so the test pins both flag states itself.
+			// `BondingDuration` and the post-unbonding window is the legacy 4. Set explicitly
+			// rather than relying on the storage default so the test pins both flag states
+			// itself.
 			pallet_staking_async::AreNominatorsSlashable::<Runtime>::put(true);
 			assert_eq!(<Staking as StakingInterface>::nominator_bonding_duration(), 28);
 			assert_eq!(

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -3167,4 +3167,43 @@ mod tests {
 		assert!(AllExceptReapStash::contains(&chill));
 		assert!(AllExceptReapStash::contains(&chill_other));
 	}
+
+	/// The nomination-pools `with_era` bound (`TotalUnbondingPools`) must stay pinned at its
+	/// historical maximum (32) across the `AreNominatorsSlashable` fast-unbond flip. Otherwise the
+	/// lowered nominator bonding duration would shrink the bound (32 -> 6), making oversized
+	/// historical sub-pools undecodable and destroying per-era unbonding accounting on the next
+	/// `unbond`.
+	#[test]
+	fn nomination_pools_bound_survives_nominator_unslashable_flip() {
+		use frame_support::traits::Get;
+		use sp_staking::StakingInterface;
+
+		sp_io::TestExternalities::new(Default::default()).execute_with(|| {
+			// The bound the pallet actually uses for `SubPools::with_era`.
+			let total_unbonding_pools = || {
+				<Staking as StakingInterface>::nominator_bonding_duration() +
+					<Runtime as pallet_nomination_pools::Config>::PostUnbondingPoolsWindow::get()
+			};
+
+			// Pre-flip: nominators slashable (storage default), so the nominator bonding duration
+			// is the full `BondingDuration` and the post-unbonding window is the legacy 4.
+			assert!(pallet_staking_async::AreNominatorsSlashable::<Runtime>::get());
+			assert_eq!(<Staking as StakingInterface>::nominator_bonding_duration(), 28);
+			assert_eq!(
+				<Runtime as pallet_nomination_pools::Config>::PostUnbondingPoolsWindow::get(),
+				4
+			);
+			assert_eq!(total_unbonding_pools(), 32);
+
+			// The flip: nominators become non-slashable, so the nominator bonding duration drops to
+			// `NominatorFastUnbondDuration` (2). The window must widen to 30 so the bound stays 32.
+			pallet_staking_async::AreNominatorsSlashable::<Runtime>::put(false);
+			assert_eq!(<Staking as StakingInterface>::nominator_bonding_duration(), 2);
+			assert_eq!(
+				<Runtime as pallet_nomination_pools::Config>::PostUnbondingPoolsWindow::get(),
+				30
+			);
+			assert_eq!(total_unbonding_pools(), 32);
+		});
+	}
 }

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -3185,9 +3185,10 @@ mod tests {
 					<Runtime as pallet_nomination_pools::Config>::PostUnbondingPoolsWindow::get()
 			};
 
-			// Pre-flip: nominators slashable (storage default), so the nominator bonding duration
-			// is the full `BondingDuration` and the post-unbonding window is the legacy 4.
-			assert!(pallet_staking_async::AreNominatorsSlashable::<Runtime>::get());
+			// Pre-flip: nominators slashable, so the nominator bonding duration is the full
+			// `BondingDuration` and the post-unbonding window is the legacy 4. Set explicitly rather
+			// than relying on the storage default so the test pins both flag states itself.
+			pallet_staking_async::AreNominatorsSlashable::<Runtime>::put(true);
 			assert_eq!(<Staking as StakingInterface>::nominator_bonding_duration(), 28);
 			assert_eq!(
 				<Runtime as pallet_nomination_pools::Config>::PostUnbondingPoolsWindow::get(),

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/staking/nom_pools.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/staking/nom_pools.rs
@@ -16,14 +16,49 @@
 
 //! Config for the nomination pools.
 
-use crate::{staking::StakingAdmin, *};
-use frame_support::traits::Nothing;
+use crate::{
+	staking::{BondingDuration, StakingAdmin},
+	*,
+};
+use frame_support::traits::{Get, Nothing};
 use sp_runtime::FixedU128;
 
 parameter_types! {
 	pub const PoolsPalletId: PalletId = PalletId(*b"py/nopls");
 	// Allow pools that got slashed up to 90% to remain operational.
 	pub const MaxPointsToBalance: u8 = 10;
+}
+
+/// Bound for `pallet_nomination_pools::SubPools::with_era`, frozen at its historical maximum so it
+/// does not shrink when the nominator bonding duration drops.
+///
+/// The pallet derives its `TotalUnbondingPools` bound as `StakeAdapter::bonding_duration() +
+/// PostUnbondingPoolsWindow`, and `StakeAdapter::bonding_duration()` resolves to
+/// `StakingInterface::nominator_bonding_duration()`, which drops from `BondingDuration` (28) to
+/// `NominatorFastUnbondDuration` (2) the moment `AreNominatorsSlashable` is set from `true` to
+/// `false`. With a fixed window the bound would shrink 32 -> 6, making any oversized historical
+/// `with_era` map undecodable; the next `unbond` then overwrites it with an empty `Default`,
+/// destroying per-era unbonding accounting (bugbounty report #90).
+///
+/// We pin the bound at `BondingDuration + 4 = 32` by computing the window as `MAX -
+/// nominator_bonding_duration()`. Subtracting the same value the pallet adds keeps
+/// `TotalUnbondingPools == MAX` by construction, regardless of the flag. Post-flip this also widens
+/// the effective merge window to `32 - 2 = 30` eras, keeping each per-era pool on its correct
+/// points-to-balance ratio long enough for deferred pre-flip slashes (`SlashDeferDuration = 27`) to
+/// still be applied.
+///
+/// TODO: this is an interim runtime fix, meant to be superseded by the in-pallet decoupling in
+/// polkadot-sdk.
+pub struct PostUnbondingPoolsWindow;
+impl Get<u32> for PostUnbondingPoolsWindow {
+	fn get() -> u32 {
+		// Historical maximum number of unbonding sub-pools: the validator bonding duration plus the
+		// legacy 4-era post-unbonding window. `BondingDuration` is the upper bound of
+		// `nominator_bonding_duration()`, so the subtraction below never saturates.
+		let max_unbonding_pools = BondingDuration::get().saturating_add(4);
+		max_unbonding_pools
+			.saturating_sub(<Staking as sp_staking::StakingInterface>::nominator_bonding_duration())
+	}
 }
 
 impl pallet_nomination_pools::Config for Runtime {
@@ -35,7 +70,7 @@ impl pallet_nomination_pools::Config for Runtime {
 	type U256ToBalance = polkadot_runtime_common::U256ToBalance;
 	type StakeAdapter =
 		pallet_nomination_pools::adapter::DelegateStake<Self, Staking, DelegatedStaking>;
-	type PostUnbondingPoolsWindow = frame_support::traits::ConstU32<4>;
+	type PostUnbondingPoolsWindow = PostUnbondingPoolsWindow;
 	type MaxMetadataLen = frame_support::traits::ConstU32<256>;
 	// we use the same number of allowed unlocking chunks as with staking.
 	type MaxUnbonding = <Self as pallet_staking_async::Config>::MaxUnlockingChunks;


### PR DESCRIPTION
`SubPools::with_era` is bounded by `TotalUnbondingPools = bonding_duration() + PostUnbondingPoolsWindow`. Setting `AreNominatorsSlashable = false` drops the nominator bonding duration 28 -> 2, shrinking the bound 32 -> 6: oversized historical maps then fail to decode and the next `unbond` overwrites them with an empty default, destroying per-era unbonding accounting.

Make `PostUnbondingPoolsWindow` a `Get` returning `MAX - nominator_bonding_duration()`, keeping the bound pinned at 32 regardless of the flag (subtracting the same value the pallet adds). Post-flip the effective merge window widens to 30 eras, covering deferred pre-flip slashes (SlashDeferDuration = 27).
AHP only, AHK is unaffected.

Interim runtime fix ahead of the in-pallet decoupling in polkadot-sdk.

