### PR TITLE
People Polkadot & Kusama: allow username lifecycle calls through the NonTransfer proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Asset Hub Polkadot & Kusama: fix `pallet-remote-proxy` dropping the newest relay storage root when multiple parachain blocks share one relay parent. `on_validation_data` now skips storing duplicate relay blocks, which used to fill the bounded `BlockToRoot` vector with copies too young to prune and silently drop the newest root, so remote-proxy proofs anchored at recent relay blocks no longer fail with `UnknownProofAnchorBlock` ([#1230](https://github.com/polkadot-fellows/runtimes/issues/1230)).
+- People Polkadot & Kusama: admit `unbind_username`, `remove_username` and `kill_username` through the `NonTransfer` proxy filter. `pallet-identity` gained the three calls after the allow-list was written; none moves a deposit out of the proxied account, so rejecting them contradicted the proxy type's documented contract ([#1241](https://github.com/polkadot-fellows/runtimes/issues/1241)).
 ### Changed
 
 - People Polkadot: raise the block weight limit to the `async_backing` constants (2s of ref time, 85% normal dispatch ratio) from `parachains_common`'s pre-async-backing pair (0.5s, 75%). This chain already authors a block every 2s under `elastic_scaling` consensus. It is now closer to Asset Hub Polkadot config.

--- a/system-parachains/people/people-kusama/src/lib.rs
+++ b/system-parachains/people/people-kusama/src/lib.rs
@@ -535,7 +535,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					) | RuntimeCall::Identity(pallet_identity::Call::set_username_for { .. }) |
 					RuntimeCall::Identity(pallet_identity::Call::accept_username { .. }) |
 					RuntimeCall::Identity(pallet_identity::Call::remove_expired_approval { .. }) |
-					RuntimeCall::Identity(pallet_identity::Call::set_primary_username { .. })
+					RuntimeCall::Identity(pallet_identity::Call::set_primary_username { .. }) |
+					RuntimeCall::Identity(pallet_identity::Call::unbind_username { .. }) |
+					RuntimeCall::Identity(pallet_identity::Call::remove_username { .. }) |
+					RuntimeCall::Identity(pallet_identity::Call::kill_username { .. })
 			),
 			ProxyType::CancelProxy => matches!(
 				c,

--- a/system-parachains/people/people-kusama/src/tests.rs
+++ b/system-parachains/people/people-kusama/src/tests.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	xcm_config::{AssetHubLocation, LocationToAccountId, RelayChainLocation},
-	Block, Runtime, RuntimeCall, RuntimeOrigin, WeightToFee,
+	Block, ProxyType, Runtime, RuntimeCall, RuntimeOrigin, WeightToFee,
 };
 use polkadot_primitives::AccountId;
 use sp_core::crypto::Ss58Codec;
@@ -170,4 +170,57 @@ fn governance_authorize_upgrade_works() {
 		Runtime,
 		RuntimeOrigin,
 	>(GovernanceOrigin::Location(AssetHubLocation::get())));
+}
+
+/// Exhaustive, so a new `pallet_identity` call upstream breaks the build.
+#[test]
+fn nontransfer_proxy_pins_every_identity_call() {
+	use codec::Decode;
+	use frame_support::traits::InstanceFilter;
+
+	fn admitted(call: &pallet_identity::Call<Runtime>) -> bool {
+		use pallet_identity::Call::*;
+		match call {
+			// Take or repatriate a deposit from the proxied account.
+			request_judgement { .. } | set_subs { .. } | add_sub { .. } => false,
+			add_registrar { .. } |
+			set_identity { .. } |
+			clear_identity { .. } |
+			cancel_request { .. } |
+			set_fee { .. } |
+			set_account_id { .. } |
+			set_fields { .. } |
+			provide_judgement { .. } |
+			kill_identity { .. } |
+			rename_sub { .. } |
+			remove_sub { .. } |
+			quit_sub { .. } |
+			add_username_authority { .. } |
+			remove_username_authority { .. } |
+			set_username_for { .. } |
+			accept_username { .. } |
+			remove_expired_approval { .. } |
+			set_primary_username { .. } |
+			unbind_username { .. } |
+			remove_username { .. } |
+			kill_username { .. } => true,
+			__Ignore(..) => unreachable!("not a dispatchable"),
+		}
+	}
+
+	// `Identity: pallet_identity = 50` in `construct_runtime!`.
+	for call_index in 0..=23u8 {
+		let mut payload = vec![50u8, call_index];
+		payload.extend_from_slice(&[0u8; 512]);
+		let call = RuntimeCall::decode(&mut &payload[..])
+			.unwrap_or_else(|_| panic!("Identity call {call_index} must decode"));
+		match &call {
+			RuntimeCall::Identity(inner) => assert_eq!(
+				ProxyType::NonTransfer.filter(&call),
+				admitted(inner),
+				"NonTransfer admission drifted for Identity call {call_index}"
+			),
+			_ => panic!("call index {call_index} did not decode to an Identity call"),
+		}
+	}
 }

