### PR TITLE
Enable async backing for BridgeHub, Coretime and Collectives system parachains

### DIFF
--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -139,7 +139,7 @@
       "wss://ksm-rpc.stakeworld.io/bridgehub"
     ],
     "is_relay": false,
-    "blocktime": 12000,
+    "blocktime": 24000,
     "extra_args": "--disable-mbm-checks",
     "benchmarks_templates": {
       "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",
@@ -163,7 +163,7 @@
       "wss://dot-rpc.stakeworld.io/bridgehub"
     ],
     "is_relay": false,
-    "blocktime": 12000,
+    "blocktime": 24000,
     "extra_args": "--disable-mbm-checks",
     "benchmarks_templates": {
       "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",
@@ -187,7 +187,7 @@
       "wss://dot-rpc.stakeworld.io/collectives"
     ],
     "is_relay": false,
-    "blocktime": 12000,
+    "blocktime": 24000,
     "extra_args": "--disable-mbm-checks",
     "benchmarks_templates": {
       "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",
@@ -209,7 +209,7 @@
       "wss://ksm-rpc.stakeworld.io/coretime"
     ],
     "is_relay": false,
-    "blocktime": 12000,
+    "blocktime": 24000,
     "extra_args": "--disable-mbm-checks",
     "benchmarks_templates": {
       "pallet_xcm_benchmarks::generic": "templates/xcm-bench-template.hbs",
@@ -222,7 +222,7 @@
     "path": "system-parachains/coretime/coretime-polkadot",
     "max_code_size": 3145728,
     "is_relay": false,
-    "blocktime": 12000,
+    "blocktime": 24000,
     "uris": [
       "wss://polkadot-coretime-rpc.polkadot.io:443",
       "wss://coretime-polkadot-rpc.n.dwellir.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Enable async backing (6s block time) for Bridge Hub Polkadot/Kusama, Coretime Polkadot/Kusama and Collectives Polkadot, and switch them to a 24s Aura slot duration ([#460](https://github.com/polkadot-fellows/runtimes/issues/460))
+
 ## [2.3.0] 04.06.2026
 
 ### Added

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -83,11 +83,23 @@ use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 
 use parachains_common::{AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature};
-pub use system_parachains_constants::SLOT_DURATION;
+
+/// Bridge Hub Kusama uses a 24s Aura slot duration.
+pub const SLOT_DURATION: u64 = 24_000;
 
 use system_parachains_constants::{
-	kusama::{consensus::*, currency::*, fee::WeightToFee, fellowship::IsFellowshipVoice},
-	AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	async_backing::{
+		AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	},
+	kusama::{
+		consensus::{
+			async_backing::UNINCLUDED_SEGMENT_CAPACITY, BLOCK_PROCESSING_VELOCITY,
+			RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		},
+		currency::*,
+		fee::WeightToFee,
+		fellowship::IsFellowshipVoice,
+	},
 };
 
 // XCM Imports

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -90,11 +90,22 @@ use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 
 use parachains_common::{AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature};
-pub use system_parachains_constants::SLOT_DURATION;
+
+/// Bridge Hub Polkadot uses a 24s Aura slot duration.
+pub const SLOT_DURATION: u64 = 24_000;
 
 use system_parachains_constants::{
-	polkadot::{consensus::*, currency::*, fee::WeightToFee},
-	AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	async_backing::{
+		AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	},
+	polkadot::{
+		consensus::{
+			async_backing::UNINCLUDED_SEGMENT_CAPACITY, BLOCK_PROCESSING_VELOCITY,
+			RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		},
+		currency::*,
+		fee::WeightToFee,
+	},
 };
 
 // XCM Imports

--- a/system-parachains/collectives/collectives-polkadot/src/lib.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/lib.rs
@@ -99,14 +99,27 @@ use parachains_common::{
 };
 use sp_runtime::Debug;
 use system_parachains_constants::{
-	polkadot::{account::*, consensus::*, currency::*, fee::WeightToFee},
-	AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MINUTES, NORMAL_DISPATCH_RATIO,
-	SLOT_DURATION,
+	async_backing::{
+		AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MINUTES,
+		NORMAL_DISPATCH_RATIO,
+	},
+	polkadot::{
+		account::*,
+		consensus::{
+			async_backing::UNINCLUDED_SEGMENT_CAPACITY, BLOCK_PROCESSING_VELOCITY,
+			RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		},
+		currency::*,
+		fee::WeightToFee,
+	},
 };
 use xcm_config::{
 	AssetHubLocation, FellowshipAdminBodyId, LocationToAccountId, RelayChainLocation, SelfParaId,
 	StakingPot, TreasurerBodyId, XcmOriginToTransactDispatchOrigin,
 };
+
+/// Collectives Polkadot uses a 24s Aura slot duration.
+pub const SLOT_DURATION: u64 = 24_000;
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;

--- a/system-parachains/coretime/coretime-kusama/src/lib.rs
+++ b/system-parachains/coretime/coretime-kusama/src/lib.rs
@@ -72,8 +72,18 @@ use sp_runtime::{
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use system_parachains_constants::{
-	kusama::{consensus::*, currency::*, fee::WeightToFee, fellowship::IsFellowshipVoice},
-	AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	async_backing::{
+		AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	},
+	kusama::{
+		consensus::{
+			async_backing::UNINCLUDED_SEGMENT_CAPACITY, BLOCK_PROCESSING_VELOCITY,
+			RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		},
+		currency::*,
+		fee::WeightToFee,
+		fellowship::IsFellowshipVoice,
+	},
 };
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use xcm::prelude::*;
@@ -84,6 +94,9 @@ use xcm_runtime_apis::{
 	dry_run::{CallDryRunEffects, Error as XcmDryRunApiError, XcmDryRunEffects},
 	fees::Error as XcmPaymentApiError,
 };
+
+/// Coretime Kusama uses a 24s Aura slot duration.
+pub const SLOT_DURATION: u64 = 24_000;
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;

--- a/system-parachains/coretime/coretime-polkadot/src/lib.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/lib.rs
@@ -73,8 +73,17 @@ use sp_runtime::{
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 use system_parachains_constants::{
-	polkadot::{consensus::*, currency::*, fee::WeightToFee},
-	AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	async_backing::{
+		AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	},
+	polkadot::{
+		consensus::{
+			async_backing::UNINCLUDED_SEGMENT_CAPACITY, BLOCK_PROCESSING_VELOCITY,
+			RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		},
+		currency::*,
+		fee::WeightToFee,
+	},
 };
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use xcm::prelude::*;
@@ -86,6 +95,9 @@ use xcm_runtime_apis::{
 	dry_run::{CallDryRunEffects, Error as XcmDryRunApiError, XcmDryRunEffects},
 	fees::Error as XcmPaymentApiError,
 };
+
+/// Coretime Polkadot uses a 24s Aura slot duration.
+pub const SLOT_DURATION: u64 = 24_000;
 
 /// The address format for describing accounts.
 pub type Address = MultiAddress<AccountId, ()>;


### PR DESCRIPTION
Enables async backing (6s block time, 24s Aura slot duration) for the remaining system parachains tracked in #460: Bridge Hub Polkadot/Kusama, Coretime Polkadot/Kusama, and Collectives Polkadot.
