### PR TITLE
Fix precompile weight trait paths on Asset Hub Polkadot

### DIFF
--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_assets_precompiles.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_assets_precompiles.rs
@@ -50,7 +50,7 @@ use core::marker::PhantomData;
 
 /// Weight functions for `pallet_assets_precompiles`.
 pub struct WeightInfo<T>(PhantomData<T>);
-impl<T: frame_system::Config> pallet_assets_precompiles::WeightInfo for WeightInfo<T> {
+impl<T: frame_system::Config> pallet_assets_precompiles::weights::WeightInfo for WeightInfo<T> {
 	/// Storage: `ForeignAssets::Asset` (r:2 w:0)
 	/// Proof: `ForeignAssets::Asset` (`max_values`: None, `max_size`: Some(808), added: 3283, mode: `MaxEncodedLen`)
 	/// Storage: `AssetsPrecompiles::ForeignAssetIdToAssetIndex` (r:1 w:1)

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_vesting_precompiles.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_vesting_precompiles.rs
@@ -50,7 +50,7 @@ use core::marker::PhantomData;
 
 /// Weight functions for `pallet_vesting_precompiles`.
 pub struct WeightInfo<T>(PhantomData<T>);
-impl<T: frame_system::Config> pallet_vesting_precompiles::WeightInfo for WeightInfo<T> {
+impl<T: frame_system::Config> pallet_vesting_precompiles::weights::WeightInfo for WeightInfo<T> {
 	/// Storage: `Vesting::Vesting` (r:1 w:0)
 	/// Proof: `Vesting::Vesting` (`max_values`: None, `max_size`: Some(1057), added: 3532, mode: `MaxEncodedLen`)
 	/// Storage: `ParachainSystem::ValidationData` (r:1 w:0)


### PR DESCRIPTION
#1270 regenerated the pallet-assets-precompiles and pallet-vesting-precompiles weights with `<crate>::WeightInfo`, but both crates only expose the trait as `<crate>::weights::WeightInfo`. 
This PR just manually fixes the issue to unlock 2.5 -  fix in the SDK [here](https://github.com/paritytech/polkadot-sdk/pull/13092)

- [X] Does not require a CHANGELOG entry
