### PR TITLE
[draft] support any asset that has a rate for transaction fee, xcm transaction fee and xcm delivery fee on Polkadot People Chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- People Polkadot: accept any asset governance registered a rate for in `pallet-asset-rate` — HOLLAR being the first one — for XCM *delivery* fees, on top of the transaction and XCM execution fees it already paid for. Delivery fees stay priced in DOT by the routers; the new `FeesAtAssetRate` asset exchanger prices the offered asset against that DOT amount at the registered rate, and the fee is then collected in that asset. XCM execution fees are charged through a generic `TakeFirstAssetTrader` instead of a HOLLAR-specific trader, so a new asset only needs a rate — no runtime upgrade — to pay for all three, and `XcmPaymentApi::query_acceptable_payment_assets` lists them.
+
 ### Fixed
 
 - Asset Hub Polkadot & Kusama: fix `pallet-remote-proxy` dropping the newest relay storage root when multiple parachain blocks share one relay parent. `on_validation_data` now skips storing duplicate relay blocks, which used to fill the bounded `BlockToRoot` vector with copies too young to prune and silently drop the newest root, so remote-proxy proofs anchored at recent relay blocks no longer fail with `UnknownProofAnchorBlock` ([#1230](https://github.com/polkadot-fellows/runtimes/issues/1230)).

--- a/integration-tests/emulated/tests/people/people-polkadot/src/tests/reserve_transfers.rs
+++ b/integration-tests/emulated/tests/people/people-polkadot/src/tests/reserve_transfers.rs
@@ -16,8 +16,7 @@
 use crate::*;
 use emulated_integration_tests_common::macros::{AssetTransferFilter, XcmPaymentApiV2};
 use frame_support::traits::fungibles;
-use people_polkadot_runtime::xcm_config::XcmConfig;
-use polkadot_runtime_constants::currency::CENTS as DOT_CENTS;
+use people_polkadot_runtime::xcm_config::{RelayTreasuryPalletAccount, XcmConfig};
 
 #[test]
 fn can_receive_hollar_from_hydration() {
@@ -96,23 +95,26 @@ fn can_send_hollar_back_to_hydration() {
 		type PolkadotXcm = <PeoplePolkadot as PeoplePolkadotPallet>::PolkadotXcm;
 		let sender = PeoplePolkadotSender::get();
 		let receiver = PeoplePolkadotReceiver::get();
+		// Delivery fees are collected here, in whichever asset they were paid.
+		let fee_receiver = RelayTreasuryPalletAccount::get();
 		// We need to open a channel between People and Hydration.
 		<PeoplePolkadot as Para>::ParachainSystem::open_outbound_hrmp_channel_for_benchmarks_or_tests(HYDRATION_PARA_ID.into());
-		// We need to mint some HOLLAR into our sender.
+		let transfer_amount = 10 * HOLLAR_UNITS;
+		let fees_amount = HOLLAR_UNITS;
+		// We need to mint some HOLLAR into our sender: HOLLAR pays for everything here, both
+		// execution and delivery, so no DOT is needed.
 		assert_ok!(<PeopleAssets as fungibles::Mutate<_>>::mint_into(
 			HollarLocation::get(),
 			&sender,
-			10 * HOLLAR_UNITS,
+			transfer_amount + fees_amount,
 		));
-		let transfer_amount = 10 * HOLLAR_UNITS;
-		let fees_amount = 10 * DOT_CENTS;
+		assert_eq!(
+			<PeopleAssets as fungibles::Inspect<_>>::balance(hollar_id.clone(), &fee_receiver),
+			0
+		);
 		let transfer_xcm = Xcm::builder()
-			.withdraw_asset((Parent, fees_amount))
-			// We need DOT to pay for delivery fees so we need
-			// to use all DOT here.
-			// TODO: Accept HOLLAR for delivery fees as well.
-			.pay_fees((Parent, fees_amount))
-			.withdraw_asset((hollar_id.clone(), transfer_amount))
+			.withdraw_asset((hollar_id.clone(), transfer_amount + fees_amount))
+			.pay_fees((hollar_id.clone(), fees_amount))
 			.initiate_transfer(
 				hydration_location,
 				Some(AssetTransferFilter::ReserveWithdraw(Definite(
@@ -120,7 +122,8 @@ fn can_send_hollar_back_to_hydration() {
 				))),
 				false,
 				vec![AssetTransferFilter::ReserveWithdraw(
-					AllOfCounted { id: hollar_id.into(), fun: WildFungible, count: 1 }.into(),
+					AllOfCounted { id: hollar_id.clone().into(), fun: WildFungible, count: 1 }
+						.into(),
 				)],
 				Xcm::<()>::builder_unsafe()
 					.refund_surplus()
@@ -135,6 +138,12 @@ fn can_send_hollar_back_to_hydration() {
 			Box::new(VersionedXcm::from(transfer_xcm)),
 			Weight::MAX,
 		));
+
+		// The delivery fees of the message sent to Hydration were paid in HOLLAR.
+		assert!(
+			<PeopleAssets as fungibles::Inspect<_>>::balance(hollar_id, &fee_receiver) > 0,
+			"delivery fees should have been collected in HOLLAR",
+		);
 	});
 }
 

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -1068,7 +1068,12 @@ impl_runtime_apis! {
 
 	impl xcm_runtime_apis::fees::XcmPaymentApi<Block> for Runtime {
 		fn query_acceptable_payment_assets(xcm_version: xcm::Version) -> Result<Vec<VersionedAssetId>, XcmPaymentApiError> {
-			let acceptable_assets = vec![AssetId(xcm_config::RelayLocation::get())];
+			// DOT, plus every asset governance registered a rate for.
+			let acceptable_assets = core::iter::once(AssetId(xcm_config::RelayLocation::get()))
+				.chain(
+					pallet_asset_rate::ConversionRateToNative::<Runtime>::iter_keys().map(AssetId),
+				)
+				.collect::<Vec<_>>();
 			PolkadotXcm::query_acceptable_payment_assets(xcm_version, acceptable_assets)
 		}
 

--- a/system-parachains/people/people-polkadot/src/tests.rs
+++ b/system-parachains/people/people-polkadot/src/tests.rs
@@ -140,6 +140,120 @@ fn xcm_payment_api_works() {
 	>();
 }
 
+/// Execution and delivery fees can both be paid in any asset governance registered a rate for, at
+/// that rate. HOLLAR is the first such asset, but nothing here is specific to it.
+#[test]
+fn xcm_fees_can_be_paid_in_any_asset_with_a_registered_rate() {
+	use crate::{
+		xcm_config::{FeesAtAssetRate, RelayLocation, XcmConfig},
+		AssetRate, Assets as AssetsPallet, PolkadotXcm, RuntimeGenesisConfig,
+	};
+	use cumulus_primitives_core::{relay_chain::AsyncBackingParams, AbridgedHostConfiguration};
+	use frame_support::weights::WeightToFee as WeightToFeeT;
+	use sp_runtime::{BuildStorage, FixedU128};
+	use xcm_executor::traits::AssetExchange;
+
+	// An asset worth 4 DOT apiece, and one governance never registered a rate for.
+	let rated = Location::new(1, [Parachain(2034), GeneralIndex(222)]);
+	let unrated = Location::new(1, [Parachain(2034), GeneralIndex(333)]);
+	let rate = FixedU128::from_u32(4);
+
+	let mut ext = sp_io::TestExternalities::new(
+		RuntimeGenesisConfig::default().build_storage().expect("runtime genesis builds"),
+	);
+	ext.execute_with(|| {
+		assert_ok!(AssetsPallet::force_create(
+			RuntimeOrigin::root(),
+			rated.clone(),
+			AccountId::from(ALICE).into(),
+			true,
+			1,
+		));
+		assert_ok!(AssetRate::create(RuntimeOrigin::root(), Box::new(rated.clone()), rate));
+
+		// Execution fees are priced in DOT, then converted at the registered rate.
+		let weight = Weight::from_parts(1_000_000_000, 10_000);
+		let native_fee = WeightToFee::<Runtime>::weight_to_fee(&weight);
+		type Trader = <XcmConfig as xcm_executor::Config>::Trader;
+		assert_eq!(
+			PolkadotXcm::query_weight_to_asset_fee::<Trader>(weight, AssetId(rated.clone()).into())
+				.unwrap(),
+			native_fee / 4,
+		);
+		// An asset without a rate buys no execution.
+		assert!(PolkadotXcm::query_weight_to_asset_fee::<Trader>(
+			weight,
+			AssetId(unrated.clone()).into()
+		)
+		.is_err());
+
+		// Delivery fees are quoted by the router in DOT, and settled in the asset at the same rate.
+		// Sending upwards needs the relay chain's limits, which only the inherent brings in.
+		cumulus_pallet_parachain_system::HostConfiguration::<Runtime>::put(
+			AbridgedHostConfiguration {
+				max_code_size: 3 * 1024 * 1024,
+				max_head_data_size: 20 * 1024,
+				max_upward_queue_count: 10,
+				max_upward_queue_size: 51_200,
+				max_upward_message_size: 51_200,
+				max_upward_message_num_per_candidate: 10,
+				hrmp_max_message_num_per_candidate: 10,
+				validation_upgrade_cooldown: 6,
+				validation_upgrade_delay: 6,
+				async_backing_params: AsyncBackingParams {
+					allowed_ancestry_len: 0,
+					max_candidate_depth: 0,
+				},
+			},
+		);
+		type AssetExchanger = <XcmConfig as xcm_executor::Config>::AssetExchanger;
+		let message = Xcm::<()>::builder_unsafe().clear_origin().build();
+		let quote = |asset: Location| -> Result<Assets, ()> {
+			PolkadotXcm::query_delivery_fees::<AssetExchanger>(
+				VersionedLocation::from(Location::parent()),
+				VersionedXcm::from(message.clone()),
+				AssetId(asset).into(),
+			)
+			.map(|fees| Assets::try_from(fees).expect("fees are in the latest version"))
+			.map_err(|_| ())
+		};
+		let in_dot = quote(RelayLocation::get()).expect("the relay chain is routable");
+		let Some(Asset { fun: Fungible(dot_fee), .. }) = in_dot.get(0).cloned() else {
+			panic!("delivery fees are a single fungible asset: {in_dot:?}");
+		};
+		assert_eq!(quote(rated.clone()).unwrap(), (rated.clone(), dot_fee / 4).into());
+		// And an asset without a rate cannot pay for delivery either.
+		assert!(quote(unrated.clone()).is_err());
+
+		// The same rate prices what the executor asks for, in both directions.
+		let dot_asked: Assets = (RelayLocation::get(), 400u128).into();
+		assert_eq!(
+			FeesAtAssetRate::quote_exchange_price(
+				&Asset { id: AssetId(rated.clone()), fun: Fungible(0) }.into(),
+				&dot_asked,
+				false,
+			),
+			Some((rated.clone(), 100u128).into()),
+		);
+		assert_eq!(
+			FeesAtAssetRate::quote_exchange_price(
+				&(rated.clone(), 100u128).into(),
+				&(RelayLocation::get(), 1u128).into(),
+				true,
+			),
+			Some((RelayLocation::get(), 400u128).into()),
+		);
+		assert_eq!(
+			FeesAtAssetRate::quote_exchange_price(
+				&Asset { id: AssetId(unrated), fun: Fungible(0) }.into(),
+				&dot_asked,
+				false,
+			),
+			None,
+		);
+	});
+}
+
 #[test]
 fn governance_authorize_upgrade_works() {
 	use polkadot_runtime_constants::system_parachain::COLLECTIVES_ID;

--- a/system-parachains/people/people-polkadot/src/xcm_config.rs
+++ b/system-parachains/people/people-polkadot/src/xcm_config.rs
@@ -14,17 +14,21 @@
 // limitations under the License.
 
 use super::{
-	assets::hollar::{HollarFromHydration, HollarLocation},
-	AccountId, AllPalletsWithSystem, AssetRate, Assets as AssetsPallet, Balance, Balances,
-	CollatorSelection, DotWeightToFee as WeightToFee, ParachainInfo, ParachainSystem, PolkadotXcm,
-	Runtime, RuntimeCall, RuntimeEvent, RuntimeHoldReason, RuntimeOrigin, XcmpQueue,
+	assets::hollar::HollarFromHydration, AccountId, AllPalletsWithSystem, AssetRate,
+	Assets as AssetsPallet, Balance, Balances, CollatorSelection, DotWeightToFee as WeightToFee,
+	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent,
+	RuntimeHoldReason, RuntimeOrigin, XcmpQueue,
 };
 use crate::{TransactionByteFee, CENTS};
+use cumulus_primitives_utility::{ChargeWeightInFungibles, TakeFirstAssetTrader};
 use frame_support::{
 	parameter_types,
 	traits::{
-		fungible::{HoldConsideration, ItemOf},
-		tokens::{imbalance::ResolveTo, ConversionToAssetBalance},
+		fungible::HoldConsideration,
+		tokens::{
+			imbalance::{ResolveAssetTo, ResolveTo},
+			ConversionFromAssetBalance, ConversionToAssetBalance,
+		},
 		ConstU32, Contains, Equals, Everything, LinearStoragePrice, Nothing,
 	},
 };
@@ -54,7 +58,10 @@ use xcm_builder::{
 	UsingComponents, WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 	XcmFeeManagerFromComponents,
 };
-use xcm_executor::{traits::ConvertLocation, XcmExecutor};
+use xcm_executor::{
+	traits::{AssetExchange, ConvertLocation},
+	AssetsInHolding, XcmExecutor,
+};
 
 pub use system_parachains_constants::polkadot::locations::{
 	AssetHubLocation, AssetHubPlurality, RelayChainLocation,
@@ -132,12 +139,16 @@ pub type FungibleTransactor = FungibleAdapter<
 	(),
 >;
 
+/// Matches every asset that comes from outside, i.e. everything held in the `Assets` pallet.
+pub type ForeignAssetsMatcher =
+	assets_common::ForeignAssetsConvertedConcreteId<(), Balance, Location>;
+
 /// Means for transacting other fungible tokens on this chain.
 pub type FungiblesTransactor = FungiblesAdapter<
 	// Use this implementation of `fungibles::*`.
 	AssetsPallet,
 	// Match everything that comes from outside.
-	assets_common::ForeignAssetsConvertedConcreteId<(), Balance, Location>,
+	ForeignAssetsMatcher,
 	// Convert an XCM `Location` into a local account ID.
 	LocationToAccountId,
 	// Our chain's account ID type (we can't get away without mentioning it explicitly):
@@ -260,23 +271,23 @@ pub type AssetFeeAsExistentialDepositMultiplierFeeCharger = AssetFeeAsExistentia
 >;
 
 pub type WeightToNativeFee = WeightToFee<Runtime>;
-pub struct WeightToStableFee;
-impl frame_support::weights::WeightToFee for WeightToStableFee {
-	type Balance = Balance;
 
-	fn weight_to_fee(weight: &Weight) -> Self::Balance {
-		let native_fee = WeightToNativeFee::weight_to_fee(weight);
+/// Prices weight in any asset that governance registered a rate for in `pallet-asset-rate`.
+///
+/// The weight is first priced in DOT, then converted to the asset at the registered rate. Assets
+/// without a rate are rejected, which makes the trader fall through to the next component.
+pub struct WeightToAssetRateFee;
+impl ChargeWeightInFungibles<AccountId, AssetsPallet> for WeightToAssetRateFee {
+	fn charge_weight_in_fungibles(asset_id: Location, weight: Weight) -> Result<Balance, XcmError> {
+		let native_fee =
+			<WeightToNativeFee as frame_support::weights::WeightToFee>::weight_to_fee(&weight);
 
-		AssetRate::to_asset_balance(native_fee, HollarLocation::get())
-			// Using max value will make the payment fail and go to the next trader component.
-			.unwrap_or(Balance::MAX)
+		AssetRate::to_asset_balance(native_fee, asset_id).map_err(|_| XcmError::AssetNotFound)
 	}
 }
 
-/// A fungible adapter for the stable asset
-pub type FungibleHollar = ItemOf<AssetsPallet, HollarLocation, AccountId>;
-
-/// All ways of paying for execution fees via XCM.
+/// All ways of paying for execution fees via XCM: DOT, or any asset with a rate registered in
+/// `pallet-asset-rate` (HOLLAR being the first such asset).
 pub type Traders = (
 	UsingComponents<
 		WeightToNativeFee,
@@ -285,14 +296,93 @@ pub type Traders = (
 		Balances,
 		ResolveTo<StakingPot, Balances>,
 	>,
-	UsingComponents<
-		WeightToStableFee,
-		HollarLocation,
+	TakeFirstAssetTrader<
 		AccountId,
-		FungibleHollar,
-		ResolveTo<StakingPot, FungibleHollar>,
+		WeightToAssetRateFee,
+		ForeignAssetsMatcher,
+		AssetsPallet,
+		ResolveAssetTo<StakingPot, AssetsPallet>,
 	>,
 );
+
+/// Lets fees that the executor prices in DOT — delivery fees — be settled in any asset that
+/// governance registered a rate for in `pallet-asset-rate`.
+///
+/// No swap happens, since this chain holds no liquidity: the asset offered for fees is priced
+/// against the DOT amount the executor asks for using the registered rate, and, if it covers it, is
+/// handed straight back so that the `FeeManager` deposits it *in kind* into the fee receiver's
+/// account. This is the same deal the [`Traders`] above offer for execution fees.
+///
+/// The `ExchangeAsset` instruction is not weighed on this chain (its weight is `Weight::MAX`), so
+/// this is only ever reachable through fee payment in the XCM executor.
+pub struct FeesAtAssetRate;
+
+impl FeesAtAssetRate {
+	/// The single fungible asset of `assets`, if that is all it holds.
+	fn only_fungible(assets: &Assets) -> Option<(Location, Balance)> {
+		match assets.inner().as_slice() {
+			[Asset { id: AssetId(location), fun: Fungible(amount) }] =>
+				Some((location.clone(), *amount)),
+			_ => None,
+		}
+	}
+
+	/// What `amount` of `from` is worth in `to`, at the rates registered in `pallet-asset-rate`.
+	///
+	/// Only pairs including DOT are priced, which is all fees ever need: rates are registered
+	/// against DOT.
+	fn convert(amount: Balance, from: &Location, to: &Location) -> Option<Balance> {
+		let native = RelayLocation::get();
+		match (from == &native, to == &native) {
+			(true, true) => Some(amount),
+			(true, false) => AssetRate::to_asset_balance(amount, to.clone()).ok(),
+			(false, true) => AssetRate::from_asset_balance(amount, from.clone()).ok(),
+			(false, false) => None,
+		}
+	}
+}
+
+impl AssetExchange for FeesAtAssetRate {
+	fn exchange_asset(
+		_origin: Option<&Location>,
+		give: AssetsInHolding,
+		want: &Assets,
+		_maximal: bool,
+	) -> Result<AssetsInHolding, AssetsInHolding> {
+		// Only the assets set aside for fee payment, a single fungible, are ever offered here.
+		let given = match give.fungible.iter().next() {
+			Some((AssetId(location), accounting))
+				if give.fungible.len() == 1 && give.non_fungible.is_empty() =>
+				Some((location.clone(), accounting.amount())),
+			_ => None,
+		};
+		let (Some((given_asset, given_amount)), Some((wanted_asset, wanted_amount))) =
+			(given, Self::only_fungible(want))
+		else {
+			return Err(give);
+		};
+
+		match Self::convert(wanted_amount, &wanted_asset, &given_asset) {
+			// What is offered is worth what was asked for, so it settles the fee as it is.
+			Some(required) if required <= given_amount => Ok(give),
+			_ => Err(give),
+		}
+	}
+
+	fn quote_exchange_price(give: &Assets, want: &Assets, maximal: bool) -> Option<Assets> {
+		let (given_asset, given_amount) = Self::only_fungible(give)?;
+		let (wanted_asset, wanted_amount) = Self::only_fungible(want)?;
+		if maximal {
+			// How much of `want`'s asset is `give` worth?
+			let obtained = Self::convert(given_amount, &given_asset, &wanted_asset)?;
+			Some((wanted_asset, obtained).into())
+		} else {
+			// How much of `give`'s asset does it take to cover `want`?
+			let required = Self::convert(wanted_amount, &wanted_asset, &given_asset)?;
+			Some((given_asset, required).into())
+		}
+	}
+}
 
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
@@ -318,11 +408,11 @@ impl xcm_executor::Config for XcmConfig {
 	type PalletInstancesInfo = AllPalletsWithSystem;
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type AssetLocker = ();
-	// TODO: Will need for delivery fees.
-	type AssetExchanger = ();
+	/// Delivery fees are priced in DOT but can be settled in any asset with a registered rate.
+	type AssetExchanger = FeesAtAssetRate;
 	type FeeManager = XcmFeeManagerFromComponents<
 		WaivedLocations,
-		SendXcmFeeToAccount<FungibleTransactor, RelayTreasuryPalletAccount>,
+		SendXcmFeeToAccount<AssetTransactors, RelayTreasuryPalletAccount>,
 	>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;


### PR DESCRIPTION
On Polkadot People Chain AssetRate has rate set by governance, currently only HOLLAR is usable as transaction fee and xcm transaction fee.

This PR wants to generalize to any asset with a rate, and to also include xcm delivery fee.

That said we may prefer to directly switch to pools like we do on Polkadot Asset Hub. This would make those asset permissionless, and the price adjusted by arbitrers rather than a potentially slow governance.