### PR TITLE
Cap individual MBM migrations to one day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Asset Hub Polkadot & Kusama: fix `pallet-remote-proxy` dropping the newest relay storage root when multiple parachain blocks share one relay parent. `on_validation_data` now skips storing duplicate relay blocks, which used to fill the bounded `BlockToRoot` vector with copies too young to prune and silently drop the newest root, so remote-proxy proofs anchored at recent relay blocks no longer fail with `UnknownProofAnchorBlock` ([#1230](https://github.com/polkadot-fellows/runtimes/issues/1230)).
 ### Changed
 
-- Asset Hub Polkadot & Kusama, People Polkadot & Kusama: cap the duration of every configured multi-block migration at one day (43_200 blocks at 2s, 14_400 blocks on the 6s People Kusama). 
+- Asset Hub Polkadot & Kusama, People Polkadot & Kusama: cap the duration of every configured multi-block migration at one day (43_200 blocks at 2s, 14_400 blocks on the 6s People Kusama) ([#1238](https://github.com/polkadot-fellows/runtimes/pull/1238)).
 - People Polkadot: raise the block weight limit to the `async_backing` constants (2s of ref time, 85% normal dispatch ratio) from `parachains_common`'s pre-async-backing pair (0.5s, 75%). This chain already authors a block every 2s under `elastic_scaling` consensus. It is now closer to Asset Hub Polkadot config.
 
 ## [2.3.2] 23.07.2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Asset Hub Polkadot & Kusama: fix `pallet-remote-proxy` dropping the newest relay storage root when multiple parachain blocks share one relay parent. `on_validation_data` now skips storing duplicate relay blocks, which used to fill the bounded `BlockToRoot` vector with copies too young to prune and silently drop the newest root, so remote-proxy proofs anchored at recent relay blocks no longer fail with `UnknownProofAnchorBlock` ([#1230](https://github.com/polkadot-fellows/runtimes/issues/1230)).
 ### Changed
 
+- Asset Hub Polkadot & Kusama, People Polkadot & Kusama: cap the duration of every configured multi-block migration at one day (43_200 blocks at 2s, 14_400 blocks on the 6s People Kusama). 
 - People Polkadot: raise the block weight limit to the `async_backing` constants (2s of ref time, 85% normal dispatch ratio) from `parachains_common`'s pre-async-backing pair (0.5s, 75%). This chain already authors a block every 2s under `elastic_scaling` consensus. It is now closer to Asset Hub Polkadot config.
 
 ## [2.3.2] 23.07.2026

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18818,6 +18818,7 @@ dependencies = [
  "polkadot-primitives",
  "scale-info",
  "sp-api 42.0.0",
+ "sp-io 46.0.0",
  "sp-runtime 47.0.0",
  "sp-state-machine 0.51.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12039,6 +12039,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "system-parachains-common",
  "system-parachains-constants",
  "xcm-runtime-apis",
 ]
@@ -12157,6 +12158,7 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
+ "system-parachains-common",
  "system-parachains-constants",
  "xcm-runtime-apis",
 ]

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/migrations.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/migrations.rs
@@ -146,11 +146,21 @@ mod multiblock_migrations {
 		migrations::foreign_assets_reserves::ForeignAssetsReservesProvider,
 	};
 	use frame_support::traits::Contains;
+	use system_parachains_common::migrations::MaxStepsCapped;
 	use xcm::v5::{Junction, Location};
 	use xcm_builder::StartsWith;
 
+	parameter_types! {
+		/// One day at the 2s block time of this chain.
+		///
+		/// No single MBM may block the chain for longer than this.
+		pub const MbmMaxBlocks: u32 = 43_200;
+	}
+
 	/// MBM migrations to apply on runtime upgrade.
-	pub type MbmMigrations = (
+	pub type MbmMigrations = MaxStepsCapped<UncappedMbmMigrations, MbmMaxBlocks>;
+
+	type UncappedMbmMigrations = (
 		assets_common::migrations::foreign_assets_reserves::ForeignAssetsReservesMigration<
 			Runtime,
 			ForeignAssetsInstance,
@@ -264,6 +274,20 @@ mod multiblock_migrations {
 					// unexpected asset
 					_ => false,
 				}
+			}
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+		use frame_support::migrations::SteppedMigrations;
+
+		#[test]
+		fn no_mbm_can_run_for_longer_than_a_day() {
+			for n in 0..MbmMigrations::len() {
+				let max_steps = MbmMigrations::nth_max_steps(n).expect("n < len; qed");
+				assert!(max_steps.is_some_and(|max| max <= MbmMaxBlocks::get()));
 			}
 		}
 	}

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/migrations.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/migrations.rs
@@ -193,11 +193,21 @@ mod multiblock_migrations {
 		migrations::foreign_assets_reserves::ForeignAssetsReservesProvider,
 	};
 	use frame_support::traits::Contains;
+	use system_parachains_common::migrations::MaxStepsCapped;
 	use xcm::v5::{Junction, Location};
 	use xcm_builder::StartsWith;
 
+	parameter_types! {
+		/// One day at the 2s block time of this chain.
+		///
+		/// No single MBM may block the chain for longer than this.
+		pub const MbmMaxBlocks: u32 = 43_200;
+	}
+
 	/// MBM migrations to apply on runtime upgrade.
-	pub type MbmMigrations = (
+	pub type MbmMigrations = MaxStepsCapped<UncappedMbmMigrations, MbmMaxBlocks>;
+
+	type UncappedMbmMigrations = (
 		assets_common::migrations::foreign_assets_reserves::ForeignAssetsReservesMigration<
 			Runtime,
 			ForeignAssetsInstance,
@@ -308,6 +318,20 @@ mod multiblock_migrations {
 					// unexpected asset
 					_ => false,
 				}
+			}
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+		use frame_support::migrations::SteppedMigrations;
+
+		#[test]
+		fn no_mbm_can_run_for_longer_than_a_day() {
+			for n in 0..MbmMigrations::len() {
+				let max_steps = MbmMigrations::nth_max_steps(n).expect("n < len; qed");
+				assert!(max_steps.is_some_and(|max| max <= MbmMaxBlocks::get()));
 			}
 		}
 	}

--- a/system-parachains/common/Cargo.toml
+++ b/system-parachains/common/Cargo.toml
@@ -21,6 +21,9 @@ cumulus-pallet-parachain-system = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 polkadot-primitives = { workspace = true }
 
+[dev-dependencies]
+sp-io = { workspace = true }
+
 [features]
 default = ["std"]
 std = [
@@ -32,6 +35,7 @@ std = [
 	"polkadot-primitives/std",
 	"scale-info/std",
 	"sp-api/std",
+	"sp-io/std",
 	"sp-runtime/std",
 	"sp-state-machine/std",
 ]

--- a/system-parachains/common/src/lib.rs
+++ b/system-parachains/common/src/lib.rs
@@ -17,6 +17,9 @@
 //! Shared types between system-parachains runtimes.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
+pub mod migrations;
 pub mod randomness;
 
 /// Extra runtime APIs.

--- a/system-parachains/common/src/migrations.rs
+++ b/system-parachains/common/src/migrations.rs
@@ -167,10 +167,13 @@ mod tests {
 		let mut meter = WeightMeter::new();
 		assert!(matches!(Capped::nth_step(1, None, &mut meter), Some(Ok(None))));
 
-		sp_state_machine::BasicExternalities::default().execute_with(|| {
+		sp_io::TestExternalities::default().execute_with(|| {
 			assert!(matches!(Capped::nth_transactional_step(1, None, &mut meter), Some(Ok(None))));
 
-			// The cap does not change how the pallet sees the tuple otherwise.
+			// `pallet-migrations` calls this on its `Migrations` in its own `integrity_test`,
+			// which would abort the runtime if it failed. Wrapping the tuple must keep it
+			// passing: every index below `len()` must still resolve to an id, a `max_steps`
+			// and a step.
 			Capped::integrity_test().unwrap();
 		});
 	}

--- a/system-parachains/common/src/migrations.rs
+++ b/system-parachains/common/src/migrations.rs
@@ -1,0 +1,177 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot. If not, see <http://www.gnu.org/licenses/>.
+
+//! Shared helpers for the multi-block migrations of the system parachains.
+
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use frame_support::{
+	migrations::{SteppedMigrationError, SteppedMigrations},
+	traits::Get,
+	weights::WeightMeter,
+};
+
+/// Caps the [`SteppedMigration::max_steps`] of every migration in `M` at `Cap`.
+///
+/// `pallet-migrations` advances a migration at most once per block and compares its `max_steps`
+/// against the number of blocks that the migration has been running for. A step limit is therefore
+/// a duration limit, and capping it bounds how long a single migration can block the chain.
+///
+/// A migration that does not declare a `max_steps` of its own is unbounded and would keep the
+/// chain in migration mode forever if it never makes progress. This wrapper closes that gap: the
+/// cap applies both as a fallback for `None` and as an upper bound for migrations that ask for
+/// more.
+///
+/// Note that the cap is per migration, so the aggregated tuple can still take `len() * Cap`
+/// blocks. A migration exceeding the cap is treated as failed and handed to the
+/// [`frame_support::migrations::FailedMigrationHandler`] of the runtime.
+///
+/// [`SteppedMigration::max_steps`]: frame_support::migrations::SteppedMigration::max_steps
+pub struct MaxStepsCapped<M, Cap>(PhantomData<(M, Cap)>);
+
+impl<M: SteppedMigrations, Cap: Get<u32>> SteppedMigrations for MaxStepsCapped<M, Cap> {
+	fn len() -> u32 {
+		M::len()
+	}
+
+	fn nth_id(n: u32) -> Option<Vec<u8>> {
+		M::nth_id(n)
+	}
+
+	fn nth_max_steps(n: u32) -> Option<Option<u32>> {
+		M::nth_max_steps(n)
+			.map(|max_steps| Some(max_steps.map_or(Cap::get(), |m| m.min(Cap::get()))))
+	}
+
+	fn nth_step(
+		n: u32,
+		cursor: Option<Vec<u8>>,
+		meter: &mut WeightMeter,
+	) -> Option<Result<Option<Vec<u8>>, SteppedMigrationError>> {
+		M::nth_step(n, cursor, meter)
+	}
+
+	fn nth_transactional_step(
+		n: u32,
+		cursor: Option<Vec<u8>>,
+		meter: &mut WeightMeter,
+	) -> Option<Result<Option<Vec<u8>>, SteppedMigrationError>> {
+		M::nth_transactional_step(n, cursor, meter)
+	}
+
+	fn nth_migrating_prefixes(n: u32) -> Option<Option<Vec<Vec<u8>>>> {
+		M::nth_migrating_prefixes(n)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn nth_pre_upgrade(n: u32) -> Option<Result<Vec<u8>, sp_runtime::TryRuntimeError>> {
+		M::nth_pre_upgrade(n)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn nth_post_upgrade(n: u32, state: Vec<u8>) -> Option<Result<(), sp_runtime::TryRuntimeError>> {
+		M::nth_post_upgrade(n, state)
+	}
+
+	fn cursor_max_encoded_len() -> usize {
+		M::cursor_max_encoded_len()
+	}
+
+	fn identifier_max_encoded_len() -> usize {
+		M::identifier_max_encoded_len()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use frame_support::{migrations::SteppedMigration, traits::ConstU32};
+
+	/// A migration that declares `MAX_STEPS` as its step limit, or none if it is `u32::MAX`.
+	struct Migration<const ID: u8, const MAX_STEPS: u32>;
+
+	impl<const ID: u8, const MAX_STEPS: u32> SteppedMigration for Migration<ID, MAX_STEPS> {
+		type Cursor = u64;
+		type Identifier = u8;
+
+		fn id() -> Self::Identifier {
+			ID
+		}
+
+		fn max_steps() -> Option<u32> {
+			(MAX_STEPS != u32::MAX).then_some(MAX_STEPS)
+		}
+
+		fn step(
+			_cursor: Option<Self::Cursor>,
+			_meter: &mut WeightMeter,
+		) -> Result<Option<Self::Cursor>, SteppedMigrationError> {
+			Ok(None)
+		}
+	}
+
+	/// Declares no `max_steps`.
+	type Unbounded = Migration<0, { u32::MAX }>;
+	/// Declares a `max_steps` below the cap.
+	type Short = Migration<1, 10>;
+	/// Declares a `max_steps` above the cap.
+	type Long = Migration<2, 1_000>;
+
+	type Migrations = (Unbounded, Short, Long);
+	type Capped = MaxStepsCapped<Migrations, ConstU32<100>>;
+
+	#[test]
+	fn unset_max_steps_falls_back_to_the_cap() {
+		assert_eq!(Migrations::nth_max_steps(0), Some(None));
+		assert_eq!(Capped::nth_max_steps(0), Some(Some(100)));
+	}
+
+	#[test]
+	fn max_steps_below_the_cap_is_kept() {
+		assert_eq!(Capped::nth_max_steps(1), Some(Some(10)));
+	}
+
+	#[test]
+	fn max_steps_above_the_cap_is_capped() {
+		assert_eq!(Migrations::nth_max_steps(2), Some(Some(1_000)));
+		assert_eq!(Capped::nth_max_steps(2), Some(Some(100)));
+	}
+
+	#[test]
+	fn out_of_bounds_index_stays_none() {
+		assert_eq!(Capped::nth_max_steps(3), None);
+		assert_eq!(Capped::nth_id(3), None);
+	}
+
+	#[test]
+	fn everything_else_is_forwarded() {
+		assert_eq!(Capped::len(), Migrations::len());
+		assert_eq!(Capped::nth_id(1), Migrations::nth_id(1));
+		assert_eq!(Capped::nth_migrating_prefixes(1), Migrations::nth_migrating_prefixes(1));
+		assert_eq!(Capped::cursor_max_encoded_len(), Migrations::cursor_max_encoded_len());
+		assert_eq!(Capped::identifier_max_encoded_len(), Migrations::identifier_max_encoded_len());
+
+		let mut meter = WeightMeter::new();
+		assert!(matches!(Capped::nth_step(1, None, &mut meter), Some(Ok(None))));
+
+		sp_state_machine::BasicExternalities::default().execute_with(|| {
+			assert!(matches!(Capped::nth_transactional_step(1, None, &mut meter), Some(Ok(None))));
+
+			// The cap does not change how the pallet sees the tuple otherwise.
+			Capped::integrity_test().unwrap();
+		});
+	}
+}

--- a/system-parachains/people/people-kusama/Cargo.toml
+++ b/system-parachains/people/people-kusama/Cargo.toml
@@ -74,6 +74,7 @@ cumulus-primitives-utility = { workspace = true }
 pallet-collator-selection = { workspace = true }
 parachain-info = { workspace = true }
 parachains-common = { workspace = true }
+system-parachains-common = { workspace = true }
 system-parachains-constants = { workspace = true }
 
 [dev-dependencies]
@@ -143,6 +144,7 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
+	"system-parachains-common/std",
 	"system-parachains-constants/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
@@ -180,6 +182,7 @@ runtime-benchmarks = [
 	"polkadot-primitives/runtime-benchmarks",
 	"polkadot-runtime-common/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"system-parachains-common/runtime-benchmarks",
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
@@ -215,6 +218,7 @@ try-runtime = [
 	"parachains-common/try-runtime",
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
+	"system-parachains-common/try-runtime",
 	"system-parachains-constants/try-runtime",
 ]
 

--- a/system-parachains/people/people-kusama/src/lib.rs
+++ b/system-parachains/people/people-kusama/src/lib.rs
@@ -153,8 +153,18 @@ pub mod migrations {
 	/// All migrations that will run on the next runtime upgrade.
 	pub type SingleBlockMigrations = (Unreleased, Permanent);
 
+	parameter_types! {
+		/// One day at the 6s block time of this chain.
+		///
+		/// No single MBM may block the chain for longer than this.
+		pub const MbmMaxBlocks: u32 = 14_400;
+	}
+
 	/// MBM migrations to apply on runtime upgrade.
-	pub type MbmMigrations = ();
+	pub type MbmMigrations =
+		system_parachains_common::migrations::MaxStepsCapped<UncappedMbmMigrations, MbmMaxBlocks>;
+
+	type UncappedMbmMigrations = ();
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/system-parachains/people/people-kusama/src/lib.rs
+++ b/system-parachains/people/people-kusama/src/lib.rs
@@ -165,6 +165,20 @@ pub mod migrations {
 		system_parachains_common::migrations::MaxStepsCapped<UncappedMbmMigrations, MbmMaxBlocks>;
 
 	type UncappedMbmMigrations = ();
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+		use frame_support::migrations::SteppedMigrations;
+
+		#[test]
+		fn no_mbm_can_run_for_longer_than_a_day() {
+			for n in 0..MbmMigrations::len() {
+				let max_steps = MbmMigrations::nth_max_steps(n).expect("n < len; qed");
+				assert!(max_steps.is_some_and(|max| max <= MbmMaxBlocks::get()));
+			}
+		}
+	}
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/system-parachains/people/people-polkadot/Cargo.toml
+++ b/system-parachains/people/people-polkadot/Cargo.toml
@@ -78,6 +78,7 @@ cumulus-primitives-utility = { workspace = true }
 pallet-collator-selection = { workspace = true }
 parachain-info = { workspace = true }
 parachains-common = { workspace = true }
+system-parachains-common = { workspace = true }
 system-parachains-constants = { workspace = true }
 
 [dev-dependencies]
@@ -151,6 +152,7 @@ std = [
 	"sp-transaction-pool/std",
 	"sp-version/std",
 	"substrate-wasm-builder",
+	"system-parachains-common/std",
 	"system-parachains-constants/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
@@ -192,6 +194,7 @@ runtime-benchmarks = [
 	"polkadot-runtime-common/runtime-benchmarks",
 	"polkadot-runtime-constants/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"system-parachains-common/runtime-benchmarks",
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
@@ -232,6 +235,7 @@ try-runtime = [
 	"parachains-common/try-runtime",
 	"polkadot-runtime-common/try-runtime",
 	"sp-runtime/try-runtime",
+	"system-parachains-common/try-runtime",
 	"system-parachains-constants/try-runtime",
 ]
 

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -149,8 +149,18 @@ pub mod migrations {
 	/// All migrations that will run on the next runtime upgrade.
 	pub type SingleBlockMigrations = (Unreleased, Permanent);
 
+	parameter_types! {
+		/// One day at the 2s block time of this chain.
+		///
+		/// No single MBM may block the chain for longer than this.
+		pub const MbmMaxBlocks: u32 = 43_200;
+	}
+
 	/// MBM migrations to apply on runtime upgrade.
-	pub type MbmMigrations = ();
+	pub type MbmMigrations =
+		system_parachains_common::migrations::MaxStepsCapped<UncappedMbmMigrations, MbmMaxBlocks>;
+
+	type UncappedMbmMigrations = ();
 }
 
 /// Executive: handles dispatch to the various modules.

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -161,6 +161,20 @@ pub mod migrations {
 		system_parachains_common::migrations::MaxStepsCapped<UncappedMbmMigrations, MbmMaxBlocks>;
 
 	type UncappedMbmMigrations = ();
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+		use frame_support::migrations::SteppedMigrations;
+
+		#[test]
+		fn no_mbm_can_run_for_longer_than_a_day() {
+			for n in 0..MbmMigrations::len() {
+				let max_steps = MbmMigrations::nth_max_steps(n).expect("n < len; qed");
+				assert!(max_steps.is_some_and(|max| max <= MbmMaxBlocks::get()));
+			}
+		}
+	}
 }
 
 /// Executive: handles dispatch to the various modules.


### PR DESCRIPTION
In theory, misconfigured MBM migrations could run indefinitely. As per https://github.com/polkadot-fellows/runtimes/pull/1217#pullrequestreview-4592477489, this PR introduces a fallback safety mechanism to cap them to one day. After hitting the timeout, the migration will be considered a failure and the `ForceUnstuckOnFailedMigration` will the triggered.

I have also drafted an upstream PR to integrate this into the migrations-pallet: https://github.com/paritytech/polkadot-sdk/pull/12841.