### PR TITLE
Asset Hub Polkadot: fund the DAP buffer above ED in genesis presets

### DIFF
--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/genesis_config_presets.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/genesis_config_presets.rs
@@ -55,7 +55,12 @@ fn asset_hub_polkadot_genesis(
 		.cloned()
 		.map(|k| (k, ASSET_HUB_POLKADOT_ED * 4096 * 4096))
 		.collect();
-	balances.push((Dap::buffer_account(), ASSET_HUB_POLKADOT_ED));
+	// The DAP buffer receives slashes and is the reward pot for the election signed phase. Reward
+	// payouts transfer with `Preservation::Preserve`, so it needs spendable balance above ED,
+	// sized in rounds of `RewardBase`.
+	balances
+		.push((Dap::buffer_account(), ASSET_HUB_POLKADOT_ED + staking::RewardBase::get() * 1_000));
+	// The staging account only receives, so ED is enough for it to exist.
 	balances.push((Dap::staging_account(), ASSET_HUB_POLKADOT_ED));
 
 	serde_json::json!({


### PR DESCRIPTION
Preparatory, ahead of integrating [polkadot-sdk#1284](https://github.com/paritytech/polkadot-sdk/pull/12843) or its backported  [SDK 2609 variant](https://github.com/paritytech/polkadot-sdk/pull/13164). The upstream SDK change makes the DAP buffer the `RewardSource` pot for the election signed phase and switches the winner payout from `mint_into` to a `Preservation::Preserve` transfer. An account holding exactly ED has zero spendable balance under `Preserve`, so every reward would silently defer into `UnpaidRewards` instead of emitting `Rewarded`.

`signed::Config` on PAH has no `RewardSource` yet, so nothing is broken today. Landing it now costs nothing, but we can as well wait for SDK to be bumped first.

Genesis presets only, so dev and test chains. Live Asset Hub Polkadot is unaffected. Kusama has no DAP and is untouched.

Twin PR in the SDK: https://github.com/paritytech/polkadot-sdk/pull/13166

- [X] Does not require a CHANGELOG entry
