### PR TITLE
People: route Bulletin location and pallet index back to Root

### DIFF
--- a/system-parachains/people/people-polkadot/src/parameters.rs
+++ b/system-parachains/people/people-polkadot/src/parameters.rs
@@ -235,8 +235,6 @@ impl EnsureOriginWithArg<RuntimeOrigin, RuntimeParametersKey> for DynamicParamet
 				StatementStorageKey::PersonStatementLimit(_),
 			) |
 			RuntimeParametersKey::BulletinStorage(
-				BulletinStorageKey::BulletinChainLocation(_) |
-				BulletinStorageKey::BulletinTransactionStoragePalletIndex(_) |
 				BulletinStorageKey::LongTermStorageClaimsPerPeriod(_) |
 				BulletinStorageKey::LongTermStorageCleanupLimit(_) |
 				BulletinStorageKey::LongTermStorageAllowanceForPeople(_) |
@@ -253,7 +251,11 @@ impl EnsureOriginWithArg<RuntimeOrigin, RuntimeParametersKey> for DynamicParamet
 					origin.clone(),
 				)
 				.map(|_| ()),
-			// What coinage costs.
+			// Where the chain sends data, and what coinage costs.
+			RuntimeParametersKey::BulletinStorage(
+				BulletinStorageKey::BulletinChainLocation(_) |
+				BulletinStorageKey::BulletinTransactionStoragePalletIndex(_),
+			) |
 			RuntimeParametersKey::Coinage(
 				CoinageKey::LoadDepositPrice(_) | CoinageKey::InstanceCreationDeposit(_),
 			) => frame_system::ensure_root(origin.clone()),

--- a/system-parachains/people/people-polkadot/src/tests.rs
+++ b/system-parachains/people/people-polkadot/src/tests.rs
@@ -592,8 +592,6 @@ fn dynamic_parameter_origin_routes_keys_by_scope() {
 		StatementStorage(statement_storage::LiteNotificationSlotsPerPeriod.into()),
 		StatementStorage(statement_storage::LitePersonStatementLimit.into()),
 		StatementStorage(statement_storage::PersonStatementLimit.into()),
-		BulletinStorage(bulletin_storage::BulletinChainLocation.into()),
-		BulletinStorage(bulletin_storage::BulletinTransactionStoragePalletIndex.into()),
 		BulletinStorage(bulletin_storage::LongTermStorageClaimsPerPeriod.into()),
 		BulletinStorage(bulletin_storage::LongTermStorageCleanupLimit.into()),
 		BulletinStorage(bulletin_storage::LongTermStorageAllowanceForPeople.into()),
@@ -605,6 +603,8 @@ fn dynamic_parameter_origin_routes_keys_by_scope() {
 		LitePersonhood(lite_personhood::RegistrationFee.into()),
 	];
 	let root_only = [
+		BulletinStorage(bulletin_storage::BulletinChainLocation.into()),
+		BulletinStorage(bulletin_storage::BulletinTransactionStoragePalletIndex.into()),
 		Coinage(coinage::LoadDepositPrice.into()),
 		Coinage(coinage::InstanceCreationDeposit.into()),
 	];


### PR DESCRIPTION
Follow-up to #1269, per the review thread [here](https://github.com/polkadot-fellows/runtimes/pull/1269#discussion_r3925501918).
`BulletinChainLocation` and `BulletinTransactionStoragePalletIndex` go back to Root only. They only change together with a Bulletin runtime change, which is a Root or whitelisted referendum anyway, and a wrong value stops renewals, not just new claims.  Whether they should be dynamic parameters at all is a fair question for later (post 2.5)