--- a/system-parachains/people/people-polkadot/src/lib.rs
+++ b/system-parachains/people/people-polkadot/src/lib.rs
@@ -526,7 +526,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					) | RuntimeCall::Identity(pallet_identity::Call::set_username_for { .. }) |
 					RuntimeCall::Identity(pallet_identity::Call::accept_username { .. }) |
 					RuntimeCall::Identity(pallet_identity::Call::remove_expired_approval { .. }) |
-					RuntimeCall::Identity(pallet_identity::Call::set_primary_username { .. })
+					RuntimeCall::Identity(pallet_identity::Call::set_primary_username { .. }) |
+					RuntimeCall::Identity(pallet_identity::Call::unbind_username { .. }) |
+					RuntimeCall::Identity(pallet_identity::Call::remove_username { .. }) |
+					RuntimeCall::Identity(pallet_identity::Call::kill_username { .. })
 			),
 			ProxyType::CancelProxy => matches!(
 				c,

--- a/system-parachains/people/people-polkadot/src/tests.rs
+++ b/system-parachains/people/people-polkadot/src/tests.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	xcm_config::{AssetHubLocation, LocationToAccountId, RelayChainLocation},
-	Block, DotWeightToFee as WeightToFee, Runtime, RuntimeCall, RuntimeOrigin,
+	Block, DotWeightToFee as WeightToFee, ProxyType, Runtime, RuntimeCall, RuntimeOrigin,
 };
 use cumulus_primitives_core::relay_chain::AccountId;
 use sp_core::crypto::Ss58Codec;
@@ -192,4 +192,57 @@ fn governance_authorize_upgrade_works() {
 		Runtime,
 		RuntimeOrigin,
 	>(GovernanceOrigin::Location(AssetHubLocation::get())));
+}
+
+/// Exhaustive, so a new `pallet_identity` call upstream breaks the build.
+#[test]
+fn nontransfer_proxy_pins_every_identity_call() {
+	use codec::Decode;
+	use frame_support::traits::InstanceFilter;
+
+	fn admitted(call: &pallet_identity::Call<Runtime>) -> bool {
+		use pallet_identity::Call::*;
+		match call {
+			// Take or repatriate a deposit from the proxied account.
+			request_judgement { .. } | set_subs { .. } | add_sub { .. } => false,
+			add_registrar { .. } |
+			set_identity { .. } |
+			clear_identity { .. } |
+			cancel_request { .. } |
+			set_fee { .. } |
+			set_account_id { .. } |
+			set_fields { .. } |
+			provide_judgement { .. } |
+			kill_identity { .. } |
+			rename_sub { .. } |
+			remove_sub { .. } |
+			quit_sub { .. } |
+			add_username_authority { .. } |
+			remove_username_authority { .. } |
+			set_username_for { .. } |
+			accept_username { .. } |
+			remove_expired_approval { .. } |
+			set_primary_username { .. } |
+			unbind_username { .. } |
+			remove_username { .. } |
+			kill_username { .. } => true,
+			__Ignore(..) => unreachable!("not a dispatchable"),
+		}
+	}
+
+	// `Identity: pallet_identity = 50` in `construct_runtime!`.
+	for call_index in 0..=23u8 {
+		let mut payload = vec![50u8, call_index];
+		payload.extend_from_slice(&[0u8; 512]);
+		let call = RuntimeCall::decode(&mut &payload[..])
+			.unwrap_or_else(|_| panic!("Identity call {call_index} must decode"));
+		match &call {
+			RuntimeCall::Identity(inner) => assert_eq!(
+				ProxyType::NonTransfer.filter(&call),
+				admitted(inner),
+				"NonTransfer admission drifted for Identity call {call_index}"
+			),
+			_ => panic!("call index {call_index} did not decode to an Identity call"),
+		}
+	}
 }


### PR DESCRIPTION
Admits `unbind_username`, `remove_username` and `kill_username` through the `NonTransfer` proxy on People Polkadot and People Kusama.

`NonTransfer` is documented to allow any call that does not move funds or assets out of the proxied account, but its Identity allow-list predates these three calls. A `NonTransfer` proxy of a username authority can grant usernames with `set_username_for` but cannot unbind or remove them. The three calls are safe to admit because:

1. `unbind_username` only starts the grace period, and `remove_username` unreserves the username deposit back to the authority. Neither moves funds out of an account.
2. `kill_username` requires `ForceOrigin`, which a proxied signed origin never satisfies, so admitting it has no effect beyond keeping the allow-list exhaustive.

Resolves #1241 