### PR TITLE
Polkadot People Chain: use 2s block instead of 0.5s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog for the runtimes governed by the Polkadot Fellowship.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- People Polkadot: raise the block weight limit to the `async_backing` constants (2s of ref time, 85% normal dispatch ratio) from `parachains_common`'s pre-async-backing pair (0.5s, 75%). This chain already authors a block every 2s under `elastic_scaling` consensus, and each block is validated on its own core, so it may use a full core's PVF execution budget — Asset Hub Polkadot runs the identical consensus config and is already configured this way. The old pairing was a leftover from the elastic-scaling switch rather than a conservative choice: at 3 blocks per 6s relay slot it granted 1.5s of compute per 6s, less total throughput than a plain async-backing chain, at triple the block production cost.
+
 ## [2.3.2] 23.07.2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- People Polkadot: raise the block weight limit to the `async_backing` constants (2s of ref time, 85% normal dispatch ratio) from `parachains_common`'s pre-async-backing pair (0.5s, 75%). This chain already authors a block every 2s under `elastic_scaling` consensus, and each block is validated on its own core, so it may use a full core's PVF execution budget — Asset Hub Polkadot runs the identical consensus config and is already configured this way. The old pairing was a leftover from the elastic-scaling switch rather than a conservative choice: at 3 blocks per 6s relay slot it granted 1.5s of compute per 6s, less total throughput than a plain async-backing chain, at triple the block production cost.
+- People Polkadot: raise the block weight limit to the `async_backing` constants (2s of ref time, 85% normal dispatch ratio) from `parachains_common`'s pre-async-backing pair (0.5s, 75%). This chain already authors a block every 2s under `elastic_scaling` consensus. It is now closer to Asset Hub Polkadot config.
 
 ## [2.3.2] 23.07.2026
 

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -52,8 +52,7 @@ use frame_system::{
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
 use parachains_common::{
 	message_queue::{NarrowOriginToSibling, ParaIdToSibling},
-	AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature, AVERAGE_ON_INITIALIZE_RATIO,
-	HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	AccountId, Balance, BlockNumber, Hash, Header, Nonce, Signature, HOURS,
 };
 
 use polkadot_runtime_common::{BlockHashCount, SlowAdjustingFeeUpdate};
@@ -73,15 +72,27 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use system_parachains_constants::polkadot::{
-	consensus::{
-		elastic_scaling::{
-			BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
+// The block weight comes from `async_backing` (2s of ref time, 85% normal dispatch ratio), matching
+// Asset Hub Polkadot, which runs the identical `elastic_scaling` consensus config below.
+//
+// This chain previously paired that config with `parachains_common`'s pre-async-backing pair
+// (0.5s, 75%), which was a leftover from the switch to elastic scaling rather than a deliberately
+// conservative choice: at 3 blocks per 6s relay slot it granted 1.5s of compute per 6s, i.e. *less*
+// total throughput than a plain async-backing chain gets from one 2s block, at triple the block
+// production cost. Each of these 2s blocks is validated on its own core, so it may use a full
+// core's 2s PVF execution budget.
+use system_parachains_constants::{
+	async_backing::{AVERAGE_ON_INITIALIZE_RATIO, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO},
+	polkadot::{
+		consensus::{
+			elastic_scaling::{
+				BLOCK_PROCESSING_VELOCITY, RELAY_PARENT_OFFSET, UNINCLUDED_SEGMENT_CAPACITY,
+			},
+			RELAY_CHAIN_SLOT_DURATION_MILLIS,
 		},
-		RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		currency::*,
+		fee::WeightToFee as DotWeightToFee,
 	},
-	currency::*,
-	fee::WeightToFee as DotWeightToFee,
 };
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use xcm::{

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -72,15 +72,6 @@ pub use sp_runtime::{MultiAddress, Perbill, Permill};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-// The block weight comes from `async_backing` (2s of ref time, 85% normal dispatch ratio), matching
-// Asset Hub Polkadot, which runs the identical `elastic_scaling` consensus config below.
-//
-// This chain previously paired that config with `parachains_common`'s pre-async-backing pair
-// (0.5s, 75%), which was a leftover from the switch to elastic scaling rather than a deliberately
-// conservative choice: at 3 blocks per 6s relay slot it granted 1.5s of compute per 6s, i.e. *less*
-// total throughput than a plain async-backing chain gets from one 2s block, at triple the block
-// production cost. Each of these 2s blocks is validated on its own core, so it may use a full
-// core's 2s PVF execution budget.
 use system_parachains_constants::{
 	async_backing::{AVERAGE_ON_INITIALIZE_RATIO, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO},
 	polkadot::{


### PR DESCRIPTION
Polkadot People Chain is using elastic scaling, let's use the 2s block weight that is available, given the future usage we want to make of it.

```

Directly changed — import source swapped parachains_common → system_parachains_constants::async_backing

┌─────────────────────────────┬───────────────────────────┬──────────────────────────┐
│          Constant           │          Before           │          After           │
├─────────────────────────────┼───────────────────────────┼──────────────────────────┤
│ MAXIMUM_BLOCK_WEIGHT        │ ref_time 0.5 s (5×10¹¹    │ ref_time 2 s (2×10¹²     │
│                             │ ps), proof_size 5 MiB     │ ps), proof_size 5 MiB    │
├─────────────────────────────┼───────────────────────────┼──────────────────────────┤
│ NORMAL_DISPATCH_RATIO       │ 75 %                      │ 85 %                     │
│                             │                           │                          │
├─────────────────────────────┼───────────────────────────┼──────────────────────────┤
│ AVERAGE_ON_INITIALIZE_RATIO │ 5 %                       │ 5 %                      │
│                             │                           │                          │
└─────────────────────────────┴───────────────────────────┴──────────────────────────┘

Derived — same formulas, new inputs
┌─────────────────────────────────┬───────────────────────────────────────────────┬────────────┬────────────┐
│              Value              │                    Formula                    │   Before   │   After    │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ Normal.max_total                │ NDR × MBW                                     │ 0.375 s    │ 1.7 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ Normal.max_extrinsic            │ max_total − base_extrinsic − block_init       │ 0.349875 s │ 1.599875 s │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ Operational.max_total           │ MBW                                           │ 0.5 s      │ 2 s        │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ Operational.reserved            │ MBW − NDR×MBW                                 │ 0.125 s    │ 0.3 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ block init allowance            │ AOIR × max_block                              │ 0.025 s    │ 0.1 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ ReservedXcmpWeight              │ MBW / 4                                       │ 0.125 s    │ 0.5 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ ReservedDmpWeight               │ MBW / 4                                       │ 0.125 s    │ 0.5 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ MessageQueueServiceWeight       │ 35 % × max_block                              │ 0.175 s    │ 0.7 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ MessageQueueIdleServiceWeight   │ 20 % × max_block                              │ 0.1 s      │ 0.4 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ MbmServiceWeight                │ 80 % × max_block                              │ 0.4 s      │ 1.6 s      │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ RuntimeBlockLength normal class │ NDR × 5 MiB                                   │ 3.75 MiB   │ 4.25 MiB   │
├─────────────────────────────────┼───────────────────────────────────────────────┼────────────┼────────────┤
│ fee multiplier target           │ TARGET_BLOCK_FULLNESS 25 % × Normal max_total │ 0.09375 s  │ 0.425 s    │
└─────────────────────────────────┴───────────────────────────────────────────────┴────────────┴────────────┘
```