### PR TITLE
Migrate off deprecated parachain runtime APIs on both relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Polkadot & Kusama relay: Migrate the `ParachainHost` runtime API off the deprecated `candidate_pending_availability` and `async_backing_params` helpers (now implemented via `candidates_pending_availability` and a direct configuration read respectively) and drop the corresponding `#[allow(deprecated)]`. `para_backing_state` still delegates to the deprecated `backing_state` helper, as the full `BackingState` cannot be reconstructed from public runtime APIs; clients should use the already-exposed `backing_constraints` and `candidates_pending_availability` instead ([#1199](https://github.com/polkadot-fellows/runtimes/issues/1199)).
+
 ## [2.3.1] 12.06.2026
 
 ### Fixed

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -2535,9 +2535,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn candidate_pending_availability(para_id: ParaId) -> Option<CommittedCandidateReceiptV2<Hash>> {
-			// `candidate_pending_availability` is deprecated upstream in favour of
-			// `candidates_pending_availability` (which supports elastic scaling). Return the first
-			// pending candidate to preserve the original single-candidate semantics.
+			// Deprecated upstream: return the first of `candidates_pending_availability`.
 			parachains_runtime_api_impl::candidates_pending_availability::<Runtime>(para_id)
 				.into_iter()
 				.next()
@@ -2636,22 +2634,16 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn para_backing_state(para_id: ParaId) -> Option<polkadot_primitives::async_backing::BackingState> {
-			// `backing_state`/`para_backing_state` are deprecated upstream in favour of
-			// `backing_constraints` + `candidates_pending_availability` (both implemented below).
-			// The full `BackingState` cannot be reconstructed from public runtime APIs because each
-			// pending candidate's `relay_parent_number` is only exposed via a `pub(crate)` accessor
-			// in the SDK, so we keep delegating to the deprecated helper until the trait method
-			// itself is removed (it will be dropped together with the helper, by bumping past the
-			// `ParachainHost` API version that defines it).
+			// Deprecated, but `BackingState` can't be rebuilt from public APIs (pending candidates'
+			// `relay_parent_number` accessor is `pub(crate)`). Keep the helper until the trait
+			// method is removed; clients should use `backing_constraints` +
+			// `candidates_pending_availability`.
 			#[allow(deprecated)]
 			parachains_runtime_api_impl::backing_state::<Runtime>(para_id)
 		}
 
 		fn async_backing_params() -> polkadot_primitives::AsyncBackingParams {
-			// `async_backing_params` is deprecated upstream (validators now derive these values
-			// dynamically from the claim queue). Read the value straight from the configuration
-			// instead of the deprecated helper; this preserves the previous behaviour for any
-			// clients still querying it.
+			// Deprecated upstream: read the configured value directly instead of the helper.
 			parachains_configuration::ActiveConfig::<Runtime>::get().async_backing_params
 		}
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -2535,8 +2535,12 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn candidate_pending_availability(para_id: ParaId) -> Option<CommittedCandidateReceiptV2<Hash>> {
-			#[allow(deprecated)]
-			parachains_runtime_api_impl::candidate_pending_availability::<Runtime>(para_id)
+			// `candidate_pending_availability` is deprecated upstream in favour of
+			// `candidates_pending_availability` (which supports elastic scaling). Return the first
+			// pending candidate to preserve the original single-candidate semantics.
+			parachains_runtime_api_impl::candidates_pending_availability::<Runtime>(para_id)
+				.into_iter()
+				.next()
 		}
 
 		fn candidate_events() -> Vec<CandidateEvent<Hash>> {
@@ -2632,13 +2636,23 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn para_backing_state(para_id: ParaId) -> Option<polkadot_primitives::async_backing::BackingState> {
+			// `backing_state`/`para_backing_state` are deprecated upstream in favour of
+			// `backing_constraints` + `candidates_pending_availability` (both implemented below).
+			// The full `BackingState` cannot be reconstructed from public runtime APIs because each
+			// pending candidate's `relay_parent_number` is only exposed via a `pub(crate)` accessor
+			// in the SDK, so we keep delegating to the deprecated helper until the trait method
+			// itself is removed (it will be dropped together with the helper, by bumping past the
+			// `ParachainHost` API version that defines it).
 			#[allow(deprecated)]
 			parachains_runtime_api_impl::backing_state::<Runtime>(para_id)
 		}
 
 		fn async_backing_params() -> polkadot_primitives::AsyncBackingParams {
-			#[allow(deprecated)]
-			parachains_runtime_api_impl::async_backing_params::<Runtime>()
+			// `async_backing_params` is deprecated upstream (validators now derive these values
+			// dynamically from the claim queue). Read the value straight from the configuration
+			// instead of the deprecated helper; this preserves the previous behaviour for any
+			// clients still querying it.
+			parachains_configuration::ActiveConfig::<Runtime>::get().async_backing_params
 		}
 
 		fn disabled_validators() -> Vec<ValidatorIndex> {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -2466,8 +2466,12 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn candidate_pending_availability(para_id: ParaId) -> Option<CommittedCandidateReceipt<Hash>> {
-			#[allow(deprecated)]
-			parachains_runtime_api_impl::candidate_pending_availability::<Runtime>(para_id)
+			// `candidate_pending_availability` is deprecated upstream in favour of
+			// `candidates_pending_availability` (which supports elastic scaling). Return the first
+			// pending candidate to preserve the original single-candidate semantics.
+			parachains_runtime_api_impl::candidates_pending_availability::<Runtime>(para_id)
+				.into_iter()
+				.next()
 		}
 
 		fn candidate_events() -> Vec<CandidateEvent<Hash>> {
@@ -2563,13 +2567,23 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn para_backing_state(para_id: ParaId) -> Option<polkadot_primitives::async_backing::BackingState> {
+			// `backing_state`/`para_backing_state` are deprecated upstream in favour of
+			// `backing_constraints` + `candidates_pending_availability` (both implemented below).
+			// The full `BackingState` cannot be reconstructed from public runtime APIs because each
+			// pending candidate's `relay_parent_number` is only exposed via a `pub(crate)` accessor
+			// in the SDK, so we keep delegating to the deprecated helper until the trait method
+			// itself is removed (it will be dropped together with the helper, by bumping past the
+			// `ParachainHost` API version that defines it).
 			#[allow(deprecated)]
 			parachains_runtime_api_impl::backing_state::<Runtime>(para_id)
 		}
 
 		fn async_backing_params() -> polkadot_primitives::AsyncBackingParams {
-			#[allow(deprecated)]
-			parachains_runtime_api_impl::async_backing_params::<Runtime>()
+			// `async_backing_params` is deprecated upstream (validators now derive these values
+			// dynamically from the claim queue). Read the value straight from the configuration
+			// instead of the deprecated helper; this preserves the previous behaviour for any
+			// clients still querying it.
+			parachains_configuration::ActiveConfig::<Runtime>::get().async_backing_params
 		}
 
 		fn disabled_validators() -> Vec<ValidatorIndex> {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -2466,9 +2466,7 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn candidate_pending_availability(para_id: ParaId) -> Option<CommittedCandidateReceipt<Hash>> {
-			// `candidate_pending_availability` is deprecated upstream in favour of
-			// `candidates_pending_availability` (which supports elastic scaling). Return the first
-			// pending candidate to preserve the original single-candidate semantics.
+			// Deprecated upstream: return the first of `candidates_pending_availability`.
 			parachains_runtime_api_impl::candidates_pending_availability::<Runtime>(para_id)
 				.into_iter()
 				.next()
@@ -2567,22 +2565,16 @@ sp_api::impl_runtime_apis! {
 		}
 
 		fn para_backing_state(para_id: ParaId) -> Option<polkadot_primitives::async_backing::BackingState> {
-			// `backing_state`/`para_backing_state` are deprecated upstream in favour of
-			// `backing_constraints` + `candidates_pending_availability` (both implemented below).
-			// The full `BackingState` cannot be reconstructed from public runtime APIs because each
-			// pending candidate's `relay_parent_number` is only exposed via a `pub(crate)` accessor
-			// in the SDK, so we keep delegating to the deprecated helper until the trait method
-			// itself is removed (it will be dropped together with the helper, by bumping past the
-			// `ParachainHost` API version that defines it).
+			// Deprecated, but `BackingState` can't be rebuilt from public APIs (pending candidates'
+			// `relay_parent_number` accessor is `pub(crate)`). Keep the helper until the trait
+			// method is removed; clients should use `backing_constraints` +
+			// `candidates_pending_availability`.
 			#[allow(deprecated)]
 			parachains_runtime_api_impl::backing_state::<Runtime>(para_id)
 		}
 
 		fn async_backing_params() -> polkadot_primitives::AsyncBackingParams {
-			// `async_backing_params` is deprecated upstream (validators now derive these values
-			// dynamically from the claim queue). Read the value straight from the configuration
-			// instead of the deprecated helper; this preserves the previous behaviour for any
-			// clients still querying it.
+			// Deprecated upstream: read the configured value directly instead of the helper.
 			parachains_configuration::ActiveConfig::<Runtime>::get().async_backing_params
 		}
 


### PR DESCRIPTION
closes #1199.

Reimplements the `candidate_pending_availability` and `async_backing_params` `ParachainHost` methods on the Polkadot and Kusama relays using their non-deprecated successors and drops the corresponding `#[allow(deprecated)]`, while documenting why `para_backing_state` must keep delegating to the deprecated helper.