### PR TITLE
Asset Hub local/dev genesis: minimal dev_stakers, add opt-in large-staker-set preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Asset Hub Polkadot & Kusama: shrink the `dev`/`local_testnet` genesis presets to a minimal `dev_stakers` set (10 validators + 20 nominators) so local/dev chain specs build in ~2s instead of ~90-113s (raw genesis drops from ~150k-216k storage keys to ~400). The previous large staker set (for staking/election scale testing) is preserved under a new opt-in `local_testnet_large_staker_set` preset, exposed by the chain-spec-generator as `asset-hub-polkadot-local-large-staker-set` / `asset-hub-kusama-local-large-staker-set`. Production/live genesis is unaffected ([#1228](https://github.com/polkadot-fellows/runtimes/pull/1228)).
 - Polkadot & Kusama relay: Disable the `session.set_keys` and `session.purge_keys` extrinsics via `PostAhmFilter`. Post-AHM session keys are managed on Asset Hub and forwarded to the relay through `ah_client::set_keys_from_ah`, so the direct relay path is no longer needed; disabling it closes the free-registration storage-spam vector (the relay `pallet_session::KeyDeposit` stays `()`) ([#1200](https://github.com/polkadot-fellows/runtimes/issues/1200)).
 - Proposal submission deposits for Polkadot Ambassador and Encointer Council Motions ([#1194](https://github.com/polkadot-fellows/runtimes/pull/1194))
 

--- a/chain-spec-generator/src/main.rs
+++ b/chain-spec-generator/src/main.rs
@@ -54,10 +54,22 @@ fn main() -> Result<(), String> {
 				"asset-hub-kusama-local",
 				Box::new(system_parachains_specs::asset_hub_kusama_local_testnet_config) as Box<_>,
 			),
+			#[cfg(feature = "asset-hub-kusama")]
+			(
+				"asset-hub-kusama-local-large-staker-set",
+				Box::new(system_parachains_specs::asset_hub_kusama_local_large_staker_set_config)
+					as Box<_>,
+			),
 			#[cfg(feature = "asset-hub-polkadot")]
 			(
 				"asset-hub-polkadot-local",
 				Box::new(system_parachains_specs::asset_hub_polkadot_local_testnet_config)
+					as Box<_>,
+			),
+			#[cfg(feature = "asset-hub-polkadot")]
+			(
+				"asset-hub-polkadot-local-large-staker-set",
+				Box::new(system_parachains_specs::asset_hub_polkadot_local_large_staker_set_config)
 					as Box<_>,
 			),
 			#[cfg(feature = "collectives-polkadot")]

--- a/chain-spec-generator/src/system_parachains_specs.rs
+++ b/chain-spec-generator/src/system_parachains_specs.rs
@@ -96,6 +96,60 @@ pub fn asset_hub_kusama_local_testnet_config() -> Result<Box<dyn sc_chain_spec::
 	))
 }
 
+/// Local Asset Hub Polkadot with a large staker set seeded at genesis, for exercising
+/// staking/election at scale (Asset Hub staking migration). Building this genesis is slow
+/// and produces a very large chain spec; prefer `asset-hub-polkadot-local` otherwise.
+#[cfg(feature = "asset-hub-polkadot")]
+pub fn asset_hub_polkadot_local_large_staker_set_config(
+) -> Result<Box<dyn sc_chain_spec::ChainSpec>, String> {
+	let mut properties = sc_chain_spec::Properties::new();
+	properties.insert("ss58Format".into(), 0.into());
+	properties.insert("tokenSymbol".into(), "DOT".into());
+	properties.insert("tokenDecimals".into(), 10.into());
+
+	Ok(Box::new(
+		AssetHubPolkadotChainSpec::builder(
+			asset_hub_polkadot_runtime::WASM_BINARY.expect("AssetHubPolkadot wasm not available!"),
+			Extensions { relay_chain: "polkadot-local".into(), para_id: 1000 },
+		)
+		.with_name("Polkadot Asset Hub Local (large staker set)")
+		.with_id("asset-hub-polkadot-local-large-staker-set")
+		.with_chain_type(sc_chain_spec::ChainType::Local)
+		.with_genesis_config_preset_name(
+			asset_hub_polkadot_runtime::genesis_config_presets::LOCAL_TESTNET_LARGE_STAKER_SET,
+		)
+		.with_properties(properties)
+		.build(),
+	))
+}
+
+/// Local Asset Hub Kusama with a large staker set seeded at genesis, for exercising
+/// staking/election at scale (Asset Hub staking migration). Building this genesis is slow
+/// and produces a very large chain spec; prefer `asset-hub-kusama-local` otherwise.
+#[cfg(feature = "asset-hub-kusama")]
+pub fn asset_hub_kusama_local_large_staker_set_config(
+) -> Result<Box<dyn sc_chain_spec::ChainSpec>, String> {
+	let mut properties = sc_chain_spec::Properties::new();
+	properties.insert("ss58Format".into(), 2.into());
+	properties.insert("tokenSymbol".into(), "KSM".into());
+	properties.insert("tokenDecimals".into(), 12.into());
+
+	Ok(Box::new(
+		AssetHubKusamaChainSpec::builder(
+			asset_hub_kusama_runtime::WASM_BINARY.expect("AssetHubKusama wasm not available!"),
+			Extensions { relay_chain: "kusama-local".into(), para_id: 1000 },
+		)
+		.with_name("Kusama Asset Hub Local (large staker set)")
+		.with_id("asset-hub-kusama-local-large-staker-set")
+		.with_chain_type(sc_chain_spec::ChainType::Local)
+		.with_genesis_config_preset_name(
+			asset_hub_kusama_runtime::genesis_config_presets::LOCAL_TESTNET_LARGE_STAKER_SET,
+		)
+		.with_properties(properties)
+		.build(),
+	))
+}
+
 #[cfg(feature = "collectives-polkadot")]
 pub fn collectives_polkadot_local_testnet_config(
 ) -> Result<Box<dyn sc_chain_spec::ChainSpec>, String> {

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/genesis_config_presets.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/genesis_config_presets.rs
@@ -27,12 +27,29 @@ use xcm_executor::traits::ConvertLocation;
 
 const ASSET_HUB_KUSAMA_ED: Balance = ExistentialDeposit::get();
 
+/// Minimal set of dev stakers `(validators, nominators)` used by the `dev`/`local_testnet`
+/// presets. Keeps pallet-staking(-async) and its election functional on local/dev networks
+/// while avoiding the ~108s genesis `build_state` cost (and ~77MB raw chain spec) of the
+/// large scale-testing set. Note: Asset Hub block production runs on collators
+/// (`collatorSelection` + `session`), so staking is not required to author blocks here.
+const LOCAL_DEV_STAKERS: Option<(u32, u32)> = Some((10, 20));
+
+/// Large staker set `(validators, nominators)` for exercising staking/election at a realistic
+/// scale (opt-in `local_testnet_large_staker_set` preset only). Building this state is slow and
+/// produces a very large genesis, so it must not be used by the default local/dev networks.
+const LARGE_DEV_STAKERS: Option<(u32, u32)> = Some((4_000, 15_000));
+
+/// Preset id for a local testnet that seeds a large staker set for staking/election scale
+/// testing (Asset Hub staking migration). This is intentionally expensive to build.
+pub const LOCAL_TESTNET_LARGE_STAKER_SET: &str = "local_testnet_large_staker_set";
+
 fn asset_hub_kusama_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	endowed_accounts: Vec<AccountId>,
 	id: ParaId,
 	foreign_assets: Vec<(Location, AccountId, Balance)>,
 	foreign_assets_endowed_accounts: Vec<(Location, AccountId, Balance)>,
+	dev_stakers: Option<(u32, u32)>,
 ) -> serde_json::Value {
 	serde_json::json!({
 		"balances": BalancesConfig {
@@ -70,7 +87,7 @@ fn asset_hub_kusama_genesis(
 		},
 		"staking": {
 			"validatorCount": 1000,
-			"devStakers": Some((4_000, 15_000)),
+			"devStakers": dev_stakers,
 		},
 		"foreignAssets": ForeignAssetsConfig {
 			assets: foreign_assets
@@ -93,7 +110,10 @@ fn asset_hub_kusama_genesis(
 	})
 }
 
-pub fn asset_hub_kusama_local_testnet_genesis(para_id: ParaId) -> serde_json::Value {
+pub fn asset_hub_kusama_local_testnet_genesis(
+	para_id: ParaId,
+	dev_stakers: Option<(u32, u32)>,
+) -> serde_json::Value {
 	asset_hub_kusama_genesis(
 		invulnerables(),
 		testnet_accounts(),
@@ -117,6 +137,7 @@ pub fn asset_hub_kusama_local_testnet_genesis(para_id: ParaId) -> serde_json::Va
 				10000000 * 4096 * 4096,
 			),
 		],
+		dev_stakers,
 	)
 }
 
@@ -130,6 +151,7 @@ fn asset_hub_kusama_development_genesis(para_id: ParaId) -> serde_json::Value {
 		para_id,
 		vec![],
 		vec![],
+		LOCAL_DEV_STAKERS,
 	)
 }
 
@@ -138,6 +160,7 @@ pub fn preset_names() -> Vec<PresetId> {
 	vec![
 		PresetId::from(sp_genesis_builder::DEV_RUNTIME_PRESET),
 		PresetId::from(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET),
+		PresetId::from(LOCAL_TESTNET_LARGE_STAKER_SET),
 	]
 }
 
@@ -146,7 +169,9 @@ pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	let patch = match id.as_ref() {
 		sp_genesis_builder::DEV_RUNTIME_PRESET => asset_hub_kusama_development_genesis(1000.into()),
 		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET =>
-			asset_hub_kusama_local_testnet_genesis(1000.into()),
+			asset_hub_kusama_local_testnet_genesis(1000.into(), LOCAL_DEV_STAKERS),
+		LOCAL_TESTNET_LARGE_STAKER_SET =>
+			asset_hub_kusama_local_testnet_genesis(1000.into(), LARGE_DEV_STAKERS),
 		_ => return None,
 	};
 	Some(

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/genesis_config_presets.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/genesis_config_presets.rs
@@ -29,6 +29,22 @@ use xcm_executor::traits::ConvertLocation;
 
 const ASSET_HUB_POLKADOT_ED: Balance = ExistentialDeposit::get();
 
+/// Minimal set of dev stakers `(validators, nominators)` used by the `dev`/`local_testnet`
+/// presets. Keeps pallet-staking(-async) and its election functional on local/dev networks
+/// while avoiding the ~108s genesis `build_state` cost (and ~77MB raw chain spec) of the
+/// large scale-testing set. Note: Asset Hub block production runs on collators
+/// (`collatorSelection` + `session`), so staking is not required to author blocks here.
+const LOCAL_DEV_STAKERS: Option<(u32, u32)> = Some((10, 20));
+
+/// Large staker set `(validators, nominators)` for exercising staking/election at a realistic
+/// scale (opt-in `local_testnet_large_staker_set` preset only). Building this state is slow and
+/// produces a very large genesis, so it must not be used by the default local/dev networks.
+const LARGE_DEV_STAKERS: Option<(u32, u32)> = Some((2_000, 25_000));
+
+/// Preset id for a local testnet that seeds a large staker set for staking/election scale
+/// testing (Asset Hub staking migration). This is intentionally expensive to build.
+pub const LOCAL_TESTNET_LARGE_STAKER_SET: &str = "local_testnet_large_staker_set";
+
 /// Invulnerable Collators for the particular case of AssetHubPolkadot
 pub fn invulnerables_asset_hub_polkadot() -> Vec<(AccountId, AssetHubPolkadotAuraId)> {
 	vec![
@@ -49,6 +65,7 @@ fn asset_hub_polkadot_genesis(
 	id: ParaId,
 	foreign_assets: Vec<(Location, AccountId, Balance)>,
 	foreign_assets_endowed_accounts: Vec<(Location, AccountId, Balance)>,
+	dev_stakers: Option<(u32, u32)>,
 ) -> serde_json::Value {
 	let mut balances: Vec<(AccountId, Balance)> = endowed_accounts
 		.iter()
@@ -90,7 +107,7 @@ fn asset_hub_polkadot_genesis(
 		},
 		"staking": {
 			"validatorCount": 600,
-			"devStakers": Some((2_000, 25_000)),
+			"devStakers": dev_stakers,
 		},
 		"foreignAssets": ForeignAssetsConfig {
 			assets: foreign_assets
@@ -113,7 +130,10 @@ fn asset_hub_polkadot_genesis(
 	})
 }
 
-pub fn asset_hub_polkadot_local_testnet_genesis(para_id: ParaId) -> serde_json::Value {
+pub fn asset_hub_polkadot_local_testnet_genesis(
+	para_id: ParaId,
+	dev_stakers: Option<(u32, u32)>,
+) -> serde_json::Value {
 	asset_hub_polkadot_genesis(
 		invulnerables_asset_hub_polkadot(),
 		testnet_accounts(),
@@ -137,6 +157,7 @@ pub fn asset_hub_polkadot_local_testnet_genesis(para_id: ParaId) -> serde_json::
 				10000000 * 4096 * 4096,
 			),
 		],
+		dev_stakers,
 	)
 }
 
@@ -147,6 +168,7 @@ fn asset_hub_polkadot_development_genesis(para_id: ParaId) -> serde_json::Value 
 		para_id,
 		vec![],
 		vec![],
+		LOCAL_DEV_STAKERS,
 	)
 }
 
@@ -155,6 +177,7 @@ pub fn preset_names() -> Vec<PresetId> {
 	vec![
 		PresetId::from(sp_genesis_builder::DEV_RUNTIME_PRESET),
 		PresetId::from(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET),
+		PresetId::from(LOCAL_TESTNET_LARGE_STAKER_SET),
 	]
 }
 
@@ -164,7 +187,9 @@ pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 		sp_genesis_builder::DEV_RUNTIME_PRESET =>
 			asset_hub_polkadot_development_genesis(1000.into()),
 		sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET =>
-			asset_hub_polkadot_local_testnet_genesis(1000.into()),
+			asset_hub_polkadot_local_testnet_genesis(1000.into(), LOCAL_DEV_STAKERS),
+		LOCAL_TESTNET_LARGE_STAKER_SET =>
+			asset_hub_polkadot_local_testnet_genesis(1000.into(), LARGE_DEV_STAKERS),
 		_ => return None,
 	};
 	Some(


### PR DESCRIPTION
## Problem / Context

The Asset Hub Polkadot & Kusama `dev`/`local_testnet` genesis presets seed a large `dev_stakers` set — `(2000, 25000)` for Polkadot and `(4000, 15000)` for Kusama. These stakers are generated programmatically in `pallet-staking-async`'s `build_state`, which makes the **raw** local chain spec huge and slow to build and dominates local/zombienet network spawn time — even though a local network authors blocks via collators (`collatorSelection` + `session`), not staking.

- **Discovered while** doing some Polkadot/Kusama bridges testing — paritytech/parity-bridges-common#3299.
- **Originally introduced** as part of the Asset Hub Migration (AHM) in #856 ([this line](https://github.com/polkadot-fellows/runtimes/pull/856/changes#diff-4181a5e90d735e214ba911625514bded1f1528341bf7c25ff4b6ab14b52e9cf6R72)), which points to staking/election testing at migration scale.

## Proposed solution

Reduce the `dev`/`local_testnet` presets to the **minimal `dev_stakers` that still fills an election snapshot page** (so the multi-block election and its benchmarks keep working): `(2000, 1500)` for Polkadot, `(2500, 1600)` for Kusama — i.e. `TargetSnapshotPerBlock` validators and `2 × VoterSnapshotPerBlock` nominators. Move the original oversized set to a new **opt-in** `local_testnet_large_staker_set` preset (exposed by the chain-spec-generator as `asset-hub-{polkadot,kusama}-local-large-staker-set`).

Production genesis is **unchanged**.

## Numbers

```sh
# build (once)
cargo build --release -p chain-spec-generator --no-default-features \
  --features fast-runtime,asset-hub-polkadot,asset-hub-kusama

# per row: generate raw spec + measure
time ./target/release/chain-spec-generator <chain> --raw > raw.json
jq -r '.genesis.raw.top | keys | length' raw.json   # keys
ls -lh raw.json                                      # size
```

> Timings are the `--raw` generation (genesis `build_state`), **not** the one-time `cargo build` (a fixed compile cost, unaffected by this change).

| preset | `chain-spec-generator <chain> --raw` | `dev_stakers` | raw keys | size | `--raw` gen time |
|---|---|---|--:|--:|--:|
| `local_testnet` (= `dev`) | `asset-hub-polkadot-local` | (2000, 1500) | **28,204** | 14 MiB | **15.9s** |
| `local_testnet` (= `dev`) | `asset-hub-kusama-local` | (2500, 1600) | **32,996** | 16 MiB | **18.8s** |
| `local_testnet_large_staker_set` | `asset-hub-polkadot-local-large-staker-set` | (2000, 25000) | 216,227 | **81 MiB** | **114.2s** |
| `local_testnet_large_staker_set` | `asset-hub-kusama-local-large-staker-set` | (4000, 15000) | 152,206 | **64 MiB** | **82.6s** |

For reference, before this PR `local_testnet` used the large set, so `asset-hub-*-local` took ~82–114s to build; it now builds in ~16–19s while keeping the election functional.

Both lean specs still author blocks:

```sh
polkadot-omni-node --chain raw.json --dev-block-time 1000 --tmp
```

## TODO / open questions

- [ ] What is the purpose of this large `dev_stakers` set — staking benchmarking, plain local testing, or the Asset Hub Migration (AHM)?
- [ ] Do we still need it this big?
- [ ] If it must stay the default for `dev`/`local_testnet`, I can flip the approach instead: keep the large set as the default and add a dedicated `local_minimal_stakers` preset for the lean/fast case.


