### PR TITLE
Correct Polkadot/Kusama proxy type lattice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Polkadot & Kusama: `is_superset` no longer declares `NonTransfer` a superset of `Auction`; the `Auction` filter admits `Registrar::swap`, which `NonTransfer` omits on purpose.
+
 - Asset Hub Polkadot & Kusama: enable `pallet-assets::force_create` by moving asset ID allocation to the new `AssetIdAllocator` config item ([#1275](https://github.com/polkadot-fellows/runtimes/pull/1275)).
 - People Polkadot & Asset Hub Polkadot: wire the `technical_maintenance` track into the operational Individuality settings: quotas, allowances and housekeeping on People, the Individuality parameters on Asset Hub ([#1269](https://github.com/polkadot-fellows/runtimes/pull/1269)).
 - Asset Hub Polkadot & Kusama: update `pallet-revive` to `0.19.1`, adding the `originIsRoot` System precompile method ([#1262](https://github.com/polkadot-fellows/runtimes/pull/1262), integrates [paritytech/polkadot-sdk#12281](https://github.com/paritytech/polkadot-sdk/pull/12281)).

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1468,6 +1468,8 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType {
 			(x, y) if x == y => true,
 			(ProxyType::Any, _) => true,
 			(_, ProxyType::Any) => false,
+			// `Auction` admits `Registrar::swap`; `NonTransfer` omits it on purpose.
+			(ProxyType::NonTransfer, ProxyType::Auction) => false,
 			(ProxyType::NonTransfer, _) => true,
 			_ => false,
 		}

--- a/relay/kusama/tests/mod.rs
+++ b/relay/kusama/tests/mod.rs
@@ -16,4 +16,5 @@
 
 mod asset_rate;
 mod location_conversion;
+mod proxy;
 mod treasury_burn_handler;

--- a/relay/kusama/tests/proxy.rs
+++ b/relay/kusama/tests/proxy.rs
@@ -1,0 +1,169 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Kusama.
+
+// Kusama is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Kusama is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Kusama.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Proxy filter tests.
+
+use frame_support::traits::InstanceFilter;
+use kusama_runtime_constants::proxy::ProxyType;
+use polkadot_primitives::AccountId;
+use polkadot_runtime_common::paras_registrar;
+use staging_kusama_runtime::{RuntimeCall, TransparentProxyType};
+
+/// Every `ProxyType` variant. A new variant breaks the `match`, which is the signal to add
+/// it here.
+fn all_proxy_types() -> Vec<ProxyType> {
+	let all = vec![
+		ProxyType::Any,
+		ProxyType::NonTransfer,
+		ProxyType::Governance,
+		ProxyType::Staking,
+		ProxyType::CancelProxy,
+		ProxyType::Auction,
+		ProxyType::Society,
+		ProxyType::NominationPools,
+		ProxyType::Spokesperson,
+		ProxyType::ParaRegistration,
+	];
+
+	for proxy_type in all.iter() {
+		match proxy_type {
+			ProxyType::Any |
+			ProxyType::NonTransfer |
+			ProxyType::Governance |
+			ProxyType::Staking |
+			ProxyType::CancelProxy |
+			ProxyType::Auction |
+			ProxyType::Society |
+			ProxyType::NominationPools |
+			ProxyType::Spokesperson |
+			ProxyType::ParaRegistration => (),
+		}
+	}
+
+	all
+}
+
+/// One call for each boundary that the proxy filters draw. The list includes the variants
+/// that a filter omits on purpose, such as `Registrar::swap`, because those are the calls
+/// that show a lattice violation.
+fn representative_calls() -> Vec<RuntimeCall> {
+	let account = || AccountId::from([1u8; 32]);
+
+	vec![
+		RuntimeCall::System(frame_system::Call::remark { remark: vec![] }),
+		RuntimeCall::Indices(pallet_indices::Call::claim { index: 0 }),
+		RuntimeCall::Indices(pallet_indices::Call::transfer { new: account().into(), index: 0 }),
+		RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
+			dest: account().into(),
+			value: 1,
+		}),
+		RuntimeCall::Staking(pallet_staking::Call::chill {}),
+		RuntimeCall::Session(pallet_session::Call::purge_keys {}),
+		RuntimeCall::Treasury(pallet_treasury::Call::remove_approval { proposal_id: 0 }),
+		RuntimeCall::ConvictionVoting(pallet_conviction_voting::Call::unlock {
+			class: 0,
+			target: account().into(),
+		}),
+		RuntimeCall::Referenda(pallet_referenda::Call::cancel { index: 0 }),
+		RuntimeCall::Vesting(pallet_vesting::Call::vest {}),
+		RuntimeCall::Vesting(pallet_vesting::Call::vested_transfer {
+			target: account().into(),
+			schedule: pallet_vesting::VestingInfo::new(1, 1, 0),
+		}),
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![] }),
+		RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement {
+			delegate: account().into(),
+			call_hash: sp_core::H256::zero(),
+		}),
+		RuntimeCall::Multisig(pallet_multisig::Call::cancel_as_multi {
+			threshold: 2,
+			other_signatories: vec![account()],
+			timepoint: pallet_multisig::Timepoint { height: 0, index: 0 },
+			call_hash: [0u8; 32],
+		}),
+		RuntimeCall::Registrar(paras_registrar::Call::register {
+			id: 2000.into(),
+			genesis_head: vec![].into(),
+			validation_code: vec![].into(),
+		}),
+		RuntimeCall::Registrar(paras_registrar::Call::deregister { id: 2000.into() }),
+		RuntimeCall::Registrar(paras_registrar::Call::reserve {}),
+		RuntimeCall::Registrar(paras_registrar::Call::swap { id: 2000.into(), other: 2001.into() }),
+		RuntimeCall::Crowdloan(polkadot_runtime_common::crowdloan::Call::dissolve {
+			index: 2000.into(),
+		}),
+		RuntimeCall::Slots(polkadot_runtime_common::slots::Call::trigger_onboard {
+			para: 2000.into(),
+		}),
+		RuntimeCall::Auctions(polkadot_runtime_common::auctions::Call::cancel_auction {}),
+		RuntimeCall::VoterList(pallet_bags_list::Call::rebag { dislocated: account().into() }),
+		RuntimeCall::NominationPools(pallet_nomination_pools::Call::claim_payout {}),
+		RuntimeCall::FastUnstake(pallet_fast_unstake::Call::register_fast_unstake {}),
+		RuntimeCall::Bounties(pallet_bounties::Call::propose_bounty {
+			value: 1,
+			description: vec![],
+		}),
+		RuntimeCall::ChildBounties(pallet_child_bounties::Call::claim_child_bounty {
+			parent_bounty_id: 0,
+			child_bounty_id: 0,
+		}),
+		RuntimeCall::Whitelist(pallet_whitelist::Call::remove_whitelisted_call {
+			call_hash: sp_core::H256::zero(),
+		}),
+		RuntimeCall::Proxy(pallet_proxy::Call::remove_proxy {
+			delegate: account().into(),
+			proxy_type: TransparentProxyType(ProxyType::ParaRegistration),
+			delay: 0,
+		}),
+		RuntimeCall::FellowshipCollective(pallet_ranked_collective::Call::cleanup_poll {
+			poll_index: 0,
+			max: 1,
+		}),
+		RuntimeCall::FellowshipReferenda(pallet_referenda::Call::cancel { index: 0 }),
+		RuntimeCall::System(frame_system::Call::remark_with_event { remark: vec![] }),
+		RuntimeCall::Society(pallet_society::Call::unbid {}),
+	]
+}
+
+/// For every declared `is_superset` edge, the superset filter must admit every call that
+/// the subset filter admits.
+///
+/// Cost: 10 proxy types give 100 ordered pairs, of which 26 are declared edges (10
+/// reflexive, 9 more under `Any`, 7 more under `NonTransfer`). With 32 calls, the inner
+/// loop runs 832 times and makes at most 1664 filter probes. Each probe is one `matches!`
+/// on an enum. The test completes in under 10 ms.
+#[test]
+fn proxy_type_superset_relation_matches_call_filters() {
+	let calls = representative_calls();
+
+	for superset in all_proxy_types() {
+		for subset in all_proxy_types() {
+			if !TransparentProxyType(superset).is_superset(&TransparentProxyType(subset)) {
+				continue;
+			}
+
+			for call in calls.iter() {
+				if TransparentProxyType(subset).filter(call) {
+					assert!(
+						TransparentProxyType(superset).filter(call),
+						"lattice violated: {superset:?} declares itself a superset of \
+						 {subset:?}, but rejects {call:?} which {subset:?} admits",
+					);
+				}
+			}
+		}
+	}
+}

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1270,6 +1270,8 @@ impl InstanceFilter<RuntimeCall> for TransparentProxyType<ProxyType> {
 			(x, y) if x == y => true,
 			(ProxyType::Any, _) => true,
 			(_, ProxyType::Any) => false,
+			// `Auction` admits `Registrar::swap`; `NonTransfer` omits it on purpose.
+			(ProxyType::NonTransfer, ProxyType::Auction) => false,
 			(ProxyType::NonTransfer, _) => true,
 			_ => false,
 		}

--- a/relay/polkadot/tests/mod.rs
+++ b/relay/polkadot/tests/mod.rs
@@ -17,3 +17,4 @@
 mod asset_rate;
 mod beefy_tests;
 mod location_conversion;
+mod proxy;

--- a/relay/polkadot/tests/proxy.rs
+++ b/relay/polkadot/tests/proxy.rs
@@ -1,0 +1,158 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Proxy filter tests.
+
+use frame_support::traits::InstanceFilter;
+use polkadot_primitives::AccountId;
+use polkadot_runtime::{RuntimeCall, TransparentProxyType};
+use polkadot_runtime_common::paras_registrar;
+use polkadot_runtime_constants::proxy::ProxyType;
+
+/// Every `ProxyType` variant. A new variant breaks the `match`, which is the signal to add
+/// it here.
+fn all_proxy_types() -> Vec<ProxyType> {
+	let all = vec![
+		ProxyType::Any,
+		ProxyType::NonTransfer,
+		ProxyType::Governance,
+		ProxyType::Staking,
+		ProxyType::CancelProxy,
+		ProxyType::Auction,
+		ProxyType::NominationPools,
+		ProxyType::ParaRegistration,
+	];
+
+	for proxy_type in all.iter() {
+		match proxy_type {
+			ProxyType::Any |
+			ProxyType::NonTransfer |
+			ProxyType::Governance |
+			ProxyType::Staking |
+			ProxyType::CancelProxy |
+			ProxyType::Auction |
+			ProxyType::NominationPools |
+			ProxyType::ParaRegistration => (),
+		}
+	}
+
+	all
+}
+
+/// One call for each boundary that the proxy filters draw. The list includes the variants
+/// that a filter omits on purpose, such as `Registrar::swap`, because those are the calls
+/// that show a lattice violation.
+fn representative_calls() -> Vec<RuntimeCall> {
+	let account = || AccountId::from([1u8; 32]);
+
+	vec![
+		RuntimeCall::System(frame_system::Call::remark { remark: vec![] }),
+		RuntimeCall::Indices(pallet_indices::Call::claim { index: 0 }),
+		RuntimeCall::Indices(pallet_indices::Call::transfer { new: account().into(), index: 0 }),
+		RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
+			dest: account().into(),
+			value: 1,
+		}),
+		RuntimeCall::Staking(pallet_staking::Call::chill {}),
+		RuntimeCall::Session(pallet_session::Call::purge_keys {}),
+		RuntimeCall::Treasury(pallet_treasury::Call::remove_approval { proposal_id: 0 }),
+		RuntimeCall::ConvictionVoting(pallet_conviction_voting::Call::unlock {
+			class: 0,
+			target: account().into(),
+		}),
+		RuntimeCall::Referenda(pallet_referenda::Call::cancel { index: 0 }),
+		RuntimeCall::Vesting(pallet_vesting::Call::vest {}),
+		RuntimeCall::Vesting(pallet_vesting::Call::vested_transfer {
+			target: account().into(),
+			schedule: pallet_vesting::VestingInfo::new(1, 1, 0),
+		}),
+		RuntimeCall::Utility(pallet_utility::Call::batch { calls: vec![] }),
+		RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement {
+			delegate: account().into(),
+			call_hash: sp_core::H256::zero(),
+		}),
+		RuntimeCall::Multisig(pallet_multisig::Call::cancel_as_multi {
+			threshold: 2,
+			other_signatories: vec![account()],
+			timepoint: pallet_multisig::Timepoint { height: 0, index: 0 },
+			call_hash: [0u8; 32],
+		}),
+		RuntimeCall::Registrar(paras_registrar::Call::register {
+			id: 2000.into(),
+			genesis_head: vec![].into(),
+			validation_code: vec![].into(),
+		}),
+		RuntimeCall::Registrar(paras_registrar::Call::deregister { id: 2000.into() }),
+		RuntimeCall::Registrar(paras_registrar::Call::reserve {}),
+		RuntimeCall::Registrar(paras_registrar::Call::swap { id: 2000.into(), other: 2001.into() }),
+		RuntimeCall::Crowdloan(polkadot_runtime_common::crowdloan::Call::dissolve {
+			index: 2000.into(),
+		}),
+		RuntimeCall::Slots(polkadot_runtime_common::slots::Call::trigger_onboard {
+			para: 2000.into(),
+		}),
+		RuntimeCall::Auctions(polkadot_runtime_common::auctions::Call::cancel_auction {}),
+		RuntimeCall::VoterList(pallet_bags_list::Call::rebag { dislocated: account().into() }),
+		RuntimeCall::NominationPools(pallet_nomination_pools::Call::claim_payout {}),
+		RuntimeCall::FastUnstake(pallet_fast_unstake::Call::register_fast_unstake {}),
+		RuntimeCall::Bounties(pallet_bounties::Call::propose_bounty {
+			value: 1,
+			description: vec![],
+		}),
+		RuntimeCall::ChildBounties(pallet_child_bounties::Call::claim_child_bounty {
+			parent_bounty_id: 0,
+			child_bounty_id: 0,
+		}),
+		RuntimeCall::Whitelist(pallet_whitelist::Call::remove_whitelisted_call {
+			call_hash: sp_core::H256::zero(),
+		}),
+		RuntimeCall::Proxy(pallet_proxy::Call::remove_proxy {
+			delegate: account().into(),
+			proxy_type: TransparentProxyType(ProxyType::ParaRegistration),
+			delay: 0,
+		}),
+	]
+}
+
+/// For every declared `is_superset` edge, the superset filter must admit every call that
+/// the subset filter admits.
+///
+/// Cost: 8 proxy types give 64 ordered pairs, of which 20 are declared edges (8 reflexive,
+/// 7 more under `Any`, 5 more under `NonTransfer`). With 28 calls, the inner loop runs 560
+/// times and makes at most 1120 filter probes. Each probe is one `matches!` on an enum. The
+/// test completes in under 10 ms.
+#[test]
+fn proxy_type_superset_relation_matches_call_filters() {
+	let calls = representative_calls();
+
+	for superset in all_proxy_types() {
+		for subset in all_proxy_types() {
+			if !TransparentProxyType(superset).is_superset(&TransparentProxyType(subset)) {
+				continue;
+			}
+
+			for call in calls.iter() {
+				if TransparentProxyType(subset).filter(call) {
+					assert!(
+						TransparentProxyType(superset).filter(call),
+						"lattice violated: {superset:?} declares itself a superset of \
+						 {subset:?}, but rejects {call:?} which {subset:?} admits",
+					);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
`is_superset` on both relays claims `NonTransfer` is a superset of `Auction`. It is not: the `Auction` filter admits `Registrar::swap`, which `NonTransfer` blocks on purpose. `pallet_proxy` trusts `is_superset` when it gates `add_proxy`, so a `NonTransfer` proxy could add an `Auction` proxy and reach `swap`. One new match arm removes the false claim.

# Tests added

Each relay gets a test that asserts every declared superset edge against the filters. The test covers this regression and every superset-filter mismatch for the call families in the current filters. A filter change that adds a new pallet family also needs a new entry in the test's call list. About 1 ms per relay, at most 1120 filter probes on Polkadot and 1664 on Kusama.
