### PR TITLE
Define canonical burn account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Asset Hub Polkadot: add the canonical burn account ([#1242](https://github.com/polkadot-fellows/runtimes/pull/1242)).
+
 ### Fixed
 
 - Asset Hub Polkadot & Kusama: fix `pallet-remote-proxy` dropping the newest relay storage root when multiple parachain blocks share one relay parent. `on_validation_data` now skips storing duplicate relay blocks, which used to fill the bounded `BlockToRoot` vector with copies too young to prune and silently drop the newest root, so remote-proxy proofs anchored at recent relay blocks no longer fail with `UnknownProofAnchorBlock` ([#1230](https://github.com/polkadot-fellows/runtimes/issues/1230)).

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -248,7 +248,7 @@ parameter_types! {
 		.build_or_panic();
 	pub const SS58Prefix: u8 = 0;
 	/// The canonical account for permanently removing DOT from circulation.
-	pub BurnAccount: AccountId = PalletId(*b"py/mnbrn").into_account_truncating();
+	pub BurnAccount: AccountId = PalletId(*b"py/cabrn").into_account_truncating();
 }
 
 /// Calls that are temporarily disabled at the runtime level.
@@ -2898,12 +2898,12 @@ mod tests {
 		assert_eq!(
 			account,
 			AccountId::from(hex_literal::hex!(
-				"6d6f646c70792f6d6e62726e0000000000000000000000000000000000000000"
+				"6d6f646c70792f636162726e0000000000000000000000000000000000000000"
 			))
 		);
 		assert_eq!(
 			account.to_ss58check_with_version(Ss58AddressFormat::try_from("polkadot").unwrap()),
-			"13UVJyLnbVp8UBiThFiF7E3CQFuoRYLAkbGAQZcDT3m5LiDU"
+			"13UVJyLnbVp77Q2CRfD1Uryp655A696vD62DbmzF7woS1Vf8"
 		);
 	}
 

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -98,11 +98,13 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, ConstU128, Get, OpaqueMetadata};
 use sp_runtime::{
 	generic, impl_opaque_keys,
-	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, IdentityLookup, Verify},
+	traits::{
+		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto,
+		IdentityLookup, Verify,
+	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, FixedU128, Perbill, Permill,
 };
-use sp_runtime::traits::AccountIdConversion;
 use xcm::latest::prelude::*;
 use xcm_runtime_apis::{
 	dry_run::{CallDryRunEffects, Error as XcmDryRunApiError, XcmDryRunEffects},

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -102,6 +102,7 @@ use sp_runtime::{
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, FixedU128, Perbill, Permill,
 };
+use sp_runtime::traits::AccountIdConversion;
 use xcm::latest::prelude::*;
 use xcm_runtime_apis::{
 	dry_run::{CallDryRunEffects, Error as XcmDryRunApiError, XcmDryRunEffects},
@@ -244,6 +245,8 @@ parameter_types! {
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
 	pub const SS58Prefix: u8 = 0;
+	/// The canonical account for permanently removing DOT from circulation.
+	pub BurnAccount: AccountId = PalletId(*b"py/mnbrn").into_account_truncating();
 }
 
 /// Calls that are temporarily disabled at the runtime level.
@@ -2883,6 +2886,23 @@ mod tests {
 		let acc =
 			AccountId::from_ss58check("5F4EbSkZz18X36xhbsjvDNs6NuZ82HyYtq5UiJ1h9SBHJXZD").unwrap();
 		assert_eq!(acc, MigController::sorted_members()[0]);
+	}
+
+	#[test]
+	fn burn_account_is_stable() {
+		use sp_core::crypto::{Ss58AddressFormat, Ss58Codec};
+
+		let account = BurnAccount::get();
+		assert_eq!(
+			account,
+			AccountId::from(hex_literal::hex!(
+				"6d6f646c70792f6d6e62726e0000000000000000000000000000000000000000"
+			))
+		);
+		assert_eq!(
+			account.to_ss58check_with_version(Ss58AddressFormat::try_from("polkadot").unwrap()),
+			"13UVJyLnbVp8UBiThFiF7E3CQFuoRYLAkbGAQZcDT3m5LiDU"
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Define the canonical burn account that can be used to burn funds. Burning in this sense means to render them permanently inaccessible - the 2.1B DOT total issuance cap stays unaffected by this.

Calculated from PalletId  `py/cabrn` for canonical burn.
  - Public key: `0x6d6f646c70792f636162726e0000000000000000000000000000000000000000`
  - SS58: `13UVJyLnbVp77Q2CRfD1Uryp655A696vD62DbmzF7woS1Vf8`

Closes #1235